### PR TITLE
Hide mobile bottom nav on desktop

### DIFF
--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -347,6 +347,13 @@ textarea {
 		--ms-player-height: 5.625rem;
 	}
 
+	/* Desktop: hide the mobile bottom nav. The element's `lg:hidden` utility has
+	   the same specificity as the base `.musicseerr-bottom-nav { display: grid }`
+	   rule and loses on source order, so it stayed visible — hide it explicitly. */
+	.musicseerr-bottom-nav {
+		display: none;
+	}
+
 	.musicseerr-topbar {
 		min-height: 4rem;
 		padding-top: 0;

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -622,7 +622,7 @@
 			{@render children()}
 		{/if}
 
-		<nav class="musicseerr-bottom-nav lg:hidden" aria-label="Primary navigation">
+		<nav class="musicseerr-bottom-nav" aria-label="Primary navigation">
 			<a
 				href="/"
 				class="musicseerr-bottom-nav__item"


### PR DESCRIPTION
The mobile bottom nav (`.musicseerr-bottom-nav`) stays visible on desktop. It relies on the `lg:hidden` utility, but that has the same specificity as the base `.musicseerr-bottom-nav { display: grid }` rule in `app.css` and loses on source order, so it never hides at `lg`.

Fix: give the custom class a single source of truth for visibility — hide it in the existing `@media (min-width: 1024px)` block and remove the now-redundant `lg:hidden` from the markup.