### PR TITLE
[MusicSeerr][dev-image-publish][1/n] Make Docker Hub publish optional

### DIFF
--- a/.github/workflows/dev-image.yml
+++ b/.github/workflows/dev-image.yml
@@ -71,6 +71,9 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -89,6 +92,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to Docker Hub
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
         uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -102,10 +106,23 @@ jobs:
         id: date
         run: echo "timestamp=$(git log -1 --pretty=%cI)" >> "$GITHUB_OUTPUT"
 
-      - name: Set image name
+      - name: Set image tags
         env:
           OWNER: ${{ github.repository_owner }}
-        run: echo "IMAGE=ghcr.io/$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')/musicseerr" >> $GITHUB_ENV
+          SHORT_SHA: ${{ steps.sha.outputs.short }}
+        run: |
+          image="ghcr.io/$(echo "$OWNER" | tr '[:upper:]' '[:lower:]')/musicseerr"
+          {
+            echo "IMAGE=$image"
+            echo "TAGS<<EOF"
+            echo "$image:dev"
+            echo "$image:dev-$SHORT_SHA"
+            if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
+              echo "habirabbu/musicseerr:dev"
+              echo "habirabbu/musicseerr:dev-$SHORT_SHA"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_ENV"
 
       - name: Build and push (multi-arch)
         uses: docker/build-push-action@v7
@@ -113,11 +130,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          tags: |
-            ${{ env.IMAGE }}:dev
-            ${{ env.IMAGE }}:dev-${{ steps.sha.outputs.short }}
-            habirabbu/musicseerr:dev
-            habirabbu/musicseerr:dev-${{ steps.sha.outputs.short }}
+          tags: ${{ env.TAGS }}
           build-args: |
             COMMIT_TAG=dev-${{ steps.sha.outputs.short }}
             BUILD_DATE=${{ steps.date.outputs.timestamp }}


### PR DESCRIPTION
## Why

Fork PR #5 merged cleanly, but the post-merge `Dev Image` workflow failed in `Publish multi-arch image` before publishing anything because the workflow always tried to log in to Docker Hub. The fork does not currently have `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` configured, so the job stopped with `Username and password required` even though GHCR login succeeded.

Docker Hub publishing should be optional for this fork. GHCR is enough for the KO-NAS deployment path, and missing Docker Hub credentials should not turn every otherwise-good merge red.

## What changed

- Project Docker Hub credentials into the publish job environment.
- Run the Docker Hub login step only when both Docker Hub secrets are present.
- Generate the `docker/build-push-action` tag list dynamically:
  - always include `ghcr.io/<owner>/musicseerr:dev`
  - always include `ghcr.io/<owner>/musicseerr:dev-<short-sha>`
  - include Docker Hub `habirabbu/musicseerr:*` tags only when both Docker Hub secrets are present

## How to review

1. Review `.github/workflows/dev-image.yml` only.
2. Confirm the GHCR tags are still always emitted.
3. Confirm Docker Hub login and Docker Hub tags are both gated by the same optional secret pair.

## Evidence

Failure being repaired:

```text
Publish multi-arch image / Log in to Docker Hub
Username and password required
```

The previous workflow run was `Dev Image` on fork `main` for merge commit `224aa42aa81b6e47b04559de96450a67322e5260`.

## Verification

<!-- pr-quality:no-test-diff-required: Workflow-only repair; adding an automated test would require a GitHub Actions harness/mocked secrets runner that this repo does not have. The local validation is YAML parsing plus diff sanity, and the real regression check is the next post-merge Dev Image workflow run tracked by MeshBoard. -->

- Manual workflow-config check passed: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dev-image.yml"); puts "yaml=ok"'`.
- Regression whitespace check passed: `git diff --check`.

## Risks / gaps

- This PR does not prove the post-merge GHCR publish until it lands on `main`; that verification is tracked by `musicseerr-dev-image-optional-dockerhub-20260612`.
- Docker Hub publishing remains disabled unless the fork later configures both Docker Hub secrets. Optional secret setup is tracked by `musicseerr-dockerhub-publish-secrets-20260612`; GHCR remains the intended KO-NAS image source.

## Collaborators

- Omar Baradei: operator and product owner; requested continuation after the mobile fork PR merge.
- `ko-mac.codex#4164dc4f2a`: Codex GPT-5 coding lane on ko-mac, June 11-12 2026, task `musicseerr-dev-image-optional-dockerhub-20260612`.
