### PR TITLE
[MusicSeerr][Lidarr cache][musicseerr-cache-fix-upstream-pr][1/n] Cache full-library Lidarr scans longer

### DIFF
--- a/backend/repositories/lidarr/base.py
+++ b/backend/repositories/lidarr/base.py
@@ -21,6 +21,9 @@ LidarrJsonObject = dict[str, Any]
 LidarrJsonArray = list[LidarrJsonObject]
 LidarrJson = LidarrJsonObject | LidarrJsonArray
 
+# Large Lidarr libraries make /api/v1/album an expensive page-path dependency.
+LIDARR_LIBRARY_SCAN_TTL_SECONDS = 3600
+
 
 def reset_lidarr_circuit_breaker():
     _lidarr_circuit_breaker.reset()
@@ -134,7 +137,7 @@ class LidarrBase:
         if not isinstance(data, list):
             return []
 
-        await self._cache.set(cache_key, data, ttl_seconds=300)
+        await self._cache.set(cache_key, data, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return data
 
     async def _invalidate_album_list_caches(self) -> None:

--- a/backend/repositories/lidarr/library.py
+++ b/backend/repositories/lidarr/library.py
@@ -11,7 +11,7 @@ from infrastructure.cache.cache_keys import (
     lidarr_requested_mbids_key,
     lidarr_monitored_mbids_key,
 )
-from .base import LidarrBase
+from .base import LidarrBase, LIDARR_LIBRARY_SCAN_TTL_SECONDS
 
 if TYPE_CHECKING:
     from infrastructure.persistence.request_history import RequestHistoryStore
@@ -84,7 +84,7 @@ class LidarrLibraryRepository(LidarrBase):
                 )
             )
 
-        await self._cache.set(cache_key, out, ttl_seconds=300)
+        await self._cache.set(cache_key, out, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return out
 
     async def get_artists_from_library(self, include_unmonitored: bool = False) -> list[dict]:
@@ -139,7 +139,7 @@ class LidarrLibraryRepository(LidarrBase):
                 artists_dict[artist_mbid]['date_added'] = date_added
 
         result = list(artists_dict.values())
-        await self._cache.set(cache_key, result, ttl_seconds=300)
+        await self._cache.set(cache_key, result, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return result
 
     async def get_library_grouped(self) -> list[LibraryGroupedArtist]:
@@ -186,7 +186,7 @@ class LidarrLibraryRepository(LidarrBase):
             LibraryGroupedArtist(artist=artist, albums=albums)
             for artist, albums in grouped.items()
         ]
-        await self._cache.set(cache_key, result, ttl_seconds=300)
+        await self._cache.set(cache_key, result, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return result
 
     async def get_library_mbids(self, include_release_ids: bool = True) -> set[str]:
@@ -213,7 +213,7 @@ class LidarrLibraryRepository(LidarrBase):
                     if isinstance(rid, str):
                         ids.add(rid.lower())
 
-        await self._cache.set(cache_key, ids, ttl_seconds=300)
+        await self._cache.set(cache_key, ids, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return ids
 
     async def get_artist_mbids(self) -> set[str]:
@@ -234,7 +234,7 @@ class LidarrLibraryRepository(LidarrBase):
             if isinstance(mbid, str):
                 ids.add(mbid.lower())
 
-        await self._cache.set(cache_key, ids, ttl_seconds=300)
+        await self._cache.set(cache_key, ids, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return ids
 
     async def get_requested_mbids(self) -> set[str]:
@@ -269,5 +269,5 @@ class LidarrLibraryRepository(LidarrBase):
             if isinstance(rg, str):
                 ids.add(rg.lower())
 
-        await self._cache.set(cache_key, ids, ttl_seconds=300)
+        await self._cache.set(cache_key, ids, ttl_seconds=LIDARR_LIBRARY_SCAN_TTL_SECONDS)
         return ids

--- a/backend/tests/repositories/test_lidarr_library_cache.py
+++ b/backend/tests/repositories/test_lidarr_library_cache.py
@@ -6,6 +6,8 @@ import httpx
 
 from core.config import Settings
 from infrastructure.cache.memory_cache import InMemoryCache
+from infrastructure.cache.cache_keys import lidarr_library_mbids_key, lidarr_raw_albums_key
+from repositories.lidarr.base import LIDARR_LIBRARY_SCAN_TTL_SECONDS
 from repositories.lidarr.library import LidarrLibraryRepository
 
 
@@ -150,6 +152,34 @@ class TestCacheInvalidation:
 
 
 class TestSharedRawAlbumCache:
+    @pytest.mark.asyncio
+    async def test_library_mbids_and_raw_albums_use_long_scan_ttl(self, repo, cache):
+        """Full-library Lidarr scans should stay warm beyond a short page visit cache."""
+        original_set = cache.set
+        cache_set_calls: list[tuple[str, int]] = []
+
+        async def record_set(key, value, ttl_seconds=60):
+            cache_set_calls.append((key, ttl_seconds))
+            await original_set(key, value, ttl_seconds=ttl_seconds)
+
+        cache.set = AsyncMock(side_effect=record_set)
+
+        with patch.object(repo, "_get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = [
+                {
+                    "foreignAlbumId": "aaaa",
+                    "statistics": {"trackFileCount": 10},
+                    "releases": [{"foreignId": "release-aaaa"}],
+                },
+            ]
+
+            result = await repo.get_library_mbids(include_release_ids=True)
+
+        assert result == {"aaaa", "release-aaaa"}
+        ttl_by_key = {key: ttl for key, ttl in cache_set_calls}
+        assert ttl_by_key[lidarr_raw_albums_key()] == LIDARR_LIBRARY_SCAN_TTL_SECONDS
+        assert ttl_by_key[lidarr_library_mbids_key(True)] == LIDARR_LIBRARY_SCAN_TTL_SECONDS
+
     @pytest.mark.asyncio
     async def test_concurrent_mbids_calls_deduplicate_raw_album_fetch(self, repo):
         """Concurrent MBID calls should coalesce to one /api/v1/album request."""


### PR DESCRIPTION
## Why

Large Lidarr libraries make album-page flows wait on expensive full-library album scans. In the KO deployment, the `/api/v1/library/mbids` payload is about 872 KB and can take tens of seconds cold; keeping that scan on the short default cache TTL causes normal browsing to re-enter the expensive path too often.

This PR upstreams the portable part of the KO fork fix from OmarB97/Musicseerr#2 as a clean branch from `HabiRabbu/Musicseerr` `main`.

## What changed

- Added `LIDARR_LIBRARY_SCAN_TTL_SECONDS = 3600` for expensive full-library Lidarr scans.
- Used that TTL for the raw `/api/v1/album` payload and derived library album, artist, grouped, MBID, artist-MBID, and monitored-without-files caches.
- Added regression coverage proving the raw album scan and derived library MBID cache use the longer scan TTL.

## How to review

Review `backend/repositories/lidarr/base.py` first for the raw album scan TTL, then `backend/repositories/lidarr/library.py` for the derived cache reuse. The test assertion is in `backend/tests/repositories/test_lidarr_library_cache.py`.

## Evidence

No visual surface changed; this is a backend cache behavior change.
<!-- pr-quality:no-visual-required: backend cache-only change verified by repository tests and lint -->

Clean upstream diff: `git diff --name-status upstream/main...HEAD` contains only:
- `backend/repositories/lidarr/base.py`
- `backend/repositories/lidarr/library.py`
- `backend/tests/repositories/test_lidarr_library_cache.py`

Backend focused tests PASS rc=0: 4 Lidarr URL tests, 24 library pagination tests, and 10 Lidarr library cache tests passed locally under Python 3.13. Ruff PASS rc=0: `make backend-lint` reported `All checks passed!`.

## Verification

- `PYTHON=/opt/homebrew/bin/python3.13 make backend-venv`
- `make backend-test-lidarr-url backend-test-library-pagination`
- `cd backend && .venv/bin/python -m pytest tests/repositories/test_lidarr_library_cache.py -v`
- `make backend-lint`
- `git diff --check upstream/main...HEAD`

## Risks / gaps

Accepted tradeoff: library in-library/monitored status can stay warm for up to 1 hour unless invalidated by existing request/import/settings flows.

Accepted tradeoff: the first cache warm after a process restart is still expensive; this change prevents that scan from recurring every 5 minutes during normal browsing.

## Collaborators

**Participants:**
- **@OmarB97** - KO deployment report, fork validation, and upstream branch preparation.
