### PR TITLE
Update file_processor.py

### DIFF
--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -454,7 +454,9 @@ class FileProcessor:
                     raise
                 try:
                     shutil.copy2(source, tmp)  # cross-mount: the one unavoidable copy
-                except BaseException:
+                except PermissionError as exc:
+                    logger.error(exc)
+                    logger.debug("Fallback to copyfile for copying file to library.")
                     shutil.copyfile(source, tmp)  # Full fallback, just copy data
             self._tagger.write_album_identity(tmp, target_tag)
             os.replace(tmp, target_path)  # atomic publish within the library dir

--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -452,7 +452,10 @@ class FileProcessor:
             except OSError as exc:
                 if exc.errno != errno.EXDEV:
                     raise
-                shutil.copy2(source, tmp)  # cross-mount: the one unavoidable copy
+                try:
+                    shutil.copy2(source, tmp)  # cross-mount: the one unavoidable copy
+                except BaseException:
+                    shutil.copyfile(source, tmp)  # Full fallback, just copy data
             self._tagger.write_album_identity(tmp, target_tag)
             os.replace(tmp, target_path)  # atomic publish within the library dir
         except BaseException:


### PR DESCRIPTION
## What
Change copy2 in file processing, to have a try-except with a copyfile option if copy2 fails (in edge cases)
## Why
This covers edge cases where copy2 writes the file and doesn't have the right perms after writing it to go and edit it.
## Testing

- [X] I have tested these changes locally
- [ ] I have added or updated tests

## AI-Assisted Contributions

If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

## Checklist

- [X] Backend lint passes (`make backend-lint`)
- [X] Backend tests pass (`make backend-test`)
- [ ] Frontend lint passes (`make frontend-lint`)
- [ ] Frontend type check passes (`make frontend-check`)
- [ ] No `any` in TypeScript
- [ ] No hardcoded colors (design tokens only)
- [ ] All external API calls have timeouts
- [ ] New msgspec structs follow existing patterns
- [ ] TanStack Query used for all new data fetching
- [ ] No secrets, tokens, or credentials in source
