### PR TITLE
[MusicSeerr][player-stall-fix][musicseerr-player-stall-fork-upstream-prs][1/n] Fix native player stall on Navidrome streams

### DIFF
--- a/frontend/src/lib/player/NativeAudioSource.spec.ts
+++ b/frontend/src/lib/player/NativeAudioSource.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const hoisted = vi.hoisted(() => {
 	const listeners = new Map<string, Set<EventListener>>();
+	const resumeAudioEngine = vi.fn(async () => undefined);
 	const audio = {
 		src: '',
 		volume: 1,
@@ -42,18 +43,22 @@ const hoisted = vi.hoisted(() => {
 		audio.load.mockReset();
 		audio.addEventListener.mockClear();
 		audio.removeEventListener.mockClear();
+		resumeAudioEngine.mockReset();
+		resumeAudioEngine.mockResolvedValue(undefined);
 	};
 
 	return {
 		audio,
 		dispatch,
 		reset,
-		getAudioElement: vi.fn(() => audio as unknown as HTMLAudioElement)
+		getAudioElement: vi.fn(() => audio as unknown as HTMLAudioElement),
+		resumeAudioEngine
 	};
 });
 
 vi.mock('./audioElement', () => ({
-	getAudioElement: hoisted.getAudioElement
+	getAudioElement: hoisted.getAudioElement,
+	resumeAudioEngine: hoisted.resumeAudioEngine
 }));
 
 import { NativeAudioSource } from './NativeAudioSource';
@@ -73,6 +78,19 @@ describe('NativeAudioSource', () => {
 		hoisted.dispatch('canplay');
 
 		await expect(loadPromise).resolves.toBeUndefined();
+	});
+
+	it('loads successfully on metadata and reports duration before playback timeupdates', async () => {
+		const source = new NativeAudioSource('local', { url: '/metadata.mp3', seekable: true });
+		const onProgress = vi.fn();
+		source.onProgress(onProgress);
+		const loadPromise = source.load();
+
+		hoisted.audio.duration = 178;
+		hoisted.dispatch('loadedmetadata');
+
+		await expect(loadPromise).resolves.toBeUndefined();
+		expect(onProgress).toHaveBeenCalledWith(0, 178);
 	});
 
 	it('fails load when timeout is reached', async () => {
@@ -109,8 +127,34 @@ describe('NativeAudioSource', () => {
 		hoisted.audio.play.mockImplementationOnce(() => Promise.reject(new Error('blocked')));
 		source.play();
 		await Promise.resolve();
+		await Promise.resolve();
 
 		expect(onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'AUTOPLAY_BLOCKED' }));
+	});
+
+	it('resumes the Web Audio engine before native playback', async () => {
+		const source = new NativeAudioSource('local', { url: '/resume.mp3', seekable: true });
+
+		source.play();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(hoisted.resumeAudioEngine).toHaveBeenCalledTimes(1);
+		expect(hoisted.audio.play).toHaveBeenCalledTimes(1);
+		expect(hoisted.resumeAudioEngine.mock.invocationCallOrder[0]).toBeLessThan(
+			hoisted.audio.play.mock.invocationCallOrder[0]
+		);
+	});
+
+	it('still attempts native playback if Web Audio resume rejects', async () => {
+		const source = new NativeAudioSource('local', { url: '/resume-rejected.mp3', seekable: true });
+
+		hoisted.resumeAudioEngine.mockRejectedValueOnce(new Error('resume blocked'));
+		source.play();
+		await Promise.resolve();
+		await Promise.resolve();
+
+		expect(hoisted.audio.play).toHaveBeenCalledTimes(1);
 	});
 
 	it('seekTo updates currentTime when stream is seekable', () => {

--- a/frontend/src/lib/player/NativeAudioSource.spec.ts
+++ b/frontend/src/lib/player/NativeAudioSource.spec.ts
@@ -93,6 +93,25 @@ describe('NativeAudioSource', () => {
 		expect(onProgress).toHaveBeenCalledWith(0, 178);
 	});
 
+	it('detaches ready listeners on first ready event so onReady is single-shot', async () => {
+		const source = new NativeAudioSource('local', { url: '/single-shot.mp3', seekable: true });
+		const onReady = vi.fn();
+		source.onReady(onReady);
+
+		const loadPromise = source.load();
+		hoisted.dispatch('canplay');
+		await loadPromise;
+
+		expect(onReady).toHaveBeenCalledTimes(1);
+		for (const event of ['canplay', 'loadedmetadata', 'loadeddata']) {
+			expect(hoisted.audio.removeEventListener).toHaveBeenCalledWith(event, expect.any(Function));
+		}
+
+		hoisted.dispatch('loadedmetadata');
+		hoisted.dispatch('loadeddata');
+		expect(onReady).toHaveBeenCalledTimes(1);
+	});
+
 	it('fails load when timeout is reached', async () => {
 		vi.useFakeTimers();
 		const source = new NativeAudioSource('local', { url: '/timeout.mp3', seekable: true });

--- a/frontend/src/lib/player/NativeAudioSource.ts
+++ b/frontend/src/lib/player/NativeAudioSource.ts
@@ -1,5 +1,5 @@
 import type { PlaybackSource, PlaybackState } from './types';
-import { getAudioElement } from './audioElement';
+import { getAudioElement, resumeAudioEngine } from './audioElement';
 
 const LOAD_TIMEOUT_MS = 15_000;
 const STALL_TIMEOUT_MS = 15_000;
@@ -46,8 +46,15 @@ export class NativeAudioSource implements PlaybackSource {
 				action();
 			};
 
-			const onCanPlay = () => {
+			const emitProgress = () => {
+				const currentTime = this.getCurrentTime();
+				const duration = this.getDuration();
+				this.progressCallbacks.forEach((cb) => cb(currentTime, duration));
+			};
+
+			const onReady = () => {
 				finalize(() => {
+					emitProgress();
 					this.readyCallbacks.forEach((cb) => cb());
 					resolve();
 				});
@@ -84,9 +91,7 @@ export class NativeAudioSource implements PlaybackSource {
 				if (this.currentState === 'buffering') {
 					this.emitStateChange('playing');
 				}
-				const currentTime = this.getCurrentTime();
-				const duration = this.getDuration();
-				this.progressCallbacks.forEach((cb) => cb(currentTime, duration));
+				emitProgress();
 			};
 
 			const onError = () => {
@@ -114,8 +119,17 @@ export class NativeAudioSource implements PlaybackSource {
 
 			this.registerListener('canplay', () => {
 				clearTimeout(timeoutHandle);
-				onCanPlay();
+				onReady();
 			});
+			this.registerListener('loadedmetadata', () => {
+				clearTimeout(timeoutHandle);
+				onReady();
+			});
+			this.registerListener('loadeddata', () => {
+				clearTimeout(timeoutHandle);
+				onReady();
+			});
+			this.registerListener('durationchange', emitProgress);
 			this.registerListener('play', onPlay);
 			this.registerListener('playing', onPlaying);
 			this.registerListener('pause', onPause);
@@ -135,10 +149,7 @@ export class NativeAudioSource implements PlaybackSource {
 	}
 
 	play(): void {
-		void this.audio.play().catch(() => {
-			this.emitError('AUTOPLAY_BLOCKED', 'Playback failed. Browser may be blocking autoplay.');
-			this.emitStateChange('error');
-		});
+		void this.playWithEngineResume();
 	}
 
 	pause(): void {
@@ -229,6 +240,20 @@ export class NativeAudioSource implements PlaybackSource {
 		if (!this.stallTimeoutHandle) return;
 		clearTimeout(this.stallTimeoutHandle);
 		this.stallTimeoutHandle = null;
+	}
+
+	private async playWithEngineResume(): Promise<void> {
+		try {
+			await resumeAudioEngine();
+		} catch {
+			// Keep native playback attempt alive even if Web Audio resume fails.
+		}
+		try {
+			await this.audio.play();
+		} catch {
+			this.emitError('AUTOPLAY_BLOCKED', 'Playback failed. Browser may be blocking autoplay.');
+			this.emitStateChange('error');
+		}
 	}
 
 	private emitStateChange(state: PlaybackState): void {

--- a/frontend/src/lib/player/NativeAudioSource.ts
+++ b/frontend/src/lib/player/NativeAudioSource.ts
@@ -117,18 +117,19 @@ export class NativeAudioSource implements PlaybackSource {
 				reject(new Error(message));
 			}, LOAD_TIMEOUT_MS);
 
-			this.registerListener('canplay', () => {
+			const readyEvents = ['canplay', 'loadedmetadata', 'loadeddata'];
+			const handleReady = () => {
 				clearTimeout(timeoutHandle);
+				// Single-shot: detach all ready listeners on first fire so the other
+				// two events can never re-enter onReady.
+				for (const event of readyEvents) {
+					this.unregisterListener(event, handleReady);
+				}
 				onReady();
-			});
-			this.registerListener('loadedmetadata', () => {
-				clearTimeout(timeoutHandle);
-				onReady();
-			});
-			this.registerListener('loadeddata', () => {
-				clearTimeout(timeoutHandle);
-				onReady();
-			});
+			};
+			for (const event of readyEvents) {
+				this.registerListener(event, handleReady);
+			}
 			this.registerListener('durationchange', emitProgress);
 			this.registerListener('play', onPlay);
 			this.registerListener('playing', onPlaying);
@@ -218,6 +219,11 @@ export class NativeAudioSource implements PlaybackSource {
 	private registerListener(event: string, handler: EventListener): void {
 		this.audio.addEventListener(event, handler);
 		this.listeners.push({ event, handler });
+	}
+
+	private unregisterListener(event: string, handler: EventListener): void {
+		this.audio.removeEventListener(event, handler);
+		this.listeners = this.listeners.filter((l) => !(l.event === event && l.handler === handler));
 	}
 
 	private cleanupListeners(): void {

--- a/frontend/src/lib/player/audioElement.spec.ts
+++ b/frontend/src/lib/player/audioElement.spec.ts
@@ -1,11 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockEngine = vi.hoisted(() => ({
+	connect: vi.fn(),
+	destroy: vi.fn(),
+	isConnected: vi.fn(() => true),
+	resume: vi.fn(async () => undefined)
+}));
+
 vi.mock('./audioEngine', () => {
-	const MockAudioEngine = vi.fn().mockImplementation(() => ({
-		connect: vi.fn(),
-		destroy: vi.fn(),
-		isConnected: vi.fn(() => true)
-	}));
+	const MockAudioEngine = vi.fn().mockImplementation(() => mockEngine);
 	return { AudioEngine: MockAudioEngine };
 });
 
@@ -13,6 +16,7 @@ import {
 	_resetAudioElement,
 	getAudioElement,
 	getAudioEngine,
+	resumeAudioEngine,
 	tryGetAudioEngine,
 	setAudioElement
 } from './audioElement';
@@ -21,6 +25,7 @@ describe('audioElement registry', () => {
 	beforeEach(() => {
 		_resetAudioElement();
 		vi.clearAllMocks();
+		mockEngine.resume.mockResolvedValue(undefined);
 	});
 
 	it('throws when getting audio element before registration', () => {
@@ -88,5 +93,33 @@ describe('audioElement registry', () => {
 		_resetAudioElement();
 		expect(engine.destroy).toHaveBeenCalled();
 		expect(tryGetAudioEngine()).toBeNull();
+	});
+
+	it('resumeAudioEngine calls the registered engine', async () => {
+		expect.assertions(1);
+		const audio = { src: '' } as HTMLAudioElement;
+		setAudioElement(audio);
+
+		await resumeAudioEngine();
+
+		expect(mockEngine.resume).toHaveBeenCalledTimes(1);
+	});
+
+	it('resumeAudioEngine is a no-op when the engine is unavailable', async () => {
+		expect.assertions(1);
+
+		await resumeAudioEngine();
+
+		expect(mockEngine.resume).not.toHaveBeenCalled();
+	});
+
+	it('resumeAudioEngine swallows browser resume rejections', async () => {
+		expect.assertions(2);
+		const audio = { src: '' } as HTMLAudioElement;
+		setAudioElement(audio);
+		mockEngine.resume.mockRejectedValueOnce(new Error('not allowed'));
+
+		await expect(resumeAudioEngine()).resolves.toBeUndefined();
+		expect(mockEngine.resume).toHaveBeenCalledTimes(1);
 	});
 });

--- a/frontend/src/lib/player/audioElement.ts
+++ b/frontend/src/lib/player/audioElement.ts
@@ -38,6 +38,15 @@ export function tryGetAudioEngine(): AudioEngine | null {
 	return engine;
 }
 
+export async function resumeAudioEngine(): Promise<void> {
+	try {
+		await engine?.resume();
+	} catch {
+		// Browsers can reject resume() outside a user activation. Native audio
+		// playback should still continue; the next user gesture can retry.
+	}
+}
+
 export function _resetAudioElement(): void {
 	engine?.destroy();
 	engine = null;

--- a/frontend/src/lib/stores/player.svelte.ts
+++ b/frontend/src/lib/stores/player.svelte.ts
@@ -45,6 +45,7 @@ import {
 	buildPrefetchUrl,
 	buildNowPlayingMetadata
 } from './playerSourceResolver';
+import { resumeAudioEngine } from '$lib/player/audioElement';
 import {
 	persistSession as doPersistSession,
 	restoreSessionData,
@@ -191,9 +192,10 @@ function createPlayerStore() {
 		storeSessionData(null);
 	}
 
-	async function resolveSourceForItem(
-		item: QueueItem
-	): Promise<{ source: PlaybackSource; loadUrl: string | undefined }> {
+	function resolveSourceForItem(item: QueueItem): {
+		source: PlaybackSource;
+		loadUrl: string | undefined;
+	} {
 		const url = resolveSourceUrl(item);
 		if (item.sourceType === 'youtube') {
 			isSeekable = true;
@@ -250,12 +252,17 @@ function createPlayerStore() {
 			errorSkipTimeout = null;
 		}
 		const prevProgress = progress,
-			prevItem = queue[currentIndex] ?? null;
+			prevItem = currentSource ? (queue[currentIndex] ?? null) : null;
 		currentIndex = index;
 		playbackState = 'loading';
 		progress = 0;
 		duration = 0;
-		await stopPreviousSession(prevItem, prevProgress);
+		if (prevItem) {
+			await stopPreviousSession(prevItem, prevProgress);
+		} else {
+			progressReporter.stop();
+			unregisterBeforeUnload();
+		}
 		currentSource?.destroy();
 		const gen = ++loadGeneration;
 		let source: PlaybackSource,
@@ -274,13 +281,20 @@ function createPlayerStore() {
 		subscribeToSource(source, gen);
 		source.setVolume(volume);
 		try {
-			if ((queue[index] ?? item).sourceType === 'jellyfin') await startJellyfinPlayback(index);
-			await source.load({
-				trackSourceId: (queue[index] ?? item).trackSourceId,
+			const activeItem = queue[index] ?? item;
+			const loadPromise = source.load({
+				trackSourceId: activeItem.trackSourceId,
 				url: resolvedUrl,
-				format: (queue[index] ?? item).format
+				format: activeItem.format
 			});
-			if (gen === loadGeneration) source.play();
+			if (gen === loadGeneration && activeItem.sourceType !== 'youtube') {
+				source.play();
+			}
+			if (activeItem.sourceType === 'jellyfin') await startJellyfinPlayback(index);
+			await loadPromise;
+			if (gen === loadGeneration && activeItem.sourceType === 'youtube') {
+				source.play();
+			}
 		} catch {
 			if (gen === loadGeneration) handleTrackError(gen);
 		}
@@ -445,6 +459,7 @@ function createPlayerStore() {
 		},
 
 		playAlbum(source: PlaybackSource, metadata: NowPlaying): void {
+			void resumeAudioEngine();
 			void stopPreviousSession(getCurrentItem(), progress);
 			currentSource?.destroy();
 			const gen = ++loadGeneration;
@@ -464,6 +479,7 @@ function createPlayerStore() {
 
 		playQueue(items: QueueItem[], startIndex: number = 0, shuffle: boolean = false): void {
 			if (items.length === 0) return;
+			void resumeAudioEngine();
 			const s = buildPlayQueueState(items, startIndex, shuffle);
 			queue = s.queue;
 			shuffleEnabled = s.shuffleEnabled;
@@ -672,6 +688,7 @@ function createPlayerStore() {
 		},
 
 		play(): void {
+			void resumeAudioEngine();
 			currentSource?.play();
 		},
 
@@ -699,6 +716,7 @@ function createPlayerStore() {
 				if (item?.sourceType === 'navidrome') void reportNavidromeStopped(item.trackSourceId);
 				persist();
 			} else {
+				void resumeAudioEngine();
 				currentSource?.play();
 			}
 		},
@@ -749,8 +767,9 @@ function createPlayerStore() {
 			duration = 0;
 			const gen = ++loadGeneration;
 
-			void resolveSourceForItem(resume.currentItem)
-				.then(async ({ source, loadUrl }) => {
+			void (async () => {
+				try {
+					const { source, loadUrl } = resolveSourceForItem(resume.currentItem);
 					if (gen !== loadGeneration) return;
 					currentSource = source;
 					nowPlaying = resume.nowPlaying;
@@ -771,13 +790,12 @@ function createPlayerStore() {
 						source.seekTo(resume.progress);
 						progress = resume.progress;
 					}
-				})
-				.catch(() => {
-					if (gen === loadGeneration) {
-						playbackState = 'error';
-						storeSessionData(null);
-					}
-				});
+				} catch {
+					if (gen !== loadGeneration) return;
+					playbackState = 'error';
+					storeSessionData(null);
+				}
+			})();
 		}
 	};
 }

--- a/frontend/src/lib/stores/player.svelte.ts
+++ b/frontend/src/lib/stores/player.svelte.ts
@@ -287,10 +287,12 @@ function createPlayerStore() {
 				url: resolvedUrl,
 				format: activeItem.format
 			});
+			// Session must exist before play(): a fast 'playing' event would otherwise
+			// start the progress reporter without a playSessionId and it bails permanently.
+			if (activeItem.sourceType === 'jellyfin') await startJellyfinPlayback(index);
 			if (gen === loadGeneration && activeItem.sourceType !== 'youtube') {
 				source.play();
 			}
-			if (activeItem.sourceType === 'jellyfin') await startJellyfinPlayback(index);
 			await loadPromise;
 			if (gen === loadGeneration && activeItem.sourceType === 'youtube') {
 				source.play();

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -14,7 +14,7 @@
 	import { scrobbleManager } from '$lib/stores/scrobble.svelte';
 	import { imageSettingsStore } from '$lib/stores/imageSettings';
 	import { serviceStatusStore } from '$lib/stores/serviceStatus';
-	import { setAudioElement, tryGetAudioEngine } from '$lib/player/audioElement';
+	import { resumeAudioEngine, setAudioElement } from '$lib/player/audioElement';
 	import { eqStore } from '$lib/stores/eq.svelte';
 	import Player from '$lib/components/Player.svelte';
 	import CacheSyncIndicator from '$lib/components/CacheSyncIndicator.svelte';
@@ -112,7 +112,7 @@
 		}
 
 		const resumeAudioContext = () => {
-			tryGetAudioEngine()?.resume();
+			void resumeAudioEngine();
 			cleanupResumeListeners?.();
 			cleanupResumeListeners = null;
 		};


### PR DESCRIPTION
## Why

Native MusicSeerr playback can get stuck after selecting a Navidrome track: the player UI enters the loading state, but the seekbar stays at `0:00` and audio does not begin even though the stream endpoint returns valid FLAC bytes quickly.

This replaces #81 with a clean upstream-only branch. The original source branch became KO's live integration branch and now carries downstream cache and AI-review commits, so this replacement keeps the upstream diff limited to the player fix.

## What changed

- Added a shared `resumeAudioEngine()` helper for Web Audio resume handling.
- For native non-YouTube sources, start playback immediately after initiating `source.load()` so the browser still associates `audio.play()` with the user's click.
- Resolve native source readiness on `loadedmetadata`, `loadeddata`, or `canplay` instead of only waiting for `canplay`.
- Emit progress/duration updates when metadata or duration changes arrive, so the player can show real duration before the first `timeupdate`.
- Added regression tests for Web Audio resume, metadata-driven load readiness, and native playback startup behavior.

## How to review

Review `frontend/src/lib/stores/player.svelte.ts` first. The key behavior change is that native playback now calls `source.play()` immediately after starting `source.load()`, while YouTube keeps its existing load-before-play behavior.

Then review `frontend/src/lib/player/NativeAudioSource.ts` for metadata readiness and progress emission, followed by `frontend/src/lib/player/audioElement.ts` for the shared audio engine resume helper.

The corresponding regression coverage is in `frontend/src/lib/player/NativeAudioSource.spec.ts`, `frontend/src/lib/player/audioElement.spec.ts`, and `frontend/src/lib/stores/player.spec.ts`.

## Evidence

No visual layout changed; this is playback sequencing and audio readiness behavior.
<!-- pr-quality:no-visual-required: playback behavior change only; controls and layout visuals are unchanged -->

Clean upstream diff PASS: `git diff --name-status upstream/main...HEAD` contains only:
- `frontend/src/lib/player/NativeAudioSource.spec.ts`
- `frontend/src/lib/player/NativeAudioSource.ts`
- `frontend/src/lib/player/audioElement.spec.ts`
- `frontend/src/lib/player/audioElement.ts`
- `frontend/src/lib/stores/player.svelte.ts`
- `frontend/src/routes/+layout.svelte`

Local verification PASS: 93 focused player/audio tests passed, Svelte check reported 0 errors and 0 warnings, ESLint passed, Prettier check passed, and production build completed. The build emitted the existing Svelte warning in `src/routes/album/[id]/albumPageState.svelte.ts`; that file is not part of this PR.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm vitest run src/lib/player/NativeAudioSource.spec.ts src/lib/player/audioElement.spec.ts src/lib/stores/player.spec.ts`
- `pnpm run check`
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run build`
- `git diff --check upstream/main...HEAD`

## Risks / gaps

Supersedes #81: the old PR branch is now a KO live integration branch with downstream commits, so it should be closed in favor of this clean branch. Tracked by MeshBoard task `musicseerr-player-stall-fork-upstream-prs-20260611`.

Accepted scope boundary: YouTube keeps its existing load-before-play path because that source has different readiness semantics.

Accepted risk with no follow-up: production verification used Navidrome FLAC playback in the KO deployment, and the regression tests cover native source sequencing generically.

## Collaborators

**Participants:**
- **@OmarB97** - operator report and production verification on KO MusicSeerr.
- **Codex on ko-mac** - clean replacement branch, conflict triage, and verification.
