### PR TITLE
feat(reimport): user can finish a download that failed in slskd manually and import it into the app

### DIFF
--- a/backend/api/v1/routes/downloads.py
+++ b/backend/api/v1/routes/downloads.py
@@ -31,6 +31,7 @@ from api.v1.schemas.download import (
     HeldActionResponse,
     HeldImportResponse,
     HeldListResponse,
+    ReimportDownloadResponse,
     RetryAllResponse,
     RetryDownloadResponse,
     StopRetriesResponse,
@@ -295,6 +296,20 @@ async def stream_held_audio(
     if not path.exists():
         raise ResourceNotFoundError("The held file is no longer available")
     return FileResponse(path, media_type=_audio_media_type(path), filename=path.name)
+
+
+@router.post("/{task_id}/reimport", response_model=ReimportDownloadResponse)
+async def reimport_download(
+    task_id: str, current_user: CurrentUserDep, service=Depends(get_download_service)
+):
+    task = await service.reimport_task(task_id, current_user.id, current_user.role)
+    return ReimportDownloadResponse(
+        success=task.status in ("completed", "partial"),
+        status=task.status,
+        files_imported=task.files_completed,
+        files_failed=task.files_failed,
+        error_message=task.error_message,
+    )
 
 
 @router.get("/{task_id}", response_model=DownloadTaskResponse)

--- a/backend/api/v1/routes/library.py
+++ b/backend/api/v1/routes/library.py
@@ -164,6 +164,7 @@ async def get_library_grouped(
 
 @router.get("/album/{album_mbid}/removal-preview", response_model=AlbumRemovePreviewResponse)
 async def get_album_removal_preview(
+    _admin: CurrentAdminDep,
     album_mbid: str,
     library_service: LibraryService = Depends(get_library_service)
 ):
@@ -176,6 +177,7 @@ async def get_album_removal_preview(
 
 @router.delete("/album/{album_mbid}", response_model=AlbumRemoveResponse)
 async def remove_album(
+    _admin: CurrentAdminDep,
     album_mbid: str,
     delete_files: bool = False,
     library_service: LibraryService = Depends(get_library_service),

--- a/backend/api/v1/schemas/download.py
+++ b/backend/api/v1/schemas/download.py
@@ -245,6 +245,14 @@ class RetryAllResponse(AppStruct):
     retried: int
 
 
+class ReimportDownloadResponse(AppStruct):
+    success: bool
+    status: str
+    files_imported: int
+    files_failed: int
+    error_message: str | None = None
+
+
 class TrackRequestBody(AppStruct):
     artist_name: str
     track_title: str

--- a/backend/api/v1/schemas/requests_page.py
+++ b/backend/api/v1/schemas/requests_page.py
@@ -47,6 +47,8 @@ class RequestHistoryItem(AppStruct):
     requested_by_name: str | None = None
     reviewed_by_name: str | None = None
     reviewed_at: datetime | None = None
+    download_task_id: str | None = None
+    can_reimport: bool = False
 
 
 class ActiveRequestsResponse(AppStruct):

--- a/backend/infrastructure/persistence/download_store.py
+++ b/backend/infrastructure/persistence/download_store.py
@@ -438,6 +438,24 @@ class DownloadStore(PersistenceBase):
 
         return await self._read(operation)
 
+    async def get_reimportable_task_ids(self, task_ids: list[str]) -> set[str]:
+        if not task_ids:
+            return set()
+
+        def operation(conn: sqlite3.Connection) -> set[str]:
+            placeholders = ",".join("?" * len(task_ids))
+            rows = conn.execute(
+                f"SELECT id FROM download_tasks WHERE id IN ({placeholders})"
+                " AND status IN ('failed', 'partial')"
+                " AND source_username IS NOT NULL"
+                " AND search_job_id IS NOT NULL"
+                " AND candidate_index IS NOT NULL",
+                task_ids,
+            ).fetchall()
+            return {row["id"] for row in rows}
+
+        return await self._read(operation)
+
     async def get_task_for_user(
         self, task_id: str, user_id: str, user_role: str
     ) -> DownloadTask | None:

--- a/backend/infrastructure/persistence/request_history.py
+++ b/backend/infrastructure/persistence/request_history.py
@@ -9,6 +9,19 @@ import msgspec
 
 logger = logging.getLogger(__name__)
 
+_REIMPORTABLE_CONDITION = (
+    "status = 'failed'"
+    " AND download_task_id IS NOT NULL"
+    " AND EXISTS ("
+    "SELECT 1 FROM download_tasks"
+    " WHERE download_tasks.id = request_history.download_task_id"
+    " AND download_tasks.status IN ('failed', 'partial')"
+    " AND download_tasks.source_username IS NOT NULL"
+    " AND download_tasks.search_job_id IS NOT NULL"
+    " AND download_tasks.candidate_index IS NOT NULL"
+    ")"
+)
+
 
 class RequestHistoryRecord(msgspec.Struct):
     musicbrainz_id: str
@@ -436,9 +449,12 @@ class RequestHistoryStore:
                 "AND musicbrainz_id_lower NOT IN "
                 "(SELECT musicbrainz_id_lower FROM request_history_dismissals WHERE user_id = ?)"
             )
-            if status_filter:
+            if status_filter == 'reimportable':
+                where = f"WHERE user_id = ? AND {_REIMPORTABLE_CONDITION} {dismiss_clause}"
+                params: tuple = (user_id, user_id)
+            elif status_filter:
                 where = f"WHERE user_id = ? AND status = ? {dismiss_clause}"
-                params: tuple = (user_id, status_filter, user_id)
+                params = (user_id, status_filter, user_id)
             else:
                 where = f"WHERE user_id = ? {dismiss_clause}"
                 params = (user_id, user_id)
@@ -476,11 +492,14 @@ class RequestHistoryStore:
 
         def operation(conn: sqlite3.Connection) -> tuple[list[RequestHistoryRecord], int]:
             params: tuple[object, ...]
-            where_clause = ""
-            if status_filter:
+            if status_filter == 'reimportable':
+                where_clause = f"WHERE {_REIMPORTABLE_CONDITION}"
+                params = ()
+            elif status_filter:
                 where_clause = "WHERE status = ?"
                 params = (status_filter,)
             else:
+                where_clause = ""
                 params = ()
 
             total_row = conn.execute(

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -44,7 +44,12 @@ from services.native.acquisition.strategy import (
     UsenetStrategy,
 )
 from services.native.album_preflight_scorer import AlbumPreflightScorer
-from services.native.file_processor import FileProcessor
+from services.native.file_processor import (
+    DOWNLOADS_MOUNT_UNAVAILABLE,
+    IMPORT_FAILED,
+    SOURCE_FILE_MISSING,
+    FileProcessor,
+)
 from services.native.library_manager import LibraryManager
 from services.native.track_matcher import TrackMatcher
 
@@ -1193,35 +1198,34 @@ class DownloadOrchestrator:
         await self._store.update_status(task.id, "processing")
         await self._bus.publish(f"download:{task.id}", "status", {"status": "processing"})
 
-        from services.native.file_processor import (
-            DOWNLOADS_MOUNT_UNAVAILABLE,
-            IMPORT_FAILED,
-            SOURCE_FILE_MISSING,
-        )
+        try:
+            result, _ = await self._import_files(task, manifest, completed=True)
+            await self._cancel_transfers(task, manifest)
 
-        result, _ = await self._import_files(task, manifest, completed=True)
-        await self._cancel_transfers(task, manifest)
+            if not result.succeeded and any(
+                f.reason == DOWNLOADS_MOUNT_UNAVAILABLE for f in result.failed
+            ):
+                await self._finalize(
+                    task, "failed", error_message=DOWNLOADS_MOUNT_UNAVAILABLE
+                )
+                return await self._store.get_task(task.id)
 
-        if not result.succeeded and any(
-            f.reason == DOWNLOADS_MOUNT_UNAVAILABLE for f in result.failed
-        ):
-            await self._finalize(
-                task, "failed", error_message=DOWNLOADS_MOUNT_UNAVAILABLE
-            )
-            return await self._store.get_task(task.id)
-
-        if await self._download_is_complete(task, bool(result.succeeded), result):
-            await self._finalize(task, "completed")
-        elif result.succeeded:
-            await self._finalize(task, "partial")
-        else:
-            if any(f.reason == SOURCE_FILE_MISSING for f in result.failed):
-                fail_msg = _FILES_NOT_FOUND_MSG
-            elif any(f.reason == IMPORT_FAILED for f in result.failed):
-                fail_msg = _IMPORT_FAILED_MSG
+            if await self._download_is_complete(task, bool(result.succeeded), result):
+                await self._finalize(task, "completed")
+            elif result.succeeded:
+                await self._finalize(task, "partial")
             else:
-                fail_msg = _NO_SOURCE_MSG
-            await self._finalize(task, "failed", error_message=fail_msg)
+                if any(f.reason == SOURCE_FILE_MISSING for f in result.failed):
+                    fail_msg = _FILES_NOT_FOUND_MSG
+                elif any(f.reason == IMPORT_FAILED for f in result.failed):
+                    fail_msg = _IMPORT_FAILED_MSG
+                else:
+                    fail_msg = _NO_SOURCE_MSG
+                await self._finalize(task, "failed", error_message=fail_msg)
+        except Exception:
+            logger.exception("Unexpected error during reimport of task %s", task.id)
+            await self._finalize(task, "failed", error_message="Reimport failed unexpectedly")
+
         return await self._store.get_task(task.id)
 
     async def _create_retry_task(self, task) -> str:  # noqa: ANN001 - DownloadTask

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -29,6 +29,7 @@ from infrastructure.persistence.download_store import DownloadStore
 from infrastructure.sse_publisher import SSEPublisher
 from models.download_manifest import (
     DownloadManifest,
+    ExpectedFile,
     ManifestCodec,
 )
 from repositories.protocols.download_client import (
@@ -166,6 +167,7 @@ class DownloadOrchestrator:
         usenet_import_settle_seconds: float = 2.0,
     ) -> None:
         self._client = client
+        self._naming_template = naming_template
         # Search/enqueue/import + the per-source policy all live on the strategies now; the
         # orchestrator keeps only the shared state below + the live enable toggles.
         self._usenet_enabled = usenet_enabled and usenet_indexer is not None and usenet_client is not None
@@ -743,7 +745,7 @@ class DownloadOrchestrator:
         await self._cancel_transfers(task)
         await self._finalize(task, DownloadStatus.COMPLETED if result.succeeded else DownloadStatus.FAILED)
 
-    async def _import_files(self, task, *, only_filenames=None, completed=False):  # noqa: ANN001, ANN201
+    async def _import_files(self, task, _manifest_override=None, *, only_filenames=None, completed=False):  # noqa: ANN001, ANN201
         """Import a subset of the manifest into the library via the source strategy (per-file
         for slskd, unpacked-folder for Usenet), quarantining only files that arrived but
         failed verification. Does not set the task's terminal status (the failover loop owns
@@ -752,18 +754,21 @@ class DownloadOrchestrator:
         ambiguous empty folder.
 
         ``completed`` = SABnzbd reported the job finished (vs an interrupted/failed poll);
-        only then can a still-empty folder mean a mount fault rather than a slow unpack."""
-        manifest = self._read_manifest(task.id)
+        only then can a still-empty folder mean a mount fault rather than a slow unpack.
+        ``_manifest_override`` skips the on-disk read (used by reimport_task, which builds
+        the manifest from DB data because _finalize already deleted the staging copy)."""
+        manifest = _manifest_override if _manifest_override is not None else self._read_manifest(task.id)
         return await self._strategies[task.source].import_files(
             task, manifest, only_filenames=only_filenames, completed=completed
         )
 
-    async def _cancel_transfers(self, task) -> None:  # noqa: ANN001 - DownloadTask
+    async def _cancel_transfers(self, task, _manifest_override=None) -> None:  # noqa: ANN001 - DownloadTask
         """Clear this task's download records (post-import, per DEC-1) and stop any still
         running. For Usenet this also deletes the unpacked data (del_files) - the post-
         import cleanup that discards the album's other tracks on a per-track grab (D4).
-        Best-effort; imported audio has already been MOVED out."""
-        manifest = self._read_manifest(task.id)
+        Best-effort; imported audio has already been MOVED out.
+        ``_manifest_override`` skips the on-disk read (used by reimport_task)."""
+        manifest = _manifest_override if _manifest_override is not None else self._read_manifest(task.id)
         strategy = self._strategy(task.source)
         if not strategy.is_cancelable(task, manifest):
             return
@@ -1138,6 +1143,86 @@ class DownloadOrchestrator:
                 )
 
         return await self._create_retry_task(task)
+
+    async def reimport_task(self, task_id: str, user_id: str, user_role: str):  # noqa: ANN201
+        """Re-run only the import half of the pipeline for a ``failed``/``partial``
+        task whose download the user finished by hand in slskd (e.g. resumed a
+        stalled/errored transfer in slskd's own UI after DroppedNeedle had already
+        given up). This re-resolves the SAME candidate slskd already picked."""
+        task = await self._store.get_task(task_id)
+        if task is None:
+            raise ResourceNotFoundError("Download task not found")
+        if user_role != "admin" and task.user_id != user_id:
+            raise PermissionDeniedError("Cannot reimport another user's download")
+        if task.status not in ("failed", "partial"):
+            raise ValidationError("Only failed or partial downloads can be reimported")
+        if (
+            task.search_job_id is None
+            or task.candidate_index is None
+            or not task.source_username
+        ):
+            raise ValidationError("This download never selected a source to reimport from")
+
+        candidates = await self._store.get_search_job_candidates(task.search_job_id)
+        if task.candidate_index >= len(candidates):
+            raise ValidationError("Original source is no longer available")
+        candidate = candidates[task.candidate_index]
+
+        use_canonical = task.download_type == "track" and bool(task.track_duration_seconds)
+        manifest = DownloadManifest(
+            task_id=task.id,
+            source_username=candidate.username,
+            release_group_mbid=task.release_group_mbid,
+            release_mbid=task.release_mbid,
+            artist_mbid=task.artist_mbid,
+            artist_name=task.artist_name,
+            album_title=task.album_title,
+            year=task.year,
+            naming_template=self._naming_template,
+            is_track=use_canonical,
+            target_files=[
+                ExpectedFile(
+                    filename=f.filename,
+                    size=f.size,
+                    duration=task.track_duration_seconds if use_canonical else f.duration,
+                )
+                for f in candidate.files
+            ],
+        )
+
+        await self._store.update_status(task.id, "processing")
+        await self._bus.publish(f"download:{task.id}", "status", {"status": "processing"})
+
+        from services.native.file_processor import (
+            DOWNLOADS_MOUNT_UNAVAILABLE,
+            IMPORT_FAILED,
+            SOURCE_FILE_MISSING,
+        )
+
+        result, _ = await self._import_files(task, manifest, completed=True)
+        await self._cancel_transfers(task, manifest)
+
+        if not result.succeeded and any(
+            f.reason == DOWNLOADS_MOUNT_UNAVAILABLE for f in result.failed
+        ):
+            await self._finalize(
+                task, "failed", error_message=DOWNLOADS_MOUNT_UNAVAILABLE
+            )
+            return await self._store.get_task(task.id)
+
+        if await self._download_is_complete(task, bool(result.succeeded), result):
+            await self._finalize(task, "completed")
+        elif result.succeeded:
+            await self._finalize(task, "partial")
+        else:
+            if any(f.reason == SOURCE_FILE_MISSING for f in result.failed):
+                fail_msg = _FILES_NOT_FOUND_MSG
+            elif any(f.reason == IMPORT_FAILED for f in result.failed):
+                fail_msg = _IMPORT_FAILED_MSG
+            else:
+                fail_msg = _NO_SOURCE_MSG
+            await self._finalize(task, "failed", error_message=fail_msg)
+        return await self._store.get_task(task.id)
 
     async def _create_retry_task(self, task) -> str:  # noqa: ANN001 - DownloadTask
         """Create a fresh queued task carrying ``retry_count + 1`` and dispatch it.

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -1171,8 +1171,8 @@ class DownloadOrchestrator:
         task = await self._store.get_task(task_id)
         if task is None:
             raise ResourceNotFoundError("Download task not found")
-        if user_role != "admin" and task.user_id != user_id:
-            raise PermissionDeniedError("Cannot reimport another user's download")
+        if user_role != "admin":
+            raise PermissionDeniedError("Only admins can reimport downloads")
         if task.status not in ("failed", "partial"):
             raise ValidationError("Only failed or partial downloads can be reimported")
         if (

--- a/backend/services/native/download_service.py
+++ b/backend/services/native/download_service.py
@@ -532,6 +532,10 @@ class DownloadService:
                 },
             )
 
+    async def reimport_task(self, task_id: str, user_id: str, user_role: str):
+        self._ensure_enabled()
+        return await self._orchestrator.reimport_task(task_id, user_id, user_role)
+
     @property
     def auto_retry_max(self) -> int:
         """Configured max auto-retry attempts, for the queue UI's attempt counter."""

--- a/backend/services/native/library_scanner.py
+++ b/backend/services/native/library_scanner.py
@@ -19,6 +19,7 @@ instance and its ``_cancel`` event.
 import asyncio
 import logging
 import os
+import re
 import time
 from collections import Counter
 from pathlib import Path
@@ -1033,6 +1034,11 @@ class LibraryScanner:
         if tag.artist and tag.album and tag.title and tag.track_number:
             return tag
         parsed = parse_names_from_path(path)
+        disc_number = tag.disc_number
+        if disc_number == 1:
+            m = re.match(r'^(?:cd|dis[ck])\s*0*(\d+)$', path.parent.name, re.IGNORECASE)
+            if m:
+                disc_number = int(m.group(1))
         return msgspec.structs.replace(
             tag,
             artist=tag.artist or parsed.artist or "",
@@ -1040,6 +1046,7 @@ class LibraryScanner:
             title=tag.title or parsed.title or "",
             track_number=tag.track_number or parsed.track_number or 0,
             year=tag.year if tag.year is not None else parsed.year,
+            disc_number=disc_number,
         )
 
     async def _identify_tiered(

--- a/backend/services/playlist_service.py
+++ b/backend/services/playlist_service.py
@@ -654,7 +654,7 @@ class PlaylistService:
                     for t in match.tracks:
                         key = _safe_track_number(t.track_number)
                         if key is not None:
-                            local_by_num[(t.disc_number or 1, key)] = (t.title, str(t.track_file_id))
+                            local_by_num[(getattr(t, "disc_number", None) or 1, key)] = (t.title, str(t.track_file_id))
             except Exception:  # noqa: BLE001
                 logger.debug("Local source resolution failed for album %s", album_id, exc_info=True)
 

--- a/backend/services/playlist_service.py
+++ b/backend/services/playlist_service.py
@@ -83,17 +83,26 @@ _SOURCE_TYPE_ALIASES = {
 }
 
 
-def _normalize_source_map(by_num: dict) -> dict[int, tuple[str, str]]:
-    """Ensure source map keys are ints (guards against cached string keys)."""
+def _normalize_source_map(by_num: dict) -> dict[tuple[int, int], tuple[str, str]]:
+    """Ensure source map keys are (disc_number, track_number) tuples.
+
+    Handles old cached entries that used bare int track_number keys (assumes disc 1),
+    and list keys that JSON round-trips produce from tuples.
+    """
     if not by_num:
         return by_num
     first_key = next(iter(by_num))
-    if isinstance(first_key, int):
+    if isinstance(first_key, tuple):
         return by_num
-    normalized: dict[int, tuple[str, str]] = {}
+    normalized: dict[tuple[int, int], tuple[str, str]] = {}
     for k, v in by_num.items():
         try:
-            normalized[int(k)] = v
+            if isinstance(k, (list, tuple)) and len(k) == 2:
+                normalized[(int(k[0]), int(k[1]))] = v
+            elif isinstance(k, int):
+                normalized[(1, k)] = v
+            else:
+                normalized[(1, int(k))] = v
         except (TypeError, ValueError):
             continue
     return normalized
@@ -517,10 +526,10 @@ class PlaylistService:
         async def _resolve_group(
             album_tracks: list[PlaylistTrackRecord],
         ) -> tuple[
-            dict[int, tuple[str, str]],
-            dict[int, tuple[str, str]],
-            dict[int, tuple[str, str]],
-            dict[int, tuple[str, str, str]],
+            dict[tuple[int, int], tuple[str, str]],
+            dict[tuple[int, int], tuple[str, str]],
+            dict[tuple[int, int], tuple[str, str]],
+            dict[tuple[int, int], tuple[str, str, str]],
         ]:
             representative = album_tracks[0]
             async with sem:
@@ -557,19 +566,20 @@ class PlaylistService:
                 if t.source_type:
                     sources.add(t.source_type)
 
-                jf_track = jf_by_num.get(t.track_number)
+                disc_key = (t.disc_number or 1, t.track_number)
+                jf_track = jf_by_num.get(disc_key)
                 if jf_track and _fuzzy_name_match(t.track_name, jf_track[0]):
                     sources.add("jellyfin")
 
-                local_track = local_by_num.get(t.track_number)
+                local_track = local_by_num.get(disc_key)
                 if local_track and _fuzzy_name_match(t.track_name, local_track[0]):
                     sources.add("local")
 
-                nd_track = nd_by_num.get(t.track_number)
+                nd_track = nd_by_num.get(disc_key)
                 if nd_track and _fuzzy_name_match(t.track_name, nd_track[0]):
                     sources.add("navidrome")
 
-                plex_track = plex_by_num.get(t.track_number)
+                plex_track = plex_by_num.get(disc_key)
                 if plex_track and _fuzzy_name_match(t.track_name, plex_track[0]):
                     sources.add("plex")
 
@@ -600,7 +610,7 @@ class PlaylistService:
         plex_service: object = None,
         album_name: str = "",
         artist_name: str = "",
-    ) -> tuple[dict[int, tuple[str, str]], dict[int, tuple[str, str]], dict[int, tuple[str, str]], dict[int, tuple[str, str, str]]]:
+    ) -> tuple[dict[tuple[int, int], tuple[str, str]], dict[tuple[int, int], tuple[str, str]], dict[tuple[int, int], tuple[str, str]], dict[tuple[int, int], tuple[str, str, str]]]:
         cache_key = f"{SOURCE_RESOLUTION_PREFIX}:{album_id}"
         if self._cache:
             cached = await self._cache.get(cache_key)
@@ -621,10 +631,10 @@ class PlaylistService:
                     _normalize_source_map(cached[3]),
                 )
 
-        jf_by_num: dict[int, tuple[str, str]] = {}
-        local_by_num: dict[int, tuple[str, str]] = {}
-        nd_by_num: dict[int, tuple[str, str]] = {}
-        plex_by_num: dict[int, tuple[str, str, str]] = {}
+        jf_by_num: dict[tuple[int, int], tuple[str, str]] = {}
+        local_by_num: dict[tuple[int, int], tuple[str, str]] = {}
+        nd_by_num: dict[tuple[int, int], tuple[str, str]] = {}
+        plex_by_num: dict[tuple[int, int], tuple[str, str, str]] = {}
 
         if jf_service is not None:
             try:
@@ -633,7 +643,7 @@ class PlaylistService:
                     for t in match.tracks:
                         key = _safe_track_number(t.track_number)
                         if key is not None:
-                            jf_by_num[key] = (t.title, t.jellyfin_id)
+                            jf_by_num[(getattr(t, "disc_number", 1) or 1, key)] = (t.title, t.jellyfin_id)
             except Exception:  # noqa: BLE001
                 logger.debug("Jellyfin source resolution failed for album %s", album_id, exc_info=True)
 
@@ -644,7 +654,7 @@ class PlaylistService:
                     for t in match.tracks:
                         key = _safe_track_number(t.track_number)
                         if key is not None:
-                            local_by_num[key] = (t.title, str(t.track_file_id))
+                            local_by_num[(t.disc_number or 1, key)] = (t.title, str(t.track_file_id))
             except Exception:  # noqa: BLE001
                 logger.debug("Local source resolution failed for album %s", album_id, exc_info=True)
 
@@ -657,7 +667,7 @@ class PlaylistService:
                     for t in match.tracks:
                         key = _safe_track_number(t.track_number)
                         if key is not None:
-                            nd_by_num[key] = (t.title, t.navidrome_id)
+                            nd_by_num[(getattr(t, "disc_number", 1) or 1, key)] = (t.title, t.navidrome_id)
             except Exception:  # noqa: BLE001
                 logger.debug("Navidrome source resolution failed for album %s", album_id, exc_info=True)
 
@@ -670,7 +680,7 @@ class PlaylistService:
                     for t in match.tracks:
                         key = _safe_track_number(t.track_number)
                         if key is not None:
-                            plex_by_num[key] = (t.title, t.part_key or t.plex_id, t.plex_id)
+                            plex_by_num[(getattr(t, "disc_number", 1) or 1, key)] = (t.title, t.part_key or t.plex_id, t.plex_id)
             except Exception:  # noqa: BLE001
                 logger.debug("Plex source resolution failed for album %s", album_id, exc_info=True)
 
@@ -700,8 +710,10 @@ class PlaylistService:
             artist_name=track.artist_name or "",
         )
 
+        disc_key = (track.disc_number or 1, track.track_number)
+
         if new_source_type == "jellyfin":
-            match_info = jf_by_num.get(track.track_number)
+            match_info = jf_by_num.get(disc_key)
             if match_info and _fuzzy_name_match(track.track_name, match_info[0]):
                 return (match_info[1], None)
             raise SourceResolutionError(
@@ -709,7 +721,7 @@ class PlaylistService:
             )
 
         if new_source_type == "local":
-            match_info = local_by_num.get(track.track_number)
+            match_info = local_by_num.get(disc_key)
             if match_info and _fuzzy_name_match(track.track_name, match_info[0]):
                 return (match_info[1], None)
             raise SourceResolutionError(
@@ -717,7 +729,7 @@ class PlaylistService:
             )
 
         if new_source_type == "navidrome":
-            match_info = nd_by_num.get(track.track_number)
+            match_info = nd_by_num.get(disc_key)
             if match_info and _fuzzy_name_match(track.track_name, match_info[0]):
                 return (match_info[1], None)
             raise SourceResolutionError(
@@ -725,7 +737,7 @@ class PlaylistService:
             )
 
         if new_source_type == "plex":
-            match_info = plex_by_num.get(track.track_number)
+            match_info = plex_by_num.get(disc_key)
             if match_info and _fuzzy_name_match(track.track_name, match_info[0]):
                 return (match_info[1], match_info[2])
             raise SourceResolutionError(

--- a/backend/services/requests_page_service.py
+++ b/backend/services/requests_page_service.py
@@ -92,6 +92,13 @@ class RequestsPageService:
 
         library_mbids = await self._fetch_library_mbids()
 
+        task_ids = [r.download_task_id for r in records if r.download_task_id]
+        reimportable: set[str] = (
+            await self._download_store.get_reimportable_task_ids(task_ids)
+            if self._download_store is not None
+            else set()
+        )
+
         items = [
             RequestHistoryItem(
                 musicbrainz_id=r.musicbrainz_id,
@@ -116,6 +123,8 @@ class RequestsPageService:
                     if r.reviewed_at
                     else None
                 ),
+                download_task_id=r.download_task_id,
+                can_reimport=r.status == 'failed' and r.download_task_id in reimportable,
             )
             for r in records
         ]

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -1582,7 +1582,7 @@ async def test_reimport_task_completes_when_files_now_present(tmp_path: Path):
     task = await _new_task(store, status="failed", track_count=1)
     await _link_candidate(store, task.id, _candidate(0.9, files=1))
 
-    result = await orch.reimport_task(task.id, "user-a", "user")
+    result = await orch.reimport_task(task.id, "user-a", "admin")
 
     assert result.status == "completed"
     fp.process_downloaded.assert_awaited()
@@ -1597,7 +1597,7 @@ async def test_reimport_task_partial_when_some_still_missing(tmp_path: Path):
     task = await _new_task(store, status="partial", track_count=2)
     await _link_candidate(store, task.id, candidate)
 
-    result = await orch.reimport_task(task.id, "user-a", "user")
+    result = await orch.reimport_task(task.id, "user-a", "admin")
 
     assert result.status == "partial"
 
@@ -1608,7 +1608,7 @@ async def test_reimport_task_rejects_no_picked_candidate(tmp_path: Path):
     task = await _new_task(store, status="failed")
 
     with pytest.raises(ValidationError):
-        await orch.reimport_task(task.id, "user-a", "user")
+        await orch.reimport_task(task.id, "user-a", "admin")
 
 
 @pytest.mark.asyncio
@@ -1617,19 +1617,19 @@ async def test_reimport_task_rejects_wrong_status(tmp_path: Path):
     task = await _new_task(store, status="queued")
 
     with pytest.raises(ValidationError):
-        await orch.reimport_task(task.id, "user-a", "user")
+        await orch.reimport_task(task.id, "user-a", "admin")
 
 
 @pytest.mark.asyncio
-async def test_reimport_task_ownership(tmp_path: Path):
+async def test_reimport_task_admin_only(tmp_path: Path):
     store, orch, *_ = _build(tmp_path)
     task = await _new_task(store, status="failed")
     await _link_candidate(store, task.id, _candidate(0.9, files=1))
 
     with pytest.raises(ResourceNotFoundError):
-        await orch.reimport_task("missing", "user-a", "user")
+        await orch.reimport_task("missing", "user-a", "admin")
     with pytest.raises(PermissionDeniedError):
-        await orch.reimport_task(task.id, "user-b", "user")
+        await orch.reimport_task(task.id, "user-a", "user")
 
 
 @pytest.mark.asyncio
@@ -1639,8 +1639,8 @@ async def test_reimport_task_second_call_after_completion_rejected(tmp_path: Pat
     task = await _new_task(store, status="failed", track_count=1)
     await _link_candidate(store, task.id, _candidate(0.9, files=1))
 
-    first = await orch.reimport_task(task.id, "user-a", "user")
+    first = await orch.reimport_task(task.id, "user-a", "admin")
     assert first.status == "completed"
 
     with pytest.raises(ValidationError):
-        await orch.reimport_task(task.id, "user-a", "user")
+        await orch.reimport_task(task.id, "user-a", "admin")

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -1504,3 +1504,89 @@ async def test_settle_after_manual_import_stays_partial_while_incomplete(tmp_pat
     settled = await store.get_task(task.id)
     assert settled.status == "partial"  # still missing one -> stays partial
     assert settled.files_completed == 8  # but the count advanced to reflect the import
+
+
+# reimport_task - re-check the mount for a download finished by hand in slskd
+
+async def _link_candidate(store, task_id, candidate):
+    job = await store.create_search_job(
+        user_id="user-a", artist_name="Artist", album_title="Album", year=2020,
+        track_count=1, release_group_mbid="rg-1", search_query="Artist - Album",
+    )
+    await store.set_search_job_candidates(job.id, [candidate])
+    await store.link_picked_candidate(
+        task_id, job.id, 0, candidate.username, candidate.parent_directory,
+        candidate.final_score,
+    )
+    return job
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_completes_when_files_now_present(tmp_path: Path):
+    store, orch, fp, lib = _build(tmp_path)
+    _coupled_fp(fp, lib)
+    task = await _new_task(store, status="failed", track_count=1)
+    await _link_candidate(store, task.id, _candidate(0.9, files=1))
+
+    result = await orch.reimport_task(task.id, "user-a", "user")
+
+    assert result.status == "completed"
+    fp.process_downloaded.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_partial_when_some_still_missing(tmp_path: Path):
+    store, orch, fp, lib = _build(tmp_path)
+    candidate = _candidate(0.9, files=2)
+    missing_file = candidate.files[1].filename
+    _coupled_fp(fp, lib, fail={missing_file})
+    task = await _new_task(store, status="partial", track_count=2)
+    await _link_candidate(store, task.id, candidate)
+
+    result = await orch.reimport_task(task.id, "user-a", "user")
+
+    assert result.status == "partial"
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_rejects_no_picked_candidate(tmp_path: Path):
+    store, orch, *_ = _build(tmp_path)
+    task = await _new_task(store, status="failed")
+
+    with pytest.raises(ValidationError):
+        await orch.reimport_task(task.id, "user-a", "user")
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_rejects_wrong_status(tmp_path: Path):
+    store, orch, *_ = _build(tmp_path)
+    task = await _new_task(store, status="queued")
+
+    with pytest.raises(ValidationError):
+        await orch.reimport_task(task.id, "user-a", "user")
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_ownership(tmp_path: Path):
+    store, orch, *_ = _build(tmp_path)
+    task = await _new_task(store, status="failed")
+    await _link_candidate(store, task.id, _candidate(0.9, files=1))
+
+    with pytest.raises(ResourceNotFoundError):
+        await orch.reimport_task("missing", "user-a", "user")
+    with pytest.raises(PermissionDeniedError):
+        await orch.reimport_task(task.id, "user-b", "user")
+
+
+@pytest.mark.asyncio
+async def test_reimport_task_second_call_after_completion_rejected(tmp_path: Path):
+    store, orch, fp, lib = _build(tmp_path)
+    _coupled_fp(fp, lib)
+    task = await _new_task(store, status="failed", track_count=1)
+    await _link_candidate(store, task.id, _candidate(0.9, files=1))
+
+    first = await orch.reimport_task(task.id, "user-a", "user")
+    assert first.status == "completed"
+
+    with pytest.raises(ValidationError):
+        await orch.reimport_task(task.id, "user-a", "user")

--- a/backend/tests/services/test_playlist_source_resolution.py
+++ b/backend/tests/services/test_playlist_source_resolution.py
@@ -277,9 +277,9 @@ class TestStringTrackNumberRegression:
             "mbid-abc", None, None, None,
         )
 
-        assert isinstance(next(iter(local)), int)
-        assert local[6] == ("Speed Kills", "2608")
-        assert local[1] == ("Johnny", "2601")
+        assert isinstance(next(iter(local)), tuple)
+        assert local[(1, 6)] == ("Speed Kills", "2608")
+        assert local[(1, 1)] == ("Johnny", "2601")
 
 
 class TestResolveTrackSourcesConcurrency:
@@ -340,7 +340,7 @@ class TestResolveTrackSourcesConcurrency:
             if album_id == "mbid-a":
                 raise RuntimeError("boom")
             # (jf_by_num, local_by_num, nd_by_num, plex_by_num)
-            return ({}, {1: ("Song B", "789")}, {}, {})
+            return ({}, {(1, 1): ("Song B", "789")}, {}, {})
 
         service._resolve_album_sources = AsyncMock(side_effect=_flaky)
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -22,8 +22,9 @@
 	font-weight: 300 700;
 	font-display: swap;
 	src: url('/fonts/spacegrotesk-latin.woff2') format('woff2');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'Space Grotesk';
@@ -31,9 +32,10 @@
 	font-weight: 300 700;
 	font-display: swap;
 	src: url('/fonts/spacegrotesk-latinext.woff2') format('woff2');
-	unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
-		U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
-		U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+		U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+		U+A720-A7FF;
 }
 @font-face {
 	font-family: 'Hanken Grotesk';
@@ -41,9 +43,9 @@
 	font-weight: 100 900;
 	font-display: swap;
 	src: url('/fonts/hankengrotesk-latin.woff2') format('woff2');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'Hanken Grotesk';
@@ -51,9 +53,10 @@
 	font-weight: 100 900;
 	font-display: swap;
 	src: url('/fonts/hankengrotesk-latinext.woff2') format('woff2');
-	unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
-		U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
-		U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+		U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+		U+A720-A7FF;
 }
 @font-face {
 	font-family: 'Space Mono';
@@ -61,9 +64,9 @@
 	font-weight: 400;
 	font-display: swap;
 	src: url('/fonts/spacemono-400-latin.woff2') format('woff2');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'Space Mono';
@@ -71,9 +74,10 @@
 	font-weight: 400;
 	font-display: swap;
 	src: url('/fonts/spacemono-400-latinext.woff2') format('woff2');
-	unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
-		U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
-		U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+		U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+		U+A720-A7FF;
 }
 @font-face {
 	font-family: 'Space Mono';
@@ -81,9 +85,9 @@
 	font-weight: 700;
 	font-display: swap;
 	src: url('/fonts/spacemono-700-latin.woff2') format('woff2');
-	unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304,
-		U+0308, U+0329, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF,
-		U+FFFD;
+	unicode-range:
+		U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+0304, U+0308, U+0329,
+		U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 @font-face {
 	font-family: 'Space Mono';
@@ -91,9 +95,10 @@
 	font-weight: 700;
 	font-display: swap;
 	src: url('/fonts/spacemono-700-latinext.woff2') format('woff2');
-	unicode-range: U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308,
-		U+0329, U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113,
-		U+2C60-2C7F, U+A720-A7FF;
+	unicode-range:
+		U+0100-02BA, U+02BD-02C5, U+02C7-02CC, U+02CE-02D7, U+02DD-02FF, U+0304, U+0308, U+0329,
+		U+1D00-1DBF, U+1E00-1E9F, U+1EF2-1EFF, U+2020, U+20A0-20AB, U+20AD-20C0, U+2113, U+2C60-2C7F,
+		U+A720-A7FF;
 }
 
 @theme {
@@ -750,7 +755,12 @@ textarea {
 
 @utility section-divider-glow {
 	height: 2px;
-	background: linear-gradient(to right, transparent, oklch(from var(--color-primary) l c h / 0.15), transparent);
+	background: linear-gradient(
+		to right,
+		transparent,
+		oklch(from var(--color-primary) l c h / 0.15),
+		transparent
+	);
 	box-shadow: 0 0 8px oklch(from var(--color-primary) l c h / 0.06);
 }
 
@@ -820,7 +830,11 @@ textarea {
 			transparent 2px,
 			transparent 4px
 		),
-		radial-gradient(circle at 33% 27%, oklch(from var(--color-base-content) l c h / 0.1), transparent 58%),
+		radial-gradient(
+			circle at 33% 27%,
+			oklch(from var(--color-base-content) l c h / 0.1),
+			transparent 58%
+		),
 		radial-gradient(circle at center, var(--color-base-300), var(--color-base-100) 95%);
 	box-shadow:
 		inset 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.08),
@@ -838,7 +852,11 @@ textarea {
 }
 
 .deck-halo {
-	background: radial-gradient(circle at center, oklch(from var(--color-accent) l c h / 0.16), transparent 66%);
+	background: radial-gradient(
+		circle at center,
+		oklch(from var(--color-accent) l c h / 0.16),
+		transparent 66%
+	);
 }
 
 .crate-card {
@@ -909,7 +927,12 @@ textarea {
 }
 
 .crate-sweep {
-	background: linear-gradient(115deg, transparent 28%, oklch(from var(--color-accent) l c h / 0.18) 50%, transparent 72%);
+	background: linear-gradient(
+		115deg,
+		transparent 28%,
+		oklch(from var(--color-accent) l c h / 0.18) 50%,
+		transparent 72%
+	);
 	animation: crate-sweep 0.75s ease-out;
 }
 @keyframes crate-sweep {

--- a/frontend/src/lib/components/AddToPlaylistModal.svelte
+++ b/frontend/src/lib/components/AddToPlaylistModal.svelte
@@ -424,7 +424,11 @@
 		border-radius: 9999px;
 		color: var(--color-primary);
 		background:
-			radial-gradient(circle at 35% 30%, oklch(from var(--color-base-content) l c h / 0.14), transparent 55%),
+			radial-gradient(
+				circle at 35% 30%,
+				oklch(from var(--color-base-content) l c h / 0.14),
+				transparent 55%
+			),
 			radial-gradient(circle at center, var(--color-base-300), var(--color-base-100) 92%);
 		box-shadow:
 			inset 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.1),
@@ -581,7 +585,11 @@
 				transparent 0 2px,
 				oklch(from var(--color-base-content) l c h / 0.16) 2px 3px
 			),
-			radial-gradient(circle at 36% 30%, oklch(from var(--color-base-content) l c h / 0.28), transparent 48%),
+			radial-gradient(
+				circle at 36% 30%,
+				oklch(from var(--color-base-content) l c h / 0.28),
+				transparent 48%
+			),
 			radial-gradient(circle at center, var(--color-base-300) 0%, var(--color-base-100) 95%);
 		box-shadow:
 			inset 0 0 0 1px oklch(from var(--color-base-content) l c h / 0.14),

--- a/frontend/src/lib/components/DeleteAlbumModal.svelte
+++ b/frontend/src/lib/components/DeleteAlbumModal.svelte
@@ -65,8 +65,8 @@
 		<h3 class="text-lg font-bold">Remove Album</h3>
 		<p class="py-4 text-base-content/70">
 			Remove <span class="font-semibold text-base-content">{albumTitle}</span> by
-			<span class="font-semibold text-base-content">{artistName}</span> from your library? Its
-			local files will be permanently deleted from disk - this can't be undone.
+			<span class="font-semibold text-base-content">{artistName}</span> from your library? Its local files
+			will be permanently deleted from disk - this can't be undone.
 		</p>
 
 		{#if loadingPreview}

--- a/frontend/src/lib/components/LibraryBadge.svelte
+++ b/frontend/src/lib/components/LibraryBadge.svelte
@@ -4,6 +4,7 @@
 	import { STATUS_COLORS } from '$lib/constants';
 	import DeleteAlbumModal from './DeleteAlbumModal.svelte';
 	import ArtistRemovedModal from './ArtistRemovedModal.svelte';
+	import { authStore } from '$lib/stores/authStore.svelte';
 
 	interface Props {
 		status: 'library' | 'requested';
@@ -62,34 +63,60 @@
 	}
 </script>
 
-<button
-	class="{positioning} rounded-full shadow-sm transition-colors duration-200 group/badge {sizeClasses.button} {lgButtonClass}"
-	style="background-color: {bgColor};"
-	onclick={handleClick}
-	onmouseenter={(e) => {
-		e.currentTarget.style.backgroundColor = '#ef4444';
-	}}
-	onmouseleave={(e) => {
-		e.currentTarget.style.backgroundColor = bgColor;
-		e.currentTarget.style.filter = '';
-	}}
-	aria-label={status === 'library' ? 'Remove from library' : 'Remove request'}
->
-	{#if status === 'library'}
-		<Check
-			class="{sizeClasses.icon} group-hover/badge:hidden"
-			color={colors.secondary}
-			strokeWidth={Number(sizeClasses.strokeWidth)}
+{#if authStore.isAdmin}
+	<button
+		class="{positioning} rounded-full shadow-sm transition-colors duration-200 group/badge {sizeClasses.button} {lgButtonClass}"
+		style="background-color: {bgColor};"
+		onclick={handleClick}
+		onmouseenter={(e) => {
+			e.currentTarget.style.backgroundColor = '#ef4444';
+		}}
+		onmouseleave={(e) => {
+			e.currentTarget.style.backgroundColor = bgColor;
+			e.currentTarget.style.filter = '';
+		}}
+		aria-label={status === 'library' ? 'Remove from library' : 'Remove request'}
+	>
+		{#if status === 'library'}
+			<Check
+				class="{sizeClasses.icon} group-hover/badge:hidden"
+				color={colors.secondary}
+				strokeWidth={Number(sizeClasses.strokeWidth)}
+			/>
+		{:else}
+			<Clock
+				class="{sizeClasses.icon} group-hover/badge:hidden"
+				color={colors.secondary}
+				strokeWidth={Number(sizeClasses.strokeWidth)}
+			/>
+		{/if}
+		<Trash2
+			class="{sizeClasses.icon} hidden group-hover/badge:block"
+			color="white"
+			strokeWidth={2}
 		/>
-	{:else}
-		<Clock
-			class="{sizeClasses.icon} group-hover/badge:hidden"
-			color={colors.secondary}
-			strokeWidth={Number(sizeClasses.strokeWidth)}
-		/>
-	{/if}
-	<Trash2 class="{sizeClasses.icon} hidden group-hover/badge:block" color="white" strokeWidth={2} />
-</button>
+	</button>
+{:else}
+	<span
+		class="{positioning} rounded-full shadow-sm {sizeClasses.button} {lgButtonClass}"
+		style="background-color: {bgColor};"
+		aria-label={status === 'library' ? 'In library' : 'Requested'}
+	>
+		{#if status === 'library'}
+			<Check
+				class={sizeClasses.icon}
+				color={colors.secondary}
+				strokeWidth={Number(sizeClasses.strokeWidth)}
+			/>
+		{:else}
+			<Clock
+				class={sizeClasses.icon}
+				color={colors.secondary}
+				strokeWidth={Number(sizeClasses.strokeWidth)}
+			/>
+		{/if}
+	</span>
+{/if}
 
 {#if showDeleteModal}
 	<DeleteAlbumModal

--- a/frontend/src/lib/components/RedactedPlaylistCard.svelte
+++ b/frontend/src/lib/components/RedactedPlaylistCard.svelte
@@ -4,9 +4,7 @@
 
 	let { playlist }: { playlist: RedactedPlaylist } = $props();
 
-	let trackText = $derived(
-		`${playlist.track_count} track${playlist.track_count === 1 ? '' : 's'}`
-	);
+	let trackText = $derived(`${playlist.track_count} track${playlist.track_count === 1 ? '' : 's'}`);
 </script>
 
 <!-- Admin-only redacted projection of another user's PRIVATE playlist (D4): no name,

--- a/frontend/src/lib/components/RequestCard.svelte
+++ b/frontend/src/lib/components/RequestCard.svelte
@@ -4,6 +4,8 @@
 	import DeleteAlbumModal from './DeleteAlbumModal.svelte';
 	import ArtistRemovedModal from './ArtistRemovedModal.svelte';
 	import type { ActiveRequestItem, RequestHistoryItem } from '$lib/types';
+	import { reimportDownload } from '$lib/queries/downloads/DownloadMutations.svelte';
+	import { authStore } from '$lib/stores/authStore.svelte';
 	import {
 		ChevronDown,
 		X,
@@ -11,6 +13,7 @@
 		Trash2,
 		Clock,
 		Download,
+		FileDown,
 		Loader,
 		CheckCircle2,
 		XCircle,
@@ -28,9 +31,12 @@
 		onretry?: (mbid: string) => void;
 		onclear?: (mbid: string) => void;
 		onremoved?: () => void;
+		onreimported?: () => void;
 	}
 
-	let { item, mode, oncancel, onretry, onclear, onremoved }: Props = $props();
+	let { item, mode, oncancel, onretry, onclear, onremoved, onreimported }: Props = $props();
+
+	const reimport = reimportDownload();
 
 	let confirmingCancel = $state(false);
 	let showDeleteModal = $state(false);
@@ -362,7 +368,23 @@
 							<RotateCcw class="h-3.5 w-3.5" />
 						</button>
 					{/if}
-					{#if historyItem.status === 'imported' && historyItem.in_library}
+					{#if authStore.isAdmin && historyItem.can_reimport && historyItem.download_task_id}
+						<button
+							class="btn btn-xs btn-ghost"
+							onclick={(e) => {
+								e.stopPropagation();
+								reimport.mutate(historyItem.download_task_id!, {
+									onSuccess: () => onreimported?.()
+								});
+							}}
+							disabled={reimport.isPending}
+							title="Already fixed this in slskd? Check the downloads mount again without re-searching."
+							aria-label="Retry import from slskd"
+						>
+							<FileDown class="h-3.5 w-3.5" />
+						</button>
+					{/if}
+					{#if authStore.isAdmin && historyItem.status === 'imported' && historyItem.in_library}
 						<button
 							class="btn btn-xs btn-ghost text-base-content/40 hover:text-error"
 							onclick={handleRemoveFromLibrary}

--- a/frontend/src/lib/components/SourcePlaylistDetail.svelte
+++ b/frontend/src/lib/components/SourcePlaylistDetail.svelte
@@ -101,7 +101,9 @@
 					{:else}
 						<Download class="w-4 h-4" />
 					{/if}
-					{importResult?.already_imported ? 'Already in DroppedNeedle' : 'Import into DroppedNeedle'}
+					{importResult?.already_imported
+						? 'Already in DroppedNeedle'
+						: 'Import into DroppedNeedle'}
 				</button>
 				{#if importResult && !importResult.already_imported}
 					<p class="text-sm text-success">

--- a/frontend/src/lib/components/downloads/DownloadItem.svelte
+++ b/frontend/src/lib/components/downloads/DownloadItem.svelte
@@ -172,7 +172,7 @@
 					<X class="h-3.5 w-3.5" /> Cancel
 				</button>
 			{/if}
-			{#if canReimport(task)}
+			{#if authStore.isAdmin && canReimport(task)}
 				<button
 					class="btn btn-ghost btn-xs"
 					onclick={() => reimport.mutate(task.id)}

--- a/frontend/src/lib/components/downloads/DownloadItem.svelte
+++ b/frontend/src/lib/components/downloads/DownloadItem.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-	import { ExternalLink, RotateCcw, TimerOff, X } from 'lucide-svelte';
+	import { ExternalLink, FileDown, RotateCcw, TimerOff, X } from 'lucide-svelte';
 
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
 	import {
 		cancelDownload,
+		reimportDownload,
 		retryDownload,
 		stopAutoRetry
 	} from '$lib/queries/downloads/DownloadMutations.svelte';
 	import { createDownloadStream } from '$lib/queries/downloads/DownloadSSE.svelte';
 	import {
 		canCancel,
+		canReimport,
 		canRetry,
 		derivedDownloadStatus,
 		retryDisplay
@@ -28,6 +30,7 @@
 	const cancel = cancelDownload();
 	const retry = retryDownload();
 	const stopRetry = stopAutoRetry();
+	const reimport = reimportDownload();
 	const stream = createDownloadStream();
 
 	// A failed/partial task waiting on its next auto-retry: offer an off-switch so the
@@ -167,6 +170,18 @@
 					aria-label="Cancel unavailable while processing files"
 				>
 					<X class="h-3.5 w-3.5" /> Cancel
+				</button>
+			{/if}
+			{#if canReimport(task)}
+				<button
+					class="btn btn-ghost btn-xs"
+					onclick={() => reimport.mutate(task.id)}
+					disabled={reimport.isPending}
+					title="Already fixed this in slskd? Check the downloads mount again without re-searching."
+					aria-label="Retry import from slskd"
+				>
+					<FileDown class="h-3.5 w-3.5" />
+					{reimport.isPending ? 'Checking...' : 'Retry import'}
 				</button>
 			{/if}
 			{#if canRetry(task)}

--- a/frontend/src/lib/components/downloads/DownloadItem.svelte.spec.ts
+++ b/frontend/src/lib/components/downloads/DownloadItem.svelte.spec.ts
@@ -8,13 +8,15 @@ const h = vi.hoisted(() => ({
 	cancelMutate: vi.fn(),
 	retryMutate: vi.fn(),
 	stopRetryMutate: vi.fn(),
+	reimportMutate: vi.fn(),
 	isAdmin: false
 }));
 
 vi.mock('$lib/queries/downloads/DownloadMutations.svelte', () => ({
 	cancelDownload: () => ({ mutate: h.cancelMutate, isPending: false }),
 	retryDownload: () => ({ mutate: h.retryMutate, isPending: false }),
-	stopAutoRetry: () => ({ mutate: h.stopRetryMutate, isPending: false })
+	stopAutoRetry: () => ({ mutate: h.stopRetryMutate, isPending: false }),
+	reimportDownload: () => ({ mutate: h.reimportMutate, isPending: false })
 }));
 
 vi.mock('$lib/queries/downloads/DownloadSSE.svelte', () => ({
@@ -84,6 +86,7 @@ describe('DownloadItem.svelte', () => {
 		h.cancelMutate = vi.fn();
 		h.retryMutate = vi.fn();
 		h.stopRetryMutate = vi.fn();
+		h.reimportMutate = vi.fn();
 		h.isAdmin = false;
 	});
 

--- a/frontend/src/lib/components/downloads/DownloadQueue.svelte.spec.ts
+++ b/frontend/src/lib/components/downloads/DownloadQueue.svelte.spec.ts
@@ -50,7 +50,8 @@ vi.mock('$lib/queries/downloads/DownloadMutations.svelte', () => ({
 	stopAllRetries: () => ({ mutate: vi.fn(), isPending: false }),
 	retryAllFailed: () => ({ mutate: vi.fn(), isPending: false }),
 	importHeldTrack: () => ({ mutate: vi.fn(), isPending: false }),
-	discardHeldTrack: () => ({ mutate: vi.fn(), isPending: false })
+	discardHeldTrack: () => ({ mutate: vi.fn(), isPending: false }),
+	reimportDownload: () => ({ mutate: vi.fn(), isPending: false })
 }));
 
 vi.mock('$lib/queries/downloads/DownloadSSE.svelte', () => ({
@@ -172,11 +173,11 @@ describe('DownloadQueue.svelte', () => {
 	});
 
 	it('hides Quarantine from non-admins and shows it (with entries) to admins', async () => {
-		h.quarantine = [{ id: 1, filename: '/x.flac', username: 'p', reason: 'dupe', quarantined_at: 0 }];
+		h.quarantine = [
+			{ id: 1, filename: '/x.flac', username: 'p', reason: 'dupe', quarantined_at: 0 }
+		];
 		render(DownloadQueue);
-		await expect
-			.element(page.getByRole('button', { name: /Quarantine/ }))
-			.not.toBeInTheDocument();
+		await expect.element(page.getByRole('button', { name: /Quarantine/ })).not.toBeInTheDocument();
 
 		h.isAdmin = true;
 		render(DownloadQueue);
@@ -186,12 +187,25 @@ describe('DownloadQueue.svelte', () => {
 	it('surfaces held tracks in a "Couldn\'t verify" section', async () => {
 		h.held = [
 			{
-				id: 1, release_group_mbid: 'rg-1', recording_mbid: 'rec-3', track_number: 3,
-				disc_number: 1, track_title: 'You Shook Me', artist_name: 'Led Zeppelin',
-				album_title: 'Led Zeppelin', year: 1969, original_filename: 'x.flac', file_format: 'flac',
-				duration_seconds: 388, reason: 'fingerprint_mismatch', source: 'usenet',
-				source_task_id: 't', created_at: 0, evidence_title: "Nobody's Fault but Mine",
-				evidence_artist: 'Led Zeppelin', evidence_score: 0.99
+				id: 1,
+				release_group_mbid: 'rg-1',
+				recording_mbid: 'rec-3',
+				track_number: 3,
+				disc_number: 1,
+				track_title: 'You Shook Me',
+				artist_name: 'Led Zeppelin',
+				album_title: 'Led Zeppelin',
+				year: 1969,
+				original_filename: 'x.flac',
+				file_format: 'flac',
+				duration_seconds: 388,
+				reason: 'fingerprint_mismatch',
+				source: 'usenet',
+				source_task_id: 't',
+				created_at: 0,
+				evidence_title: "Nobody's Fault but Mine",
+				evidence_artist: 'Led Zeppelin',
+				evidence_score: 0.99
 			}
 		];
 		render(DownloadQueue);

--- a/frontend/src/lib/components/downloads/HeldTrackReview.svelte
+++ b/frontend/src/lib/components/downloads/HeldTrackReview.svelte
@@ -79,7 +79,8 @@
 
 <div class="space-y-2">
 	<p class="text-xs text-base-content/55">
-		Downloaded, but couldn't confirm it's the right recording.{#if evidence} {evidence}.{/if}
+		Downloaded, but couldn't confirm it's the right recording.{#if evidence}
+			{evidence}.{/if}
 	</p>
 
 	<div class="flex items-center gap-2">

--- a/frontend/src/lib/components/downloads/RequestButton.svelte
+++ b/frontend/src/lib/components/downloads/RequestButton.svelte
@@ -52,7 +52,8 @@
 	<button class="btn btn-info {klass}" disabled>Requested</button>
 {:else if !configured}
 	{#if isAdmin}
-		<a href="/settings?tab=download-client" class="btn btn-warning {klass}">Configure Download Client</a
+		<a href="/settings?tab=download-client" class="btn btn-warning {klass}"
+			>Configure Download Client</a
 		>
 	{:else}
 		<button

--- a/frontend/src/lib/components/downloads/SearchResultCard.svelte
+++ b/frontend/src/lib/components/downloads/SearchResultCard.svelte
@@ -81,7 +81,9 @@
 	);
 
 	const heading = $derived(
-		isUsenet ? albumTitle || rel?.title || 'Unknown' : candidate.parent_directory || 'Unknown folder'
+		isUsenet
+			? albumTitle || rel?.title || 'Unknown'
+			: candidate.parent_directory || 'Unknown folder'
 	);
 	const subtitle = $derived(isUsenet ? (rel?.title ?? '') : candidate.username);
 

--- a/frontend/src/lib/components/downloads/SearchResultCard.svelte.spec.ts
+++ b/frontend/src/lib/components/downloads/SearchResultCard.svelte.spec.ts
@@ -59,7 +59,9 @@ describe('SearchResultCard.svelte', () => {
 		const onPick = vi.fn();
 		renderCard({ candidate: makeCandidate(), onPick, disabled: true });
 		// a disabled button can't dispatch onclick, so this proves a second pick can't fire
-		await expect.element(page.getByRole('button', { name: /Pick candidate from alice/ })).toBeDisabled();
+		await expect
+			.element(page.getByRole('button', { name: /Pick candidate from alice/ }))
+			.toBeDisabled();
 		expect(onPick).not.toHaveBeenCalled();
 	});
 

--- a/frontend/src/lib/components/downloads/WantedCard.svelte
+++ b/frontend/src/lib/components/downloads/WantedCard.svelte
@@ -1,9 +1,18 @@
 <script lang="ts">
-	import { RotateCcw, TimerOff } from 'lucide-svelte';
+	import { FileDown, RotateCcw, TimerOff } from 'lucide-svelte';
 
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
-	import { retryDownload, stopAutoRetry } from '$lib/queries/downloads/DownloadMutations.svelte';
-	import { formatCountdown, retryLadderState } from '$lib/queries/downloads/downloadStatus';
+	import {
+		reimportDownload,
+		retryDownload,
+		stopAutoRetry
+	} from '$lib/queries/downloads/DownloadMutations.svelte';
+	import {
+		canReimport,
+		formatCountdown,
+		retryLadderState
+	} from '$lib/queries/downloads/downloadStatus';
+	import { authStore } from '$lib/stores/authStore.svelte';
 	import { nowSeconds, startSharedClock } from '$lib/stores/clock.svelte';
 	import type { DownloadTask } from '$lib/types';
 	import { albumHref, artistHref } from '$lib/utils/entityRoutes';
@@ -15,6 +24,7 @@
 
 	const retry = retryDownload();
 	const stopRetry = stopAutoRetry();
+	const reimport = reimportDownload();
 
 	// this card owns its clock dependency: the shared tick runs while any Wanted card is
 	// mounted (refcounted -> still one interval), so the countdown ticks without relying on
@@ -129,6 +139,20 @@
 			</div>
 		</div>
 	</div>
+	{#if authStore.isAdmin && canReimport(task)}
+		<div class="mt-2 flex justify-end">
+			<button
+				class="btn btn-ghost btn-xs"
+				onclick={() => reimport.mutate(task.id)}
+				disabled={reimport.isPending}
+				title="Already fixed this in slskd? Check the downloads mount again without re-searching."
+				aria-label="Retry import from slskd"
+			>
+				<FileDown class="h-3.5 w-3.5" />
+				{reimport.isPending ? 'Checking...' : 'Retry import'}
+			</button>
+		</div>
+	{/if}
 </article>
 
 <style>

--- a/frontend/src/lib/components/settings/SettingsConnectApps.svelte
+++ b/frontend/src/lib/components/settings/SettingsConnectApps.svelte
@@ -127,7 +127,8 @@
 		} catch (err) {
 			const status = (err as { status?: number })?.status;
 			toastStore.show({
-				message: status === 409 ? 'Limit reached - revoke one first' : 'Could not create app-password',
+				message:
+					status === 409 ? 'Limit reached - revoke one first' : 'Could not create app-password',
 				type: 'error'
 			});
 		}
@@ -174,8 +175,8 @@
 			DroppedNeedle and stream your library.
 		</p>
 		<p class="mt-1 max-w-2xl text-sm text-base-content/50">
-			The Jellyfin, Navidrome and Plex tabs connect DroppedNeedle out to another server. This
-			does the opposite: other apps connect in and play what is here.
+			The Jellyfin, Navidrome and Plex tabs connect DroppedNeedle out to another server. This does
+			the opposite: other apps connect in and play what is here.
 		</p>
 
 		<div class="inbound-diagram mt-5" aria-hidden="true">
@@ -197,270 +198,273 @@
 			<TriangleAlert class="h-5 w-5" aria-hidden="true" />
 			<span>Could not load Connect Apps settings.</span>
 		</div>
+	{:else if showDisabledPanel}
+		<div class="card border border-base-300 bg-base-200">
+			<div class="card-body items-center text-center">
+				<Waypoints class="h-8 w-8 text-base-content/40" aria-hidden="true" />
+				<h3 class="card-title">Connect Apps is turned off</h3>
+				<p class="max-w-md text-base-content/60">
+					Ask your administrator to turn on the OpenSubsonic or Jellyfin API. Once it is on, create
+					an app-password here to play your library in apps like Symfonium or Finamp.
+				</p>
+			</div>
+		</div>
 	{:else}
-		{#if showDisabledPanel}
-			<div class="card border border-base-300 bg-base-200">
-				<div class="card-body items-center text-center">
-					<Waypoints class="h-8 w-8 text-base-content/40" aria-hidden="true" />
-					<h3 class="card-title">Connect Apps is turned off</h3>
-					<p class="max-w-md text-base-content/60">
-						Ask your administrator to turn on the OpenSubsonic or Jellyfin API. Once it is on,
-						create an app-password here to play your library in apps like Symfonium or Finamp.
-					</p>
-				</div>
-			</div>
-		{:else}
-			<div class="card border border-base-300 bg-base-200">
-				<div class="card-body gap-5">
-					<h3 class="card-title text-base">Protocols</h3>
+		<div class="card border border-base-300 bg-base-200">
+			<div class="card-body gap-5">
+				<h3 class="card-title text-base">Protocols</h3>
 
-					<label class="flex items-center justify-between gap-4">
-						<span>
-							<span class="font-medium">OpenSubsonic API</span>
-							<span class="block text-sm text-base-content/60">
-								Symfonium, Feishin, Amperfy and other Subsonic apps.
-							</span>
+				<label class="flex items-center justify-between gap-4">
+					<span>
+						<span class="font-medium">OpenSubsonic API</span>
+						<span class="block text-sm text-base-content/60">
+							Symfonium, Feishin, Amperfy and other Subsonic apps.
 						</span>
-						<input
-							type="checkbox"
-							class="toggle toggle-accent"
-							aria-label="Enable OpenSubsonic API"
-							bind:checked={subsonicEnabled}
-							disabled={!isAdmin}
-						/>
-					</label>
+					</span>
+					<input
+						type="checkbox"
+						class="toggle toggle-accent"
+						aria-label="Enable OpenSubsonic API"
+						bind:checked={subsonicEnabled}
+						disabled={!isAdmin}
+					/>
+				</label>
 
-					<label class="flex items-center justify-between gap-4">
-						<span>
-							<span class="font-medium">Jellyfin-compatible API</span>
-							<span class="block text-sm text-base-content/60">
-								Finamp, Jellify, Manet Music and Symfonium's Jellyfin mode.
-							</span>
+				<label class="flex items-center justify-between gap-4">
+					<span>
+						<span class="font-medium">Jellyfin-compatible API</span>
+						<span class="block text-sm text-base-content/60">
+							Finamp, Jellify, Manet Music and Symfonium's Jellyfin mode.
 						</span>
-						<input
-							type="checkbox"
-							class="toggle toggle-accent"
-							aria-label="Enable Jellyfin API"
-							bind:checked={jellyfinEnabled}
-							disabled={!isAdmin}
-						/>
-					</label>
+					</span>
+					<input
+						type="checkbox"
+						class="toggle toggle-accent"
+						aria-label="Enable Jellyfin API"
+						bind:checked={jellyfinEnabled}
+						disabled={!isAdmin}
+					/>
+				</label>
 
-					<div class="divider my-0"></div>
+				<div class="divider my-0"></div>
 
-					<label class="flex items-center justify-between gap-4">
-						<span class="font-medium">On-the-fly transcoding</span>
-						<input
-							type="checkbox"
-							class="toggle toggle-accent"
-							aria-label="Enable transcoding"
-							bind:checked={transcodingEnabled}
-							disabled={!isAdmin}
-						/>
-					</label>
+				<label class="flex items-center justify-between gap-4">
+					<span class="font-medium">On-the-fly transcoding</span>
+					<input
+						type="checkbox"
+						class="toggle toggle-accent"
+						aria-label="Enable transcoding"
+						bind:checked={transcodingEnabled}
+						disabled={!isAdmin}
+					/>
+				</label>
 
-					{#if transcodingEnabled}
-						<div class="grid gap-4 sm:grid-cols-2">
-							<label class="form-control">
-								<span class="label-text mb-1">Default format</span>
-								<select
-									class="select select-bordered"
-									aria-label="Transcode format"
-									bind:value={transcodeFormat}
-									disabled={!isAdmin}
-								>
-									<option value="mp3">MP3</option>
-									<option value="opus">Opus</option>
-								</select>
-							</label>
-							<label class="form-control">
-								<span class="label-text mb-1">Max bitrate (kbps)</span>
-								<input
-									type="number"
-									min="32"
-									max="1411"
-									class="input input-bordered"
-									aria-label="Max bitrate kbps"
-									bind:value={transcodeMaxKbps}
-									disabled={!isAdmin}
-								/>
-							</label>
-						</div>
-					{/if}
-
-					<label class="form-control">
-						<span class="label-text mb-1">Similar-songs discovery</span>
-						<select
-							class="select select-bordered"
-							aria-label="Discovery mode"
-							bind:value={discoverMode}
-							disabled={!isAdmin}
-						>
-							<option value="local-only">Local only - same artist, no outbound calls</option>
-							<option value="lazy-mb">Lazy MusicBrainz - fetch related artists once, cached</option>
-							<option value="use-scrobble-targets">
-								Use Last.fm / ListenBrainz when linked
-							</option>
-						</select>
-					</label>
-
-					{#if isAdmin}
-						<div class="card-actions justify-end">
-							<button class="btn btn-accent" onclick={handleSave} disabled={save.isPending}>
-								{#if save.isPending}
-									<span class="loading loading-spinner loading-sm"></span>
-								{/if}
-								Save
-							</button>
-						</div>
-					{:else}
-						<p class="text-sm text-base-content/50">
-							Only an administrator can change these. You can still manage your own app-passwords
-							below.
-						</p>
-					{/if}
-				</div>
-			</div>
-
-			<div class="card border border-base-300 bg-base-200">
-				<div class="card-body gap-4">
-					<div class="flex flex-wrap items-center justify-between gap-2">
-						<h3 class="card-title text-base">App-passwords</h3>
-						<span class="badge badge-ghost" aria-label="app-password count">
-							{activeCount} / {cap}
-						</span>
-					</div>
-					<p class="text-sm text-base-content/60">
-						An app-password is a separate secret you give to one app, so your real account
-						password stays private. You can revoke it any time. Use a different one per device.
-					</p>
-
-					{#if passwordsQuery.data && passwordsQuery.data.items.length > 0}
-						<div class="overflow-x-auto">
-							<table class="table table-sm">
-								<thead>
-									<tr>
-										<th>Name</th>
-										<th>Created</th>
-										<th>Last used</th>
-										<th>Last client</th>
-										<th class="text-right">Action</th>
-									</tr>
-								</thead>
-								<tbody>
-									{#each passwordsQuery.data.items as pw (pw.id)}
-										<tr>
-											<td class="font-medium">{pw.name}</td>
-											<td>{formatDate(pw.created_at)}</td>
-											<td>{formatDate(pw.last_used_at)}</td>
-											<td>{pw.last_client ?? '-'}</td>
-											<td class="text-right">
-												<button
-													class="btn btn-ghost btn-xs text-error"
-													aria-label={`Revoke ${pw.name}`}
-													onclick={() => (pendingRevoke = pw)}
-												>
-													<Trash2 class="h-4 w-4" aria-hidden="true" />
-													Revoke
-												</button>
-											</td>
-										</tr>
-									{/each}
-								</tbody>
-							</table>
-						</div>
-					{:else}
-						<div class="rounded-box border border-dashed border-base-300 p-6 text-center text-base-content/60">
-							No app-passwords yet - create one to connect an app.
-						</div>
-					{/if}
-
-					<div class="flex flex-wrap items-end gap-2">
-						<label class="form-control flex-1">
-							<span class="label-text mb-1">New app-password name</span>
-							<input
-								type="text"
-								class="input input-bordered"
-								list="connect-apps-suggested-names"
-								placeholder="Symfonium (phone)"
-								aria-label="New app-password name"
-								bind:value={newName}
-							/>
-							<datalist id="connect-apps-suggested-names">
-								{#each SUGGESTED_NAMES as suggestion (suggestion)}
-									<option value={suggestion}></option>
-								{/each}
-							</datalist>
+				{#if transcodingEnabled}
+					<div class="grid gap-4 sm:grid-cols-2">
+						<label class="form-control">
+							<span class="label-text mb-1">Default format</span>
+							<select
+								class="select select-bordered"
+								aria-label="Transcode format"
+								bind:value={transcodeFormat}
+								disabled={!isAdmin}
+							>
+								<option value="mp3">MP3</option>
+								<option value="opus">Opus</option>
+							</select>
 						</label>
-						<button
-							class="btn btn-accent"
-							onclick={handleCreate}
-							disabled={create.isPending || atCap}
-							title={atCap ? 'Revoke one first' : undefined}
-						>
-							{#if create.isPending}
+						<label class="form-control">
+							<span class="label-text mb-1">Max bitrate (kbps)</span>
+							<input
+								type="number"
+								min="32"
+								max="1411"
+								class="input input-bordered"
+								aria-label="Max bitrate kbps"
+								bind:value={transcodeMaxKbps}
+								disabled={!isAdmin}
+							/>
+						</label>
+					</div>
+				{/if}
+
+				<label class="form-control">
+					<span class="label-text mb-1">Similar-songs discovery</span>
+					<select
+						class="select select-bordered"
+						aria-label="Discovery mode"
+						bind:value={discoverMode}
+						disabled={!isAdmin}
+					>
+						<option value="local-only">Local only - same artist, no outbound calls</option>
+						<option value="lazy-mb">Lazy MusicBrainz - fetch related artists once, cached</option>
+						<option value="use-scrobble-targets"> Use Last.fm / ListenBrainz when linked </option>
+					</select>
+				</label>
+
+				{#if isAdmin}
+					<div class="card-actions justify-end">
+						<button class="btn btn-accent" onclick={handleSave} disabled={save.isPending}>
+							{#if save.isPending}
 								<span class="loading loading-spinner loading-sm"></span>
-							{:else}
-								<Plus class="h-4 w-4" aria-hidden="true" />
 							{/if}
-							Create
+							Save
 						</button>
 					</div>
+				{:else}
+					<p class="text-sm text-base-content/50">
+						Only an administrator can change these. You can still manage your own app-passwords
+						below.
+					</p>
+				{/if}
+			</div>
+		</div>
+
+		<div class="card border border-base-300 bg-base-200">
+			<div class="card-body gap-4">
+				<div class="flex flex-wrap items-center justify-between gap-2">
+					<h3 class="card-title text-base">App-passwords</h3>
+					<span class="badge badge-ghost" aria-label="app-password count">
+						{activeCount} / {cap}
+					</span>
+				</div>
+				<p class="text-sm text-base-content/60">
+					An app-password is a separate secret you give to one app, so your real account password
+					stays private. You can revoke it any time. Use a different one per device.
+				</p>
+
+				{#if passwordsQuery.data && passwordsQuery.data.items.length > 0}
+					<div class="overflow-x-auto">
+						<table class="table table-sm">
+							<thead>
+								<tr>
+									<th>Name</th>
+									<th>Created</th>
+									<th>Last used</th>
+									<th>Last client</th>
+									<th class="text-right">Action</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each passwordsQuery.data.items as pw (pw.id)}
+									<tr>
+										<td class="font-medium">{pw.name}</td>
+										<td>{formatDate(pw.created_at)}</td>
+										<td>{formatDate(pw.last_used_at)}</td>
+										<td>{pw.last_client ?? '-'}</td>
+										<td class="text-right">
+											<button
+												class="btn btn-ghost btn-xs text-error"
+												aria-label={`Revoke ${pw.name}`}
+												onclick={() => (pendingRevoke = pw)}
+											>
+												<Trash2 class="h-4 w-4" aria-hidden="true" />
+												Revoke
+											</button>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				{:else}
+					<div
+						class="rounded-box border border-dashed border-base-300 p-6 text-center text-base-content/60"
+					>
+						No app-passwords yet - create one to connect an app.
+					</div>
+				{/if}
+
+				<div class="flex flex-wrap items-end gap-2">
+					<label class="form-control flex-1">
+						<span class="label-text mb-1">New app-password name</span>
+						<input
+							type="text"
+							class="input input-bordered"
+							list="connect-apps-suggested-names"
+							placeholder="Symfonium (phone)"
+							aria-label="New app-password name"
+							bind:value={newName}
+						/>
+						<datalist id="connect-apps-suggested-names">
+							{#each SUGGESTED_NAMES as suggestion (suggestion)}
+								<option value={suggestion}></option>
+							{/each}
+						</datalist>
+					</label>
+					<button
+						class="btn btn-accent"
+						onclick={handleCreate}
+						disabled={create.isPending || atCap}
+						title={atCap ? 'Revoke one first' : undefined}
+					>
+						{#if create.isPending}
+							<span class="loading loading-spinner loading-sm"></span>
+						{:else}
+							<Plus class="h-4 w-4" aria-hidden="true" />
+						{/if}
+						Create
+					</button>
 				</div>
 			</div>
+		</div>
 
-			<div class="grid gap-4 lg:grid-cols-2">
-				{#each [{ key: 'subsonic', label: 'OpenSubsonic', url: subsonicUrl, on: settingsQuery.data?.subsonic_enabled ?? false, clients: SUBSONIC_CLIENTS }, { key: 'jellyfin', label: 'Jellyfin', url: jellyfinUrl, on: settingsQuery.data?.jellyfin_enabled ?? false, clients: JELLYFIN_CLIENTS }] as proto (proto.key)}
-					<div class="card border border-base-300 bg-base-200" class:opacity-60={!proto.on}>
-						<div class="card-body gap-3">
-							<h3 class="card-title text-base">
-								{proto.label}
-								{#if !proto.on}
-									<span class="badge badge-sm badge-ghost">enable above to use</span>
-								{/if}
-							</h3>
-							<label class="form-control">
-								<span class="label-text mb-1">Server URL</span>
-								<div class="join">
-									<input
-										class="input input-bordered join-item flex-1 font-mono text-sm"
-										readonly
-										value={proto.url}
-										aria-label={`${proto.label} server URL`}
-									/>
-									<button
-										class="btn btn-square join-item"
-										aria-label={`Copy ${proto.label} URL`}
-										onclick={() => copy(proto.url)}
-									>
-										<Copy class="h-4 w-4" aria-hidden="true" />
-									</button>
-								</div>
-							</label>
-							<p class="text-sm">
-								<span class="text-base-content/60">Username:</span>
-								<span class="font-mono">{username || 'your username'}</span>
-							</p>
-							<p class="text-sm text-base-content/60">
-								Use your <strong>app-password</strong> (above) as the password / API key.
-							</p>
-							<p class="text-xs text-base-content/50">Tested clients: {proto.clients}</p>
-						</div>
+		<div class="grid gap-4 lg:grid-cols-2">
+			{#each [{ key: 'subsonic', label: 'OpenSubsonic', url: subsonicUrl, on: settingsQuery.data?.subsonic_enabled ?? false, clients: SUBSONIC_CLIENTS }, { key: 'jellyfin', label: 'Jellyfin', url: jellyfinUrl, on: settingsQuery.data?.jellyfin_enabled ?? false, clients: JELLYFIN_CLIENTS }] as proto (proto.key)}
+				<div class="card border border-base-300 bg-base-200" class:opacity-60={!proto.on}>
+					<div class="card-body gap-3">
+						<h3 class="card-title text-base">
+							{proto.label}
+							{#if !proto.on}
+								<span class="badge badge-sm badge-ghost">enable above to use</span>
+							{/if}
+						</h3>
+						<label class="form-control">
+							<span class="label-text mb-1">Server URL</span>
+							<div class="join">
+								<input
+									class="input input-bordered join-item flex-1 font-mono text-sm"
+									readonly
+									value={proto.url}
+									aria-label={`${proto.label} server URL`}
+								/>
+								<button
+									class="btn btn-square join-item"
+									aria-label={`Copy ${proto.label} URL`}
+									onclick={() => copy(proto.url)}
+								>
+									<Copy class="h-4 w-4" aria-hidden="true" />
+								</button>
+							</div>
+						</label>
+						<p class="text-sm">
+							<span class="text-base-content/60">Username:</span>
+							<span class="font-mono">{username || 'your username'}</span>
+						</p>
+						<p class="text-sm text-base-content/60">
+							Use your <strong>app-password</strong> (above) as the password / API key.
+						</p>
+						<p class="text-xs text-base-content/50">Tested clients: {proto.clients}</p>
 					</div>
-				{/each}
-			</div>
-		{/if}
+				</div>
+			{/each}
+		</div>
 	{/if}
 
-	<dialog bind:this={revealDialog} class="modal" onclose={() => (revealedSecret = null)} aria-label="New app-password">
+	<dialog
+		bind:this={revealDialog}
+		class="modal"
+		onclose={() => (revealedSecret = null)}
+		aria-label="New app-password"
+	>
 		<div class="modal-box">
 			<h3 class="flex items-center gap-2 text-lg font-bold">
 				<TriangleAlert class="h-5 w-5 text-warning" aria-hidden="true" />
 				Copy your app-password now
 			</h3>
 			<p class="py-2 text-sm text-base-content/70">
-				This is the only time "{revealedName}" will be shown. If you lose it, revoke it and create
-				a new one.
+				This is the only time "{revealedName}" will be shown. If you lose it, revoke it and create a
+				new one.
 			</p>
 			<div class="join w-full">
 				<input
@@ -482,7 +486,12 @@
 		</div>
 	</dialog>
 
-	<dialog bind:this={revokeDialog} class="modal" onclose={() => (pendingRevoke = null)} aria-label="Confirm revoke">
+	<dialog
+		bind:this={revokeDialog}
+		class="modal"
+		onclose={() => (pendingRevoke = null)}
+		aria-label="Confirm revoke"
+	>
 		<div class="modal-box">
 			<h3 class="text-lg font-bold">Revoke "{pendingRevoke?.name}"?</h3>
 			<p class="py-2 text-sm text-base-content/70">
@@ -531,7 +540,8 @@
 		letter-spacing: 0.04em;
 		color: var(--color-accent-content, var(--color-base-100));
 		background: var(--color-accent);
-		box-shadow: 0 0 0 1px oklch(from var(--color-accent) l c h / 0.4),
+		box-shadow:
+			0 0 0 1px oklch(from var(--color-accent) l c h / 0.4),
 			0 0 30px oklch(from var(--color-accent) l c h / 0.35);
 	}
 	.inbound-core-dot {

--- a/frontend/src/lib/components/settings/SettingsConnectApps.svelte.spec.ts
+++ b/frontend/src/lib/components/settings/SettingsConnectApps.svelte.spec.ts
@@ -16,14 +16,26 @@ const h = vi.hoisted(() => ({
 	},
 	passwords: {
 		items: [
-			{ id: 'ap-1', name: 'Symfonium (phone)', created_at: '2026-06-01T00:00:00Z', last_used_at: null, last_client: null }
+			{
+				id: 'ap-1',
+				name: 'Symfonium (phone)',
+				created_at: '2026-06-01T00:00:00Z',
+				last_used_at: null,
+				last_client: null
+			}
 		],
 		cap: 25,
 		active_count: 1
 	},
 	createMutate: vi.fn().mockResolvedValue({
 		secret: 'super-secret-123',
-		app_password: { id: 'ap-2', name: 'Finamp (tablet)', created_at: '', last_used_at: null, last_client: null }
+		app_password: {
+			id: 'ap-2',
+			name: 'Finamp (tablet)',
+			created_at: '',
+			last_used_at: null,
+			last_client: null
+		}
 	}),
 	revokeMutate: vi.fn().mockResolvedValue(undefined),
 	saveMutate: vi.fn().mockResolvedValue({})
@@ -67,7 +79,13 @@ beforeEach(() => {
 	};
 	h.passwords = {
 		items: [
-			{ id: 'ap-1', name: 'Symfonium (phone)', created_at: '2026-06-01T00:00:00Z', last_used_at: null, last_client: null }
+			{
+				id: 'ap-1',
+				name: 'Symfonium (phone)',
+				created_at: '2026-06-01T00:00:00Z',
+				last_used_at: null,
+				last_client: null
+			}
 		],
 		cap: 25,
 		active_count: 1
@@ -95,7 +113,9 @@ describe('SettingsConnectApps.svelte', () => {
 		render(SettingsConnectApps);
 		await expect.element(page.getByLabelText('OpenSubsonic server URL')).toBeInTheDocument();
 		await expect.element(page.getByLabelText('Jellyfin server URL')).toBeInTheDocument();
-		await expect.element(page.getByText(/Tested clients: Symfonium, Feishin, Amperfy/)).toBeInTheDocument();
+		await expect
+			.element(page.getByText(/Tested clients: Symfonium, Feishin, Amperfy/))
+			.toBeInTheDocument();
 	});
 
 	it('reveals the created secret exactly once', async () => {
@@ -104,7 +124,9 @@ describe('SettingsConnectApps.svelte', () => {
 		await page.getByRole('button', { name: 'Create' }).click();
 		// The reveal modal markup is always in the DOM (no CSS hides it in tests), so key the
 		// assertion off bound values that only populate after a successful create.
-		await expect.element(page.getByLabelText('App-password secret')).toHaveValue('super-secret-123');
+		await expect
+			.element(page.getByLabelText('App-password secret'))
+			.toHaveValue('super-secret-123');
 		await expect
 			.element(page.getByText(/only time "Finamp \(tablet\)" will be shown/))
 			.toBeInTheDocument();
@@ -127,7 +149,9 @@ describe('SettingsConnectApps.svelte', () => {
 	it('non-admin sees a read-only note instead of editable controls', async () => {
 		h.isAdmin = false;
 		render(SettingsConnectApps);
-		await expect.element(page.getByText(/Only an administrator can change these/)).toBeInTheDocument();
+		await expect
+			.element(page.getByText(/Only an administrator can change these/))
+			.toBeInTheDocument();
 		await expect.element(page.getByLabelText('Enable OpenSubsonic API')).toBeDisabled();
 	});
 

--- a/frontend/src/lib/components/settings/SettingsMusicSource.svelte
+++ b/frontend/src/lib/components/settings/SettingsMusicSource.svelte
@@ -36,8 +36,8 @@
 	<div class="card-body">
 		<h2 class="card-title text-2xl">Primary Music Source</h2>
 		<p class="text-base-content/70 mb-4">
-			Choose which listening service powers your Home and Discover by default. You can also set
-			this from your profile, and switch it on each page.
+			Choose which listening service powers your Home and Discover by default. You can also set this
+			from your profile, and switch it on each page.
 		</p>
 
 		<fieldset class="fieldset">

--- a/frontend/src/lib/components/settings/SettingsOnboardingChecklist.svelte
+++ b/frontend/src/lib/components/settings/SettingsOnboardingChecklist.svelte
@@ -28,31 +28,36 @@
 	const aSourceConfigured = $derived(slskdConfigured || hasIndexer);
 	const aClientConfigured = $derived(slskdConfigured || sabnzbdEnabled);
 
-	const items = $derived(
-		[
-			{ label: 'Add a library path', done: hasLibraryPath, required: true, optional: false },
-			{
-				label: 'Add an indexer or configure Soulseek',
-				done: aSourceConfigured,
-				required: true,
-				optional: false
-			},
-			{
-				label: 'Configure a download client (slskd and/or SABnzbd)',
-				done: aClientConfigured,
-				required: true,
-				optional: false
-			},
-			...(slskdConfigured
-				? [{ label: "Mount slskd's downloads folder", done: mountOk, required: true, optional: false }]
-				: []),
-			...(sabnzbdEnabled
-				? [{ label: "Mount SABnzbd's downloads folder", done: true, required: false, optional: true }]
-				: []),
-			{ label: 'Run a library scan', done: false, required: false, optional: true },
-			{ label: 'Set an AcoustID key', done: hasAcoustid, required: false, optional: true }
-		]
-	);
+	const items = $derived([
+		{ label: 'Add a library path', done: hasLibraryPath, required: true, optional: false },
+		{
+			label: 'Add an indexer or configure Soulseek',
+			done: aSourceConfigured,
+			required: true,
+			optional: false
+		},
+		{
+			label: 'Configure a download client (slskd and/or SABnzbd)',
+			done: aClientConfigured,
+			required: true,
+			optional: false
+		},
+		...(slskdConfigured
+			? [
+					{
+						label: "Mount slskd's downloads folder",
+						done: mountOk,
+						required: true,
+						optional: false
+					}
+				]
+			: []),
+		...(sabnzbdEnabled
+			? [{ label: "Mount SABnzbd's downloads folder", done: true, required: false, optional: true }]
+			: []),
+		{ label: 'Run a library scan', done: false, required: false, optional: true },
+		{ label: 'Set an AcoustID key', done: hasAcoustid, required: false, optional: true }
+	]);
 
 	const doneCount = $derived(items.filter((i) => i.done).length);
 	const requiredDone = $derived(items.filter((i) => i.required).every((i) => i.done));

--- a/frontend/src/lib/components/settings/SettingsSecurity.svelte
+++ b/frontend/src/lib/components/settings/SettingsSecurity.svelte
@@ -267,8 +267,8 @@
 				<div class="alert alert-warning alert-soft text-sm">
 					<CircleAlert class="h-4 w-4 shrink-0" />
 					<span>
-						<strong>Only enable if you are serving DroppedNeedle over HTTPS.</strong> Enabling HSTS on a
-						plain HTTP install will lock users out until the HSTS header expires in their browser.
+						<strong>Only enable if you are serving DroppedNeedle over HTTPS.</strong> Enabling HSTS on
+						a plain HTTP install will lock users out until the HSTS header expires in their browser.
 					</span>
 				</div>
 

--- a/frontend/src/lib/components/settings/SettingsUsers.svelte
+++ b/frontend/src/lib/components/settings/SettingsUsers.svelte
@@ -370,7 +370,11 @@
 						class="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center shrink-0 overflow-hidden"
 					>
 						{#if user.avatar_url}
-							<img src={user.avatar_url} alt={user.display_name} class="h-full w-full object-cover" />
+							<img
+								src={user.avatar_url}
+								alt={user.display_name}
+								class="h-full w-full object-cover"
+							/>
 						{:else}
 							<UserRound class="h-5 w-5 text-primary/60" />
 						{/if}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -376,7 +376,10 @@ export const API = {
 		heldImport: (id: number) => `/api/v1/downloads/held/${id}/import`,
 		heldDiscard: (id: number) => `/api/v1/downloads/held/${id}/discard`,
 		heldAudio: (id: number) => `/api/v1/downloads/held/${id}/audio`,
-		reimport: (taskId: string) => `/api/v1/downloads/${taskId}/reimport`
+		reimport: (taskId: string) => `/api/v1/downloads/${taskId}/reimport`,
+		cutoffUnmet: () => '/api/v1/downloads/cutoff-unmet',
+		upgradeAlbum: () => '/api/v1/downloads/upgrade/album',
+		upgradeTrack: () => '/api/v1/downloads/upgrade/track'
 	},
 	requests: {
 		new: () => '/api/v1/requests/new',

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -375,7 +375,8 @@ export const API = {
 		},
 		heldImport: (id: number) => `/api/v1/downloads/held/${id}/import`,
 		heldDiscard: (id: number) => `/api/v1/downloads/held/${id}/discard`,
-		heldAudio: (id: number) => `/api/v1/downloads/held/${id}/audio`
+		heldAudio: (id: number) => `/api/v1/downloads/held/${id}/audio`,
+		reimport: (taskId: string) => `/api/v1/downloads/${taskId}/reimport`
 	},
 	requests: {
 		new: () => '/api/v1/requests/new',

--- a/frontend/src/lib/queries/auth/ImportCandidatesQuery.svelte.ts
+++ b/frontend/src/lib/queries/auth/ImportCandidatesQuery.svelte.ts
@@ -17,9 +17,7 @@ export const getImportCandidatesQuery = (
 		enabled: enabled(),
 		queryFn: ({ signal }) =>
 			api.get<ImportCandidateListResponse>(
-				provider() === 'plex'
-					? AUTH_ENDPOINTS.adminImportPlex
-					: AUTH_ENDPOINTS.adminImportJellyfin,
+				provider() === 'plex' ? AUTH_ENDPOINTS.adminImportPlex : AUTH_ENDPOINTS.adminImportJellyfin,
 				{ signal }
 			)
 	}));

--- a/frontend/src/lib/queries/connect-apps/ConnectAppsMutations.spec.ts
+++ b/frontend/src/lib/queries/connect-apps/ConnectAppsMutations.spec.ts
@@ -45,7 +45,9 @@ describe('saveConnectAppsSettings', () => {
 		saveConnectAppsSettings();
 		const opts = lastMutationOpts();
 		await (opts.mutationFn as (v: unknown) => Promise<unknown>)({ subsonic_enabled: true });
-		expect(mockPut).toHaveBeenCalledWith('/api/v1/connect-apps/settings', { subsonic_enabled: true });
+		expect(mockPut).toHaveBeenCalledWith('/api/v1/connect-apps/settings', {
+			subsonic_enabled: true
+		});
 		await (opts.onSuccess as () => Promise<unknown>)();
 		expect(mockInvalidate).toHaveBeenCalledWith({
 			queryKey: ConnectAppsQueryKeyFactory.settings()

--- a/frontend/src/lib/queries/discover/DiscoverQueryKeyFactory.spec.ts
+++ b/frontend/src/lib/queries/discover/DiscoverQueryKeyFactory.spec.ts
@@ -30,9 +30,14 @@ describe('DiscoverQueryKeyFactory (AMU-5)', () => {
 
 	describe('radio', () => {
 		it('includes userId', () => {
-			expect(
-				DiscoverQueryKeyFactory.radio('user-a', 'artist', 'mbid-1', 'listenbrainz')
-			).toEqual(['discover', 'user-a', 'radio', 'artist', 'mbid-1', { source: 'listenbrainz' }]);
+			expect(DiscoverQueryKeyFactory.radio('user-a', 'artist', 'mbid-1', 'listenbrainz')).toEqual([
+				'discover',
+				'user-a',
+				'radio',
+				'artist',
+				'mbid-1',
+				{ source: 'listenbrainz' }
+			]);
 		});
 
 		it('differs per user', () => {

--- a/frontend/src/lib/queries/discover/DiscoverQueryKeyFactory.ts
+++ b/frontend/src/lib/queries/discover/DiscoverQueryKeyFactory.ts
@@ -6,8 +6,20 @@ export const DiscoverQueryKeyFactory = {
 	prefix: ['discover'] as const,
 	discover: (userId: string | null | undefined, source: MusicSource) =>
 		[...DiscoverQueryKeyFactory.prefix, userId ?? null, source] as const,
-	radio: (userId: string | null | undefined, seedType: string, seedId: string, source: MusicSource) =>
-		[...DiscoverQueryKeyFactory.prefix, userId ?? null, 'radio', seedType, seedId, { source }] as const,
+	radio: (
+		userId: string | null | undefined,
+		seedType: string,
+		seedId: string,
+		source: MusicSource
+	) =>
+		[
+			...DiscoverQueryKeyFactory.prefix,
+			userId ?? null,
+			'radio',
+			seedType,
+			seedId,
+			{ source }
+		] as const,
 	playlistSuggestions: (
 		userId: string | null | undefined,
 		playlistId: string,

--- a/frontend/src/lib/queries/downloads/DownloadMutations.svelte.ts
+++ b/frontend/src/lib/queries/downloads/DownloadMutations.svelte.ts
@@ -7,6 +7,7 @@ import { LibraryQueryKeyFactory } from '$lib/queries/library/LibraryQueryKeyFact
 import { toastStore } from '$lib/stores/toast';
 import type {
 	CancelDownloadResponse,
+	ReimportDownloadResponse,
 	RequestAccepted,
 	RetryDownloadResponse,
 	TrackRequestResponse
@@ -229,5 +230,30 @@ export function discardHeldTrack() {
 		},
 		onError: (err: unknown) =>
 			toastStore.show({ message: errorMessage(err, 'Failed to discard track'), type: 'error' })
+	}));
+}
+
+export function reimportDownload() {
+	return createMutation(() => ({
+		mutationFn: (id: string) =>
+			api.global.post<ReimportDownloadResponse>(API.downloads.reimport(id), {}),
+		onSuccess: (data: ReimportDownloadResponse) => {
+			if (data.status === 'completed') {
+				toastStore.show({ message: 'Import complete', type: 'success' });
+			} else if (data.status === 'partial') {
+				toastStore.show({
+					message: 'Imported what was found, some files still missing',
+					type: 'info'
+				});
+			} else {
+				toastStore.show({
+					message: data.error_message ?? "Couldn't find the files on the downloads mount yet",
+					type: 'error'
+				});
+			}
+			void invalidateTasks();
+		},
+		onError: (err: unknown) =>
+			toastStore.show({ message: errorMessage(err, 'Failed to reimport download'), type: 'error' })
 	}));
 }

--- a/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
+++ b/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
@@ -7,6 +7,7 @@ import {
 	bucketDownloads,
 	bucketSections,
 	canCancel,
+	canReimport,
 	canRetry,
 	collapseRetryChains,
 	derivedDownloadStatus,
@@ -130,6 +131,35 @@ describe('canCancel / canRetry', () => {
 	});
 });
 
+describe('canReimport', () => {
+	it('allows reimport for failed/partial tasks that picked a candidate', () => {
+		expect(canReimport(task({ status: 'failed', search_job_id: 'j', candidate_index: 0 }))).toBe(
+			true
+		);
+		expect(canReimport(task({ status: 'partial', search_job_id: 'j', candidate_index: 2 }))).toBe(
+			true
+		);
+	});
+
+	it('disallows reimport for a task that never picked a candidate', () => {
+		expect(
+			canReimport(task({ status: 'failed', search_job_id: null, candidate_index: null }))
+		).toBe(false);
+	});
+
+	it('disallows reimport for statuses other than failed/partial', () => {
+		expect(canReimport(task({ status: 'cancelled', search_job_id: 'j', candidate_index: 0 }))).toBe(
+			false
+		);
+		expect(canReimport(task({ status: 'completed', search_job_id: 'j', candidate_index: 0 }))).toBe(
+			false
+		);
+		expect(
+			canReimport(task({ status: 'downloading', search_job_id: 'j', candidate_index: 0 }))
+		).toBe(false);
+	});
+});
+
 describe('nowPressing', () => {
 	it('prefers the most recent downloading/processing task over a newer searching one', () => {
 		const dl = task({ id: 'dl', status: 'downloading', created_at: 1 });
@@ -172,8 +202,12 @@ describe('retryDisplay', () => {
 	});
 
 	it('is null when auto-retry is off (retry_max 0): plain status, never "out of retries" or "/0"', () => {
-		expect(retryDisplay(task({ status: 'failed', next_retry_at: null, retry_max: 0 }), NOW)).toBeNull();
-		expect(retryDisplay(task({ status: 'downloading', retry_count: 1, retry_max: 0 }), NOW)).toBeNull();
+		expect(
+			retryDisplay(task({ status: 'failed', next_retry_at: null, retry_max: 0 }), NOW)
+		).toBeNull();
+		expect(
+			retryDisplay(task({ status: 'downloading', retry_count: 1, retry_max: 0 }), NOW)
+		).toBeNull();
 	});
 });
 
@@ -204,12 +238,12 @@ describe('isWanted + sectionForTask + bucketSections', () => {
 	const NOW = 1_000_000;
 
 	it('a failed/partial task with a scheduled retry is wanted', () => {
-		expect(isWanted(task({ status: 'failed', retry_count: 1, next_retry_at: NOW + 600 }), NOW)).toBe(
-			true
-		);
-		expect(isWanted(task({ status: 'partial', retry_count: 1, next_retry_at: NOW + 600 }), NOW)).toBe(
-			true
-		);
+		expect(
+			isWanted(task({ status: 'failed', retry_count: 1, next_retry_at: NOW + 600 }), NOW)
+		).toBe(true);
+		expect(
+			isWanted(task({ status: 'partial', retry_count: 1, next_retry_at: NOW + 600 }), NOW)
+		).toBe(true);
 		expect(isWanted(task({ status: 'failed', next_retry_at: null }), NOW)).toBe(false);
 	});
 
@@ -229,7 +263,9 @@ describe('isWanted + sectionForTask + bucketSections', () => {
 	});
 
 	it('an in-flight retry stays in now_spinning, not wanted', () => {
-		expect(sectionForTask(task({ status: 'downloading', retry_count: 2 }), NOW)).toBe('now_spinning');
+		expect(sectionForTask(task({ status: 'downloading', retry_count: 2 }), NOW)).toBe(
+			'now_spinning'
+		);
 	});
 
 	it('buckets a mixed queue and sorts wanted by soonest next attempt', () => {
@@ -276,8 +312,20 @@ describe('retryLadderState', () => {
 
 describe('collapseRetryChains', () => {
 	it('keeps only the latest attempt per (type, identity, owner) by created_at', () => {
-		const original = task({ id: 'o', status: 'failed', retry_count: 0, created_at: 1, release_group_mbid: 'rg1' });
-		const retry = task({ id: 'r', status: 'downloading', retry_count: 1, created_at: 2, release_group_mbid: 'rg1' });
+		const original = task({
+			id: 'o',
+			status: 'failed',
+			retry_count: 0,
+			created_at: 1,
+			release_group_mbid: 'rg1'
+		});
+		const retry = task({
+			id: 'r',
+			status: 'downloading',
+			retry_count: 1,
+			created_at: 2,
+			release_group_mbid: 'rg1'
+		});
 		const collapsed = collapseRetryChains([original, retry]);
 		expect(collapsed).toHaveLength(1);
 		expect(collapsed[0].id).toBe('r');
@@ -300,8 +348,20 @@ describe('collapseRetryChains', () => {
 		// The live bug: a re-request resets retry_count to 0, so a stale failed retry-7 task
 		// from yesterday must NOT outrank, and hide, today's active retry-0 download. Newest
 		// created_at wins - the higher retry_count does not.
-		const stale = task({ id: 'old', status: 'failed', retry_count: 7, created_at: 100, release_group_mbid: 'rg1' });
-		const fresh = task({ id: 'new', status: 'downloading', retry_count: 0, created_at: 200, release_group_mbid: 'rg1' });
+		const stale = task({
+			id: 'old',
+			status: 'failed',
+			retry_count: 7,
+			created_at: 100,
+			release_group_mbid: 'rg1'
+		});
+		const fresh = task({
+			id: 'new',
+			status: 'downloading',
+			retry_count: 0,
+			created_at: 200,
+			release_group_mbid: 'rg1'
+		});
 		const collapsed = collapseRetryChains([stale, fresh]);
 		expect(collapsed).toHaveLength(1);
 		expect(collapsed[0].id).toBe('new');

--- a/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
+++ b/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
@@ -133,12 +133,12 @@ describe('canCancel / canRetry', () => {
 
 describe('canReimport', () => {
 	it('allows reimport for failed/partial tasks that picked a candidate', () => {
-		expect(canReimport(task({ status: 'failed', search_job_id: 'j', candidate_index: 0 }))).toBe(
-			true
-		);
-		expect(canReimport(task({ status: 'partial', search_job_id: 'j', candidate_index: 2 }))).toBe(
-			true
-		);
+		expect(
+			canReimport(task({ status: 'failed', search_job_id: 'j', candidate_index: 0, source_username: 'peer' }))
+		).toBe(true);
+		expect(
+			canReimport(task({ status: 'partial', search_job_id: 'j', candidate_index: 2, source_username: 'peer' }))
+		).toBe(true);
 	});
 
 	it('disallows reimport for a task that never picked a candidate', () => {

--- a/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
+++ b/frontend/src/lib/queries/downloads/downloadStatus.spec.ts
@@ -134,10 +134,14 @@ describe('canCancel / canRetry', () => {
 describe('canReimport', () => {
 	it('allows reimport for failed/partial tasks that picked a candidate', () => {
 		expect(
-			canReimport(task({ status: 'failed', search_job_id: 'j', candidate_index: 0, source_username: 'peer' }))
+			canReimport(
+				task({ status: 'failed', search_job_id: 'j', candidate_index: 0, source_username: 'peer' })
+			)
 		).toBe(true);
 		expect(
-			canReimport(task({ status: 'partial', search_job_id: 'j', candidate_index: 2, source_username: 'peer' }))
+			canReimport(
+				task({ status: 'partial', search_job_id: 'j', candidate_index: 2, source_username: 'peer' })
+			)
 		).toBe(true);
 	});
 

--- a/frontend/src/lib/queries/downloads/downloadStatus.ts
+++ b/frontend/src/lib/queries/downloads/downloadStatus.ts
@@ -65,6 +65,14 @@ export function canRetry(task: DownloadTask): boolean {
 	return task.status === 'failed' || task.status === 'cancelled' || task.status === 'partial';
 }
 
+export function canReimport(task: DownloadTask): boolean {
+	return (
+		(task.status === 'failed' || task.status === 'partial') &&
+		task.search_job_id != null &&
+		task.candidate_index != null
+	);
+}
+
 export type RetryDisplay =
 	| { kind: 'scheduled'; etaMinutes: number }
 	| { kind: 'retrying'; attempt: number; max: number }

--- a/frontend/src/lib/queries/downloads/downloadStatus.ts
+++ b/frontend/src/lib/queries/downloads/downloadStatus.ts
@@ -69,7 +69,8 @@ export function canReimport(task: DownloadTask): boolean {
 	return (
 		(task.status === 'failed' || task.status === 'partial') &&
 		task.search_job_id != null &&
-		task.candidate_index != null
+		task.candidate_index != null &&
+		task.source_username != null
 	);
 }
 

--- a/frontend/src/lib/queries/library/LibraryQueries.svelte.ts
+++ b/frontend/src/lib/queries/library/LibraryQueries.svelte.ts
@@ -125,9 +125,7 @@ export const getLibraryScanStatusQuery = () =>
 	createQuery(() => ({
 		staleTime: CACHE_TTL.SCAN_STATUS,
 		refetchInterval: (query: { state: { data?: LibraryScanStatus | undefined } }) =>
-			query.state.data?.status === 'scanning'
-				? CACHE_TTL.SCAN_STATUS
-				: CACHE_TTL.SCAN_STATUS_IDLE,
+			query.state.data?.status === 'scanning' ? CACHE_TTL.SCAN_STATUS : CACHE_TTL.SCAN_STATUS_IDLE,
 		queryKey: LibraryQueryKeyFactory.scanStatus(),
 		queryFn: ({ signal }) => api.global.get<LibraryScanStatus>(API.library.scanStatus(), { signal })
 	}));

--- a/frontend/src/lib/stores/downloadsActivity.svelte.ts
+++ b/frontend/src/lib/stores/downloadsActivity.svelte.ts
@@ -27,7 +27,11 @@ async function poll(): Promise<void> {
 		for (const t of items) {
 			const prev = prevStatus.get(t.id);
 			const wasActive = prev !== undefined && isActiveDownloadStatus(prev);
-			if (wasActive && (t.status === 'completed' || t.status === 'partial') && t.release_group_mbid) {
+			if (
+				wasActive &&
+				(t.status === 'completed' || t.status === 'partial') &&
+				t.release_group_mbid
+			) {
 				libraryStore.addMbid(t.release_group_mbid);
 				landed = true;
 			}

--- a/frontend/src/lib/stores/version.svelte.ts
+++ b/frontend/src/lib/stores/version.svelte.ts
@@ -1,7 +1,10 @@
 import { PersistedState } from 'runed';
 
 // svelte-ignore state_referenced_locally
-const dismissedVersion = new PersistedState<string | null>('droppedneedle_whats_new_dismissed', null);
+const dismissedVersion = new PersistedState<string | null>(
+	'droppedneedle_whats_new_dismissed',
+	null
+);
 
 export function isWhatsNewDismissed(currentVersion: string): boolean {
 	return dismissedVersion.current === currentVersion;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -611,6 +611,8 @@ export type RequestHistoryItem = {
 	requested_by_name?: string | null;
 	reviewed_by_name?: string | null;
 	reviewed_at?: string | null;
+	download_task_id?: string | null;
+	can_reimport?: boolean;
 };
 
 export type ActiveRequestsResponse = {

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1824,6 +1824,14 @@ export interface RetryDownloadResponse {
 	task_id: string;
 }
 
+export interface ReimportDownloadResponse {
+	success: boolean;
+	status: string;
+	files_imported: number;
+	files_failed: number;
+	error_message?: string | null;
+}
+
 export interface QuarantineEntry {
 	id: number;
 	client_id: string;

--- a/frontend/src/lib/utils/discoverQueueCache.svelte.spec.ts
+++ b/frontend/src/lib/utils/discoverQueueCache.svelte.spec.ts
@@ -103,16 +103,8 @@ describe('discoverQueueCache', () => {
 
 	it('isolates cache entries per user (no cross-user leak)', () => {
 		expect.assertions(3);
-		setQueueCachedData(
-			{ items: [], currentIndex: 0, queueId: 'queue-a' },
-			USER_A,
-			'listenbrainz'
-		);
-		setQueueCachedData(
-			{ items: [], currentIndex: 0, queueId: 'queue-b' },
-			USER_B,
-			'listenbrainz'
-		);
+		setQueueCachedData({ items: [], currentIndex: 0, queueId: 'queue-a' }, USER_A, 'listenbrainz');
+		setQueueCachedData({ items: [], currentIndex: 0, queueId: 'queue-b' }, USER_B, 'listenbrainz');
 
 		expect(getQueueCachedData(USER_A, 'listenbrainz')?.data.queueId).toBe('queue-a');
 		expect(getQueueCachedData(USER_B, 'listenbrainz')?.data.queueId).toBe('queue-b');

--- a/frontend/src/routes/album/[id]/AlbumHeader.svelte
+++ b/frontend/src/routes/album/[id]/AlbumHeader.svelte
@@ -439,10 +439,12 @@
 								<Check class="h-4 w-4" />
 								In Library
 							</div>
-							<button class="btn btn-sm btn-error btn-outline gap-1" onclick={ondelete}>
-								<Trash2 class="h-4 w-4" />
-								Remove
-							</button>
+							{#if authStore.isAdmin}
+								<button class="btn btn-sm btn-error btn-outline gap-1" onclick={ondelete}>
+									<Trash2 class="h-4 w-4" />
+									Remove
+								</button>
+							{/if}
 						{:else if isRequested}
 							{#if !headerDownloadTask}
 								<div class="badge badge-lg badge-warning gap-2">
@@ -450,10 +452,12 @@
 									Requested
 								</div>
 							{/if}
-							<button class="btn btn-sm btn-error btn-outline gap-1" onclick={ondelete}>
-								<Trash2 class="h-4 w-4" />
-								Remove
-							</button>
+							{#if authStore.isAdmin}
+								<button class="btn btn-sm btn-error btn-outline gap-1" onclick={ondelete}>
+									<Trash2 class="h-4 w-4" />
+									Remove
+								</button>
+							{/if}
 						{:else}
 							<button
 								class="btn btn-lg gap-2"

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -27,7 +27,11 @@
 	);
 	let redactedPlaylists = $derived(items.filter(isRedactedPlaylist) as RedactedPlaylist[]);
 	let errorMessage = $derived(
-		query.isError ? (query.error instanceof Error ? query.error.message : "Couldn't load playlists") : null
+		query.isError
+			? query.error instanceof Error
+				? query.error.message
+				: "Couldn't load playlists"
+			: null
 	);
 
 	let showNewInput = $state(false);

--- a/frontend/src/routes/playlists/[id]/PlaylistHeader.svelte
+++ b/frontend/src/routes/playlists/[id]/PlaylistHeader.svelte
@@ -292,7 +292,9 @@
 				class="group/name flex items-center gap-2 text-left"
 				aria-label="Edit playlist name"
 			>
-				<h1 class="hero-title text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight truncate">
+				<h1
+					class="hero-title text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight truncate"
+				>
 					{playlist.name}
 				</h1>
 				<Pencil
@@ -300,7 +302,9 @@
 				/>
 			</button>
 		{:else}
-			<h1 class="hero-title text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight truncate">
+			<h1
+				class="hero-title text-3xl sm:text-4xl lg:text-5xl xl:text-6xl font-bold leading-tight truncate"
+			>
 				{playlist.name}
 			</h1>
 		{/if}
@@ -361,13 +365,18 @@
 			</button>
 
 			{#if canEdit}
-				<label class="ml-1 flex cursor-pointer items-center gap-2" title="Toggle who can see this playlist">
+				<label
+					class="ml-1 flex cursor-pointer items-center gap-2"
+					title="Toggle who can see this playlist"
+				>
 					{#if playlist.is_public}
 						<Globe class="h-4 w-4 text-success" />
 					{:else}
 						<Lock class="h-4 w-4 text-base-content/50" />
 					{/if}
-					<span class="text-sm text-base-content/70">{playlist.is_public ? 'Public' : 'Private'}</span>
+					<span class="text-sm text-base-content/70"
+						>{playlist.is_public ? 'Public' : 'Private'}</span
+					>
 					<input
 						type="checkbox"
 						class="toggle toggle-sm toggle-success"

--- a/frontend/src/routes/playlists/[id]/page.svelte.spec.ts
+++ b/frontend/src/routes/playlists/[id]/page.svelte.spec.ts
@@ -305,7 +305,9 @@ describe('Playlist detail page', () => {
 			.toBeVisible();
 		await expect.element(page.getByText(/Shared by Ann/)).toBeVisible();
 		expect(page.getByRole('button', { name: /Edit playlist name/ }).elements()).toHaveLength(0);
-		expect(page.getByRole('checkbox', { name: /Make playlist (public|private)/ }).elements()).toHaveLength(0);
+		expect(
+			page.getByRole('checkbox', { name: /Make playlist (public|private)/ }).elements()
+		).toHaveLength(0);
 	});
 
 	it('inline name editing: clicking name shows input, Escape cancels', async () => {

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -164,7 +164,9 @@
 		}
 	}
 
-	const passwordPending = $derived(changePasswordMutation.isPending || setPasswordMutation.isPending);
+	const passwordPending = $derived(
+		changePasswordMutation.isPending || setPasswordMutation.isPending
+	);
 
 	function handleAvatarFile(file: File) {
 		if (!file.type.startsWith('image/')) return;
@@ -399,7 +401,10 @@
 					<div class="flex flex-col items-center gap-4 py-12 text-center">
 						<CircleAlert class="h-10 w-10 text-base-content/50" />
 						<p class="text-base-content/70">Failed to load profile</p>
-						<button class="btn btn-primary btn-sm gap-2" onclick={() => void profileQuery.refetch()}>
+						<button
+							class="btn btn-primary btn-sm gap-2"
+							onclick={() => void profileQuery.refetch()}
+						>
 							<RefreshCw class="h-4 w-4" />
 							Try Again
 						</button>
@@ -601,14 +606,17 @@
 										<button
 											onclick={() => void submitPassword()}
 											class="btn btn-primary btn-sm glow-primary-soft gap-1.5 rounded-full"
-											disabled={passwordPending || !newPassword || (hasLocalPassword && !currentPassword)}
+											disabled={passwordPending ||
+												!newPassword ||
+												(hasLocalPassword && !currentPassword)}
 										>
 											{#if passwordPending}
 												<span class="loading loading-spinner loading-xs"></span>
 											{/if}
 											{hasLocalPassword ? 'Update password' : 'Set password'}
 										</button>
-										<button onclick={togglePasswordForm} class="btn btn-ghost btn-sm">Cancel</button>
+										<button onclick={togglePasswordForm} class="btn btn-ghost btn-sm">Cancel</button
+										>
 									</div>
 								</div>
 							{/if}
@@ -724,7 +732,9 @@
 										<div class="flex flex-col items-center gap-1">
 											<div class="flex items-center gap-1.5 text-base-content/50">
 												<Users class="h-3.5 w-3.5" />
-												<span class="text-[10px] font-medium uppercase tracking-wider"> Artists </span>
+												<span class="text-[10px] font-medium uppercase tracking-wider">
+													Artists
+												</span>
 											</div>
 											<span class="text-xl font-bold tabular-nums">
 												{formatNumber(stats.total_artists)}

--- a/frontend/src/routes/requests/+page.svelte
+++ b/frontend/src/routes/requests/+page.svelte
@@ -630,6 +630,9 @@
 					<option value="importFailed">Import Failed</option>
 					<option value="importBlocked">Import Blocked</option>
 					<option value="cancelled">Cancelled</option>
+					{#if authStore.isAdmin}
+						<option value="reimportable">Can reimport</option>
+					{/if}
 				</select>
 
 				<select
@@ -702,6 +705,7 @@
 								: undefined}
 							onclear={handleClear}
 							onremoved={handleRemoved}
+							onreimported={loadHistory}
 						/>
 					{/each}
 				</div>


### PR DESCRIPTION
## What
allows reimport of a failed download after a user manually pushes it through in slskd

## Why
sometimes a few files may fail and this saves a full re-queue/re-download

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

## AI-Assisted Contributions

If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`)
- [x] Frontend lint passes (`make frontend-lint`)
- [x] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source
