### PR TITLE
Decrypt lidarr_api_key when loading settings at startup

### DIFF
--- a/backend/core/dependencies/cleanup.py
+++ b/backend/core/dependencies/cleanup.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 
 from core.config import get_settings
-from infrastructure.crypto import init_crypto
+from infrastructure.crypto import decrypt, init_crypto
 from infrastructure.http.client import close_http_clients
 
 from ._registry import clear_all_singletons
@@ -59,6 +59,18 @@ def clear_listenbrainz_dependent_caches() -> None:
 async def init_app_state(app) -> None:
     settings = get_settings()
     await asyncio.to_thread(init_crypto, settings.root_app_dir / "config")
+    # config.json stores lidarr_api_key encrypted at rest, but
+    # Settings.load_from_file() copies it in verbatim (it runs before
+    # crypto is up), so the Lidarr client sends Fernet ciphertext as
+    # X-Api-Key and gets 401s until the next settings save. Decrypt in
+    # place now that crypto is initialised; plaintext values pass through
+    # untouched (decrypt flags InvalidToken instead of raising).
+    for field in ("lidarr_api_key", "audiodb_api_key"):
+        value = getattr(settings, field, "")
+        if value:
+            plaintext, was_plaintext = decrypt(value)
+            if not was_plaintext:
+                setattr(settings, field, plaintext)
 
 
 async def cleanup_app_state() -> None:


### PR DESCRIPTION
## What

Decrypt `lidarr_api_key` (and `audiodb_api_key`) in place during `init_app_state`, right after `init_crypto`. Plaintext values pass through untouched since `decrypt()` flags `InvalidToken` instead of raising.

## Why

`Settings.load_from_file()` runs before `init_crypto` and copies `config.json` in verbatim. Saving Lidarr settings stores the key Fernet-encrypted (`preferences_service` encrypts at rest), so after any restart the Lidarr client sends the ciphertext as `X-Api-Key`. Every request 401s and the `lidarr` circuit breaker sticks open until someone re-saves the settings — the save path writes plaintext into the live `Settings` object, which masks the bug until the next restart.

## Testing

- [x] I have tested these changes locally
- [ ] I have added or updated tests

Reproduced and verified on a live deployment: before the patch, every restart produced `Lidarr GET failed (401)` + a stuck-open breaker; with it, Lidarr calls return 200 from boot. Confirmed the stored ciphertext decrypts to the correct key and that a plaintext key in `config.json` still passes through unchanged.

## AI-Assisted Contributions

Diagnosed and written with AI assistance (Claude Code): traced the settings-hydration order on a live instance and drafted the patch and this PR. Reviewed and tested by a human before submission.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`)
- [ ] Frontend lint passes (`make frontend-lint`)
- [ ] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source