### PR TITLE
ci: add SAST and container security scanning to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,27 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  codeql:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: python
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+
   build:
     name: Build (${{ matrix.arch }})
     strategy:
@@ -28,10 +49,43 @@ jobs:
             platform: linux/arm64
             arch: arm64
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # ── SAST: Secret scanning ─────────────────────────────────────────────
+      - name: Gitleaks secret scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # ── SAST: Dockerfile linting ──────────────────────────────────────────
+      - name: Lint Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: warning
+
+      # ── SAST: Filesystem / dependency CVE scan ────────────────────────────
+      - name: Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy FS results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-fs.sarif
+
+      # ── Docker build ──────────────────────────────────────────────────────
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -63,6 +117,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -116,3 +171,18 @@ jobs:
           docker buildx imagetools create \
             -t "${IMAGE}:latest" \
             "${IMAGE}:${TAG}"
+
+      # ── DAST: Container image CVE scan ────────────────────────────────────
+      - name: Trivy image scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ steps.version.outputs.tag }}
+          format: sarif
+          output: trivy-image.sarif
+          severity: HIGH,CRITICAL
+
+      - name: Upload Trivy image results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-image.sarif


### PR DESCRIPTION
Integrates static analysis and image scanning into the release pipeline to surface vulnerabilities before and after publish.

Changes:
- Add CodeQL job (runs parallel to build, targets Python)
- Add Gitleaks secret scanning on checkout
- Add Hadolint Dockerfile linting (warn threshold)
- Add Trivy filesystem scan before Docker build (HIGH/CRITICAL)
- Add Trivy image scan after push to ghcr.io (HIGH/CRITICAL)
- Upload all Trivy results as SARIF to GitHub Security tab
- Add security-events: write permission to build and publish jobs

All scan results are visible under the Security > Code scanning tab. OWASP ZAP (DAST) deferred until a staging deploy step is available.