### PR TITLE
fix: add timeout

### DIFF
--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -23,7 +23,9 @@ class Settings(BaseSettings):
     lidarr_url: str = Field(default="http://lidarr:8686")
     lidarr_api_key: str = Field(default="")
     lidarr_timeout: float = Field(
-        default=60.0,
+        default=30.0,
+        ge=5.0,
+        le=600.0,
         description="HTTP read/write timeout in seconds for Lidarr API calls.",
     )
     

--- a/backend/repositories/lidarr/base.py
+++ b/backend/repositories/lidarr/base.py
@@ -49,7 +49,7 @@ class LidarrBase:
 
     @property
     def _base_url(self) -> str:
-        return self._settings.lidarr_url
+        return self._settings.lidarr_url.rstrip("/")
 
     def is_configured(self) -> bool:
         return bool(self._settings.lidarr_api_key)
@@ -79,18 +79,12 @@ class LidarrBase:
             raise ExternalServiceError("Lidarr is not configured (no API key)")
 
         path = endpoint.lstrip("/")
-        base = self._base_url.rstrip("/")
-        url = f"{base}/{path}" if path else base
+        url = f"{self._base_url}/{path}" if path else self._base_url
 
-        try:
-            lidarr_t = float(self._settings.lidarr_timeout)
-        except (TypeError, ValueError):
-            lidarr_t = 60.0
-        try:
-            connect_t = float(self._settings.http_connect_timeout)
-        except (TypeError, ValueError):
-            connect_t = 5.0
-        timeout = httpx.Timeout(lidarr_t, connect=connect_t)
+        timeout = httpx.Timeout(
+            self._settings.lidarr_timeout,
+            connect=self._settings.http_connect_timeout,
+        )
 
         try:
             response = await self._client.request(


### PR DESCRIPTION
- Fixes #15 by making a customizable timeout for connecting to Lidarr. 
- Also handles possible bug if user puts in url with url prefix like `/lidarr`