### PR TITLE
Support PKCE for OIDC login

### DIFF
--- a/backend/infrastructure/persistence/auth_store.py
+++ b/backend/infrastructure/persistence/auth_store.py
@@ -135,9 +135,14 @@ class AuthStore:
                 CREATE TABLE IF NOT EXISTS auth_oidc_states (
                     state TEXT PRIMARY KEY,
                     created_at TEXT NOT NULL,
-                    expires_at TEXT NOT NULL
+                    expires_at TEXT NOT NULL,
+                    code_verifier TEXT
                 );
             """)
+            # Migration: add code_verifier (PKCE) to pre-existing auth_oidc_states.
+            have = {row[1] for row in conn.execute("PRAGMA table_info(auth_oidc_states)")}
+            if "code_verifier" not in have:
+                conn.execute("ALTER TABLE auth_oidc_states ADD COLUMN code_verifier TEXT")
             conn.commit()
         finally:
             conn.close()
@@ -503,7 +508,9 @@ class AuthStore:
             logger.info(f"Cleaned up {count} expired auth token(s)")
         return count
 
-    async def store_oidc_state(self, state: str, ttl_seconds: int = 600) -> None:
+    async def store_oidc_state(
+        self, state: str, ttl_seconds: int = 600, code_verifier: str | None = None
+    ) -> None:
         now = _now_iso()
         expiry = (datetime.now(timezone.utc) + timedelta(seconds = ttl_seconds)).isoformat()
 
@@ -511,24 +518,24 @@ class AuthStore:
             # Also prune stale states opportunistically
             conn.execute("DELETE FROM auth_oidc_states WHERE expires_at < ?", (now,))
             conn.execute(
-                "INSERT INTO auth_oidc_states (state, created_at, expires_at) VALUES (?, ?, ?)",
-                (state, now, expiry),
+                "INSERT INTO auth_oidc_states (state, created_at, expires_at, code_verifier) VALUES (?, ?, ?, ?)",
+                (state, now, expiry, code_verifier),
             )
 
         await self._write(operation)
 
-    async def consume_oidc_state(self, state: str) -> bool:
+    async def consume_oidc_state(self, state: str) -> tuple[bool, str | None]:
         now = _now_iso()
 
-        def operation(conn: sqlite3.Connection) -> bool:
+        def operation(conn: sqlite3.Connection) -> tuple[bool, str | None]:
             row = conn.execute(
-                "SELECT state FROM auth_oidc_states WHERE state = ? AND expires_at > ?",
+                "SELECT code_verifier FROM auth_oidc_states WHERE state = ? AND expires_at > ?",
                 (state, now),
             ).fetchone()
             if row is None:
-                return False
+                return False, None
             conn.execute("DELETE FROM auth_oidc_states WHERE state = ?", (state,))
-            return True
+            return True, row["code_verifier"]
 
         return await self._write(operation)
 

--- a/backend/services/oidc_user_auth_service.py
+++ b/backend/services/oidc_user_auth_service.py
@@ -25,7 +25,6 @@ _STATE_TTL = 600
 
 _CACHE_PREFIX_DISCOVERY = "oidc:discovery:"
 _CACHE_PREFIX_CODE      = "oidc:code:"
-_CACHE_PREFIX_PKCE      = "oidc:pkce:"
 
 
 class OIDCUserAuthService:
@@ -125,16 +124,12 @@ class OIDCUserAuthService:
         config = self._require_config()
         doc = await self._discover(config.issuer)
 
-        state = _random_state()
-        await self._store.store_oidc_state(state, ttl_seconds = _STATE_TTL)
-
-        # PKCE (S256): stash the verifier against the state so the callback can
-        # complete the token exchange. Lets public clients (no secret) work, and
-        # is recommended even for confidential clients (OAuth 2.1).
+        # PKCE (S256): persist the verifier with the state so the callback can
+        # complete the token exchange (durable + worker-safe). Lets public clients
+        # (no secret) work, and is recommended even for confidential ones (OAuth 2.1).
         verifier, challenge = _make_pkce()
-        await self._cache.set(
-            f"{_CACHE_PREFIX_PKCE}{state}", verifier, ttl_seconds = _STATE_TTL
-        )
+        state = _random_state()
+        await self._store.store_oidc_state(state, ttl_seconds = _STATE_TTL, code_verifier = verifier)
 
         params = {
             "response_type": "code",
@@ -149,13 +144,9 @@ class OIDCUserAuthService:
         return f"{doc['authorization_endpoint']}?{query}"
 
     async def handle_callback(self, *, code: str, state: str, user_agent: str | None = None) -> str:
-        valid = await self._store.consume_oidc_state(state)
+        valid, code_verifier = await self._store.consume_oidc_state(state)
         if not valid:
             raise AuthenticationError("Invalid or expired OIDC state")
-
-        pkce_key = f"{_CACHE_PREFIX_PKCE}{state}"
-        code_verifier = await self._cache.get(pkce_key)
-        await self._cache.delete(pkce_key)
 
         config = self._require_config()
         doc = await self._discover(config.issuer)

--- a/backend/services/oidc_user_auth_service.py
+++ b/backend/services/oidc_user_auth_service.py
@@ -25,6 +25,7 @@ _STATE_TTL = 600
 
 _CACHE_PREFIX_DISCOVERY = "oidc:discovery:"
 _CACHE_PREFIX_CODE      = "oidc:code:"
+_CACHE_PREFIX_PKCE      = "oidc:pkce:"
 
 
 class OIDCUserAuthService:
@@ -67,7 +68,7 @@ class OIDCUserAuthService:
         config = self._prefs.get_oidc_connection_raw()
         if not config.enabled:
             raise ConfigurationError("OIDC login is not enabled")
-        if not all([config.issuer, config.client_id, config.client_secret, config.redirect_uri]):
+        if not all([config.issuer, config.client_id, config.redirect_uri]):
             raise ConfigurationError("OIDC configuration is incomplete")
         return config
 
@@ -127,12 +128,22 @@ class OIDCUserAuthService:
         state = _random_state()
         await self._store.store_oidc_state(state, ttl_seconds = _STATE_TTL)
 
+        # PKCE (S256): stash the verifier against the state so the callback can
+        # complete the token exchange. Lets public clients (no secret) work, and
+        # is recommended even for confidential clients (OAuth 2.1).
+        verifier, challenge = _make_pkce()
+        await self._cache.set(
+            f"{_CACHE_PREFIX_PKCE}{state}", verifier, ttl_seconds = _STATE_TTL
+        )
+
         params = {
             "response_type": "code",
             "client_id": config.client_id,
             "redirect_uri": config.redirect_uri,
             "scope": config.scopes,
             "state": state,
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
         }
         query = urlencode(params)
         return f"{doc['authorization_endpoint']}?{query}"
@@ -142,10 +153,14 @@ class OIDCUserAuthService:
         if not valid:
             raise AuthenticationError("Invalid or expired OIDC state")
 
+        pkce_key = f"{_CACHE_PREFIX_PKCE}{state}"
+        code_verifier = await self._cache.get(pkce_key)
+        await self._cache.delete(pkce_key)
+
         config = self._require_config()
         doc = await self._discover(config.issuer)
 
-        tokens = await self._exchange_code(code, config, doc)
+        tokens = await self._exchange_code(code, config, doc, code_verifier)
 
         profile = await self._fetch_user_info(tokens, config, doc)
 
@@ -188,14 +203,25 @@ class OIDCUserAuthService:
 
         return user, raw_token
 
-    async def _exchange_code(self, code: str, config: OIDCConnectionSettings, doc: dict) -> dict:
+    async def _exchange_code(
+        self,
+        code: str,
+        config: OIDCConnectionSettings,
+        doc: dict,
+        code_verifier: str | None = None,
+    ) -> dict:
         body = {
             "grant_type": "authorization_code",
             "code": code,
             "redirect_uri": config.redirect_uri,
             "client_id": config.client_id,
-            "client_secret": config.client_secret,
         }
+        # Confidential clients still send their secret; public (PKCE-only) clients
+        # don't have one. PKCE proves possession of the verifier for both.
+        if config.client_secret:
+            body["client_secret"] = config.client_secret
+        if code_verifier:
+            body["code_verifier"] = code_verifier
         try:
             async with httpx.AsyncClient(timeout = 15.0) as client:
                 resp = await client.post(
@@ -296,6 +322,17 @@ class OIDCUserAuthService:
 
 def _random_state() -> str:
     return urlsafe_b64encode(os.urandom(32)).decode()
+
+
+def _make_pkce() -> tuple[str, str]:
+    """Return (code_verifier, code_challenge) for PKCE S256.
+
+    The verifier is 43 chars of base64url (unreserved per RFC 7636); the
+    challenge is base64url(SHA256(verifier)), both unpadded.
+    """
+    verifier = urlsafe_b64encode(os.urandom(32)).rstrip(b"=").decode()
+    challenge = urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    return verifier, challenge
 
 
 def _decode_jwt_payload(token: str) -> dict | None:

--- a/backend/tests/services/test_oidc_pkce.py
+++ b/backend/tests/services/test_oidc_pkce.py
@@ -1,0 +1,55 @@
+"""Tests for OIDC PKCE: challenge derivation and verifier persistence."""
+
+import base64
+import hashlib
+
+import pytest
+
+from infrastructure.persistence.auth_store import AuthStore
+from services.oidc_user_auth_service import _make_pkce
+
+
+def test_make_pkce_format_and_challenge():
+    verifier, challenge = _make_pkce()
+
+    # RFC 7636: verifier is 43-128 chars from the unreserved set.
+    assert 43 <= len(verifier) <= 128
+    assert all(c.isalnum() or c in "-._~" for c in verifier)
+
+    # challenge == base64url(SHA256(verifier)), unpadded.
+    expected = (
+        base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())
+        .rstrip(b"=")
+        .decode()
+    )
+    assert challenge == expected
+    assert "=" not in challenge
+
+
+def test_make_pkce_is_random():
+    assert _make_pkce()[0] != _make_pkce()[0]
+
+
+@pytest.mark.asyncio
+async def test_oidc_state_roundtrips_verifier(tmp_path):
+    store = AuthStore(tmp_path / "auth.db")
+    await store.store_oidc_state("state-1", code_verifier="verifier-abc")
+
+    valid, verifier = await store.consume_oidc_state("state-1")
+    assert valid is True
+    assert verifier == "verifier-abc"
+
+    # Single-use: a second consume fails and yields no verifier.
+    valid2, verifier2 = await store.consume_oidc_state("state-1")
+    assert valid2 is False
+    assert verifier2 is None
+
+
+@pytest.mark.asyncio
+async def test_oidc_state_without_verifier(tmp_path):
+    store = AuthStore(tmp_path / "auth.db")
+    await store.store_oidc_state("state-2")
+
+    valid, verifier = await store.consume_oidc_state("state-2")
+    assert valid is True
+    assert verifier is None

--- a/frontend/src/lib/components/settings/SettingsSecurity.svelte
+++ b/frontend/src/lib/components/settings/SettingsSecurity.svelte
@@ -497,7 +497,7 @@
 								<span class="label-text font-medium">Allow login with SSO</span>
 								<p class="text-xs text-base-content/50">
 									{#if !hasOidcCredentials}
-										Fill in the client ID, client secret, and redirect URI first.
+										Fill in the client ID and redirect URI first.
 									{:else if !oidcForm.testResult?.valid && !oidcForm.wasAlreadyEnabled}
 										Test and get a valid connection to enable
 									{:else}

--- a/frontend/src/lib/components/settings/SettingsSecurity.svelte
+++ b/frontend/src/lib/components/settings/SettingsSecurity.svelte
@@ -63,8 +63,9 @@
 		await oidcForm.save();
 	}
 
+	// Client secret is optional: public clients use PKCE (no secret).
 	const hasOidcCredentials = $derived(
-		Boolean(oidcForm.data?.client_id && oidcForm.data?.client_secret && oidcForm.data?.redirect_uri)
+		Boolean(oidcForm.data?.client_id && oidcForm.data?.redirect_uri)
 	);
 	const oidcToggleDisabled = $derived(
 		!hasOidcCredentials || (!oidcForm.testResult?.valid && !oidcForm.wasAlreadyEnabled)
@@ -411,6 +412,7 @@
 					<div class="form-control w-full">
 						<label class="label" for="oidc-client-secret">
 							<span class="label-text font-medium">Client Secret</span>
+							<span class="label-text-alt opacity-60">optional — leave blank for public/PKCE clients</span>
 						</label>
 						<label class="input input-bordered flex items-center gap-2 w-full">
 							{#if showClientSecret}

--- a/frontend/src/routes/auth/callback/+page.svelte
+++ b/frontend/src/routes/auth/callback/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { page } from '$app/state';
-	import { goto } from '$app/navigation';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { ApiError } from '$lib/api/client';
 	import { createOidcExchangeMutation } from '$lib/queries/auth/AuthMutations.svelte';
@@ -21,7 +20,10 @@
 		try {
 			const data = await oidcExchange.mutateAsync({ code });
 			authStore.setUser(toAuthUser(data.user));
-			goto('/');
+			// Full reload (not goto) so the layout re-hydrates auth from the just-set
+			// session cookie. A client-side nav races the cookie and bounces to /login
+			// on the first sign-in.
+			window.location.href = '/';
 		} catch (e) {
 			error =
 				e instanceof ApiError


### PR DESCRIPTION
Adds PKCE (S256) to the OIDC authorization-code flow and makes the client secret optional, so public/PKCE clients (no secret) work.

- authorize request sends `code_challenge` + `code_challenge_method=S256`
- the verifier is stashed against the `state` and sent as `code_verifier` on token exchange
- `client_secret` is only included when present, so confidential clients are unchanged
- secret field marked optional in Settings > Security

OAuth 2.1 recommends PKCE for all client types.