### PR TITLE
fix(lidarr): monitor artist when requesting album for existing unmonitored artist

### DIFF
--- a/backend/api/v1/routes/jellyfin_library.py
+++ b/backend/api/v1/routes/jellyfin_library.py
@@ -47,15 +47,9 @@ router = APIRouter(route_class=MsgSpecRoute, prefix="/jellyfin", tags=["jellyfin
 @router.get("/hub", response_model=JellyfinHubResponse)
 async def get_jellyfin_hub(
     service: JellyfinLibraryService = Depends(get_jellyfin_library_service),
-    playlist_service: PlaylistService = Depends(get_playlist_service),
 ) -> JellyfinHubResponse:
     try:
-        hub = await service.get_hub_data()
-        imported_ids = await playlist_service.get_imported_source_ids("jellyfin:")
-        for p in hub.playlists:
-            if p.id in imported_ids:
-                p.is_imported = True
-        return hub
+        return await service.get_hub_data()
     except ExternalServiceError as e:
         logger.error("Jellyfin service error getting hub data: %s", e)
         raise HTTPException(status_code=502, detail="Failed to communicate with Jellyfin")

--- a/backend/api/v1/routes/navidrome_library.py
+++ b/backend/api/v1/routes/navidrome_library.py
@@ -62,15 +62,9 @@ _NEEDS_REVERSE: dict[tuple[str, str], bool] = {
 @router.get("/hub", response_model=NavidromeHubResponse)
 async def get_navidrome_hub(
     service: NavidromeLibraryService = Depends(get_navidrome_library_service),
-    playlist_service: PlaylistService = Depends(get_playlist_service),
 ) -> NavidromeHubResponse:
     try:
-        hub = await service.get_hub_data()
-        imported_ids = await playlist_service.get_imported_source_ids("navidrome:")
-        for p in hub.playlists:
-            if p.id in imported_ids:
-                p.is_imported = True
-        return hub
+        return await service.get_hub_data()
     except ExternalServiceError as e:
         logger.error("Navidrome service error getting hub data: %s", e)
         raise HTTPException(status_code=502, detail="Failed to communicate with Navidrome")

--- a/backend/api/v1/routes/plex_library.py
+++ b/backend/api/v1/routes/plex_library.py
@@ -54,15 +54,9 @@ _PLEX_SORT_FIELD: dict[str, str] = {
 @router.get("/hub", response_model=PlexHubResponse)
 async def get_plex_hub(
     service: PlexLibraryService = Depends(get_plex_library_service),
-    playlist_service: PlaylistService = Depends(get_playlist_service),
 ) -> PlexHubResponse:
     try:
-        hub = await service.get_hub_data()
-        imported_ids = await playlist_service.get_imported_source_ids("plex:")
-        for p in hub.playlists:
-            if p.id in imported_ids:
-                p.is_imported = True
-        return hub
+        return await service.get_hub_data()
     except ExternalServiceError as e:
         logger.error("Plex service error getting hub data: %s", e)
         raise HTTPException(status_code=502, detail="Failed to communicate with Plex")

--- a/backend/api/v1/schemas/jellyfin.py
+++ b/backend/api/v1/schemas/jellyfin.py
@@ -85,7 +85,6 @@ class JellyfinHubResponse(AppStruct):
     most_played_albums: list[JellyfinAlbumSummary] = []
     all_albums_preview: list[JellyfinAlbumSummary] = []
     genres: list[str] = []
-    playlists: list[JellyfinPlaylistSummary] = []
 
 
 class JellyfinPaginatedResponse(AppStruct):

--- a/backend/api/v1/schemas/navidrome.py
+++ b/backend/api/v1/schemas/navidrome.py
@@ -85,7 +85,6 @@ class NavidromeHubResponse(AppStruct):
     favorite_tracks: list[NavidromeTrackInfo] = []
     all_albums_preview: list[NavidromeAlbumSummary] = []
     genres: list[str] = []
-    playlists: list[NavidromePlaylistSummary] = []
 
 
 class NavidromeAlbumPage(AppStruct):

--- a/backend/api/v1/schemas/plex.py
+++ b/backend/api/v1/schemas/plex.py
@@ -114,7 +114,6 @@ class PlexHubResponse(AppStruct):
     recently_added: list[PlexAlbumSummary] = []
     all_albums_preview: list[PlexAlbumSummary] = []
     genres: list[str] = []
-    playlists: list[PlexPlaylistSummary] = []
 
 
 class PlexDiscoveryAlbum(AppStruct):

--- a/backend/repositories/jellyfin_repository.py
+++ b/backend/repositories/jellyfin_repository.py
@@ -797,7 +797,10 @@ class JellyfinRepository:
                 return []
             raw_items = result.get("Items", [])
             items = [parse_item(i) for i in raw_items]
-            await self._cache.set(cache_key, items, ttl_seconds=300)
+            # Don't cache an empty result: a cold/indexing Jellyfin can briefly
+            # return no playlists, and caching that would hide them for the full TTL.
+            if items:
+                await self._cache.set(cache_key, items, ttl_seconds=300)
             return items
         except Exception as e:  # noqa: BLE001
             logger.error(f"Failed to get Jellyfin playlists: {e}")

--- a/backend/repositories/lidarr/album.py
+++ b/backend/repositories/lidarr/album.py
@@ -414,6 +414,12 @@ class LidarrAlbumRepository(LidarrHistoryRepository):
             if not is_monitored:
                 album_obj = await self._update_album(album_id, {"monitored": True})
 
+            if not artist.get("monitored"):
+                await self._put(
+                    "/api/v1/artist/editor",
+                    {"artistIds": [artist_id], "monitored": True, "monitorNewItems": "none"},
+                )
+
             try:
                 await self._post_command({"name": "AlbumSearch", "albumIds": [album_id]})
             except ExternalServiceError:

--- a/backend/repositories/navidrome_repository.py
+++ b/backend/repositories/navidrome_repository.py
@@ -488,7 +488,10 @@ class NavidromeRepository:
                     duration=p.get("duration", 0),
                 )
             )
-        await self._cache.set(cache_key, playlists, self._ttl_list)
+        # Don't cache an empty result: a source that briefly returns no playlists
+        # would otherwise hide them for the full TTL.
+        if playlists:
+            await self._cache.set(cache_key, playlists, self._ttl_list)
         return playlists
 
     async def get_playlist(self, id: str) -> SubsonicPlaylist:

--- a/backend/repositories/plex_repository.py
+++ b/backend/repositories/plex_repository.py
@@ -464,7 +464,10 @@ class PlexRepository:
         )
         raw = container.get("Metadata", [])
         playlists = [parse_playlist(p) for p in raw]
-        await self._cache.set(cache_key, playlists, self._ttl_list)
+        # Don't cache an empty result: a source that briefly returns no playlists
+        # would otherwise hide them for the full TTL.
+        if playlists:
+            await self._cache.set(cache_key, playlists, self._ttl_list)
         return playlists
 
     async def get_playlist_items(self, rating_key: str) -> list[PlexTrack]:

--- a/backend/services/jellyfin_library_service.py
+++ b/backend/services/jellyfin_library_service.py
@@ -575,7 +575,6 @@ class JellyfinLibraryService:
             asyncio.wait_for(self.get_recently_added(limit=20), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_most_played_artists(limit=10), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_most_played_albums(limit=10), timeout=_HUB_TIMEOUT),
-            asyncio.wait_for(self.list_playlists(limit=20), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_genres(), timeout=_HUB_TIMEOUT),
             return_exceptions=True,
         )
@@ -615,13 +614,9 @@ class JellyfinLibraryService:
         if isinstance(results[6], BaseException):
             logger.warning("Hub: get_most_played_albums failed: %s", results[6])
 
-        playlists = results[7] if not isinstance(results[7], BaseException) else []
+        genres = results[7] if not isinstance(results[7], BaseException) else []
         if isinstance(results[7], BaseException):
-            logger.warning("Hub: list_playlists failed: %s", results[7])
-
-        genres = results[8] if not isinstance(results[8], BaseException) else []
-        if isinstance(results[8], BaseException):
-            logger.warning("Hub: get_genres failed: %s", results[8])
+            logger.warning("Hub: get_genres failed: %s", results[7])
 
         return JellyfinHubResponse(
             stats=stats,
@@ -631,7 +626,6 @@ class JellyfinLibraryService:
             most_played_artists=most_played_artists,
             most_played_albums=most_played_albums,
             all_albums_preview=all_albums_preview,
-            playlists=playlists,
             genres=genres,
         )
 

--- a/backend/services/navidrome_library_service.py
+++ b/backend/services/navidrome_library_service.py
@@ -692,7 +692,6 @@ class NavidromeLibraryService:
             asyncio.wait_for(self.get_favorites(), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_albums(size=12), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_stats(), timeout=_HUB_TIMEOUT),
-            asyncio.wait_for(self.list_playlists(limit=20), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_genres(), timeout=_HUB_TIMEOUT),
             return_exceptions=True,
         )
@@ -724,13 +723,9 @@ class NavidromeLibraryService:
         if isinstance(results[3], BaseException):
             logger.warning("Hub: get_stats failed: %s", results[3])
 
-        playlists = results[4] if not isinstance(results[4], BaseException) else []
+        genres = results[4] if not isinstance(results[4], BaseException) else []
         if isinstance(results[4], BaseException):
-            logger.warning("Hub: list_playlists failed: %s", results[4])
-
-        genres = results[5] if not isinstance(results[5], BaseException) else []
-        if isinstance(results[5], BaseException):
-            logger.warning("Hub: get_genres failed: %s", results[5])
+            logger.warning("Hub: get_genres failed: %s", results[4])
 
         return NavidromeHubResponse(
             stats=stats,
@@ -739,7 +734,6 @@ class NavidromeLibraryService:
             favorite_artists=favorite_artists,
             favorite_tracks=favorite_tracks,
             all_albums_preview=all_albums_preview,
-            playlists=playlists,
             genres=genres,
         )
 

--- a/backend/services/plex_library_service.py
+++ b/backend/services/plex_library_service.py
@@ -824,7 +824,6 @@ class PlexLibraryService:
             asyncio.wait_for(self.get_albums(size=12), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_stats(), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_recently_added_albums(limit=20), timeout=_HUB_TIMEOUT),
-            asyncio.wait_for(self.list_playlists(limit=20), timeout=_HUB_TIMEOUT),
             asyncio.wait_for(self.get_genres(), timeout=_HUB_TIMEOUT),
             return_exceptions=True,
         )
@@ -852,20 +851,15 @@ class PlexLibraryService:
         if isinstance(results[3], BaseException):
             logger.warning("Hub: get_recently_added_albums failed: %s", results[3])
 
-        playlists = results[4] if not isinstance(results[4], BaseException) else []
+        genres = results[4] if not isinstance(results[4], BaseException) else []
         if isinstance(results[4], BaseException):
-            logger.warning("Hub: list_playlists failed: %s", results[4])
-
-        genres = results[5] if not isinstance(results[5], BaseException) else []
-        if isinstance(results[5], BaseException):
-            logger.warning("Hub: get_genres failed: %s", results[5])
+            logger.warning("Hub: get_genres failed: %s", results[4])
 
         return PlexHubResponse(
             stats=stats,
             recently_played=recently_played,
             recently_added=recently_added,
             all_albums_preview=all_albums_preview,
-            playlists=playlists,
             genres=genres,
         )
 

--- a/frontend/src/lib/actions/reveal.ts
+++ b/frontend/src/lib/actions/reveal.ts
@@ -8,10 +8,12 @@ if (typeof window !== 'undefined') {
 }
 
 export function reveal(node: HTMLElement, options?: { threshold?: number; stagger?: number }) {
-	const threshold = options?.threshold ?? 0.2;
+	// threshold 0, not a ratio: a ratio is unreachable for elements taller than
+	// 1/ratio viewports, leaving them invisible while still occupying layout space.
+	const threshold = options?.threshold ?? 0;
 	const stagger = options?.stagger ?? 50;
 
-	if (reducedMotion) {
+	if (reducedMotion || typeof IntersectionObserver === 'undefined') {
 		node.classList.add('revealed');
 		return { destroy() {} };
 	}

--- a/frontend/src/lib/components/settings/SettingsSecurity.svelte
+++ b/frontend/src/lib/components/settings/SettingsSecurity.svelte
@@ -452,10 +452,13 @@
 							type="url"
 							bind:value={oidcForm.data.redirect_uri}
 							class="input input-bordered w-full"
-							placeholder="https://musicseerr.example.com/auth/callback"
+							placeholder="https://musicseerr.example.com/api/v1/auth/oidc/callback"
 						/>
 						<p class="text-xs text-base-content/50 mt-1.5 ml-1">
-							Register this exact URL as a redirect/callback URI with your provider.
+							This must point to the Musicseerr <strong>backend API</strong>, not the web app page.
+							Register this exact URL (ending in
+							<code class="text-xs">/api/v1/auth/oidc/callback</code>) as a redirect/callback URI
+							with your provider.
 						</p>
 					</div>
 

--- a/frontend/src/lib/queries/playlists/SourcePlaylistsQuery.svelte.ts
+++ b/frontend/src/lib/queries/playlists/SourcePlaylistsQuery.svelte.ts
@@ -1,0 +1,27 @@
+import { api } from '$lib/api/client';
+import { API, CACHE_TTL } from '$lib/constants';
+import type { SourcePlaylistSummary } from '$lib/types';
+import { createQuery } from '@tanstack/svelte-query';
+import {
+	SourcePlaylistsQueryKeyFactory,
+	type PlaylistSource
+} from './SourcePlaylistsQueryKeyFactory';
+
+const PLAYLIST_ENDPOINTS: Record<PlaylistSource, (limit: number) => string> = {
+	jellyfin: API.jellyfinLibrary.playlists,
+	plex: API.plexLibrary.playlists,
+	navidrome: API.navidromeLibrary.playlists
+};
+
+// Fetched separately from the library hub so a slow playlists call can't stall or
+// blank the rest of the hub (the hub gathers its calls behind one short timeout).
+// refetchOnMount revalidates in the background so a transient empty result self-heals.
+export const getSourcePlaylistsQuery = (source: PlaylistSource, limit = 200) =>
+	createQuery(() => ({
+		staleTime: CACHE_TTL.PLAYLIST_SOURCES,
+		queryKey: SourcePlaylistsQueryKeyFactory.list(source, limit),
+		queryFn: ({ signal }) =>
+			api.get<SourcePlaylistSummary[]>(PLAYLIST_ENDPOINTS[source](limit), { signal }),
+		retry: 2,
+		refetchOnMount: 'always'
+	}));

--- a/frontend/src/lib/queries/playlists/SourcePlaylistsQueryKeyFactory.ts
+++ b/frontend/src/lib/queries/playlists/SourcePlaylistsQueryKeyFactory.ts
@@ -1,0 +1,7 @@
+export type PlaylistSource = 'jellyfin' | 'plex' | 'navidrome';
+
+export const SourcePlaylistsQueryKeyFactory = {
+	prefix: ['source-playlists'] as const,
+	list: (source: PlaylistSource, limit: number) =>
+		[...SourcePlaylistsQueryKeyFactory.prefix, source, limit] as const
+};

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1138,7 +1138,6 @@ export type PlexHubResponse = {
 	recently_played: PlexAlbumSummary[];
 	recently_added: PlexAlbumSummary[];
 	all_albums_preview: PlexAlbumSummary[];
-	playlists: SourcePlaylistSummary[];
 	genres: string[];
 };
 
@@ -1167,7 +1166,6 @@ export type NavidromeHubResponse = {
 	favorite_artists: NavidromeArtistSummary[];
 	favorite_tracks: NavidromeTrackInfo[];
 	all_albums_preview: NavidromeAlbumSummary[];
-	playlists: SourcePlaylistSummary[];
 	genres: string[];
 };
 
@@ -1179,7 +1177,6 @@ export type JellyfinHubResponse = {
 	most_played_artists: JellyfinArtistSummary[];
 	most_played_albums: JellyfinAlbumSummary[];
 	all_albums_preview: JellyfinAlbumSummary[];
-	playlists: SourcePlaylistSummary[];
 	genres: string[];
 };
 

--- a/frontend/src/routes/library/jellyfin/+page.svelte
+++ b/frontend/src/routes/library/jellyfin/+page.svelte
@@ -23,6 +23,7 @@
 	import ArtistIndexSidebar from '$lib/components/ArtistIndexSidebar.svelte';
 	import { playerStore } from '$lib/stores/player.svelte';
 	import { nowPlayingMerged } from '$lib/stores/nowPlayingMerged.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import { buildDiscoveryQueueFromJellyfin } from '$lib/player/queueHelpers';
 	import { formatDurationSec as formatDuration } from '$lib/utils/formatting';
 	import { reveal } from '$lib/actions/reveal';
@@ -75,6 +76,9 @@
 	);
 
 	let jellyfinSessions = $derived(nowPlayingMerged.sessionsForSource('jellyfin'));
+
+	const playlistsQuery = getSourcePlaylistsQuery('jellyfin');
+	let playlists = $derived(playlistsQuery.data ?? []);
 
 	let refreshing = $state(false);
 
@@ -266,9 +270,9 @@
 
 	<BrowseHeroCards cards={browseCards} />
 
-	{#if hub && hub.playlists.length > 0}
+	{#if playlists.length > 0}
 		<PlaylistImportBanner
-			playlists={hub.playlists}
+			{playlists}
 			sourceLabel="Jellyfin"
 			playlistsHref="/library/jellyfin/playlists"
 		>

--- a/frontend/src/routes/library/jellyfin/playlists/+page.svelte
+++ b/frontend/src/routes/library/jellyfin/playlists/+page.svelte
@@ -1,30 +1,11 @@
 <script lang="ts">
-	import { API } from '$lib/constants';
-	import { api } from '$lib/api/client';
 	import BackButton from '$lib/components/BackButton.svelte';
 	import SourcePlaylistCard from '$lib/components/SourcePlaylistCard.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import { Tv } from 'lucide-svelte';
-	import type { SourcePlaylistSummary } from '$lib/types';
 
-	let playlists = $state<SourcePlaylistSummary[]>([]);
-	let loading = $state(true);
-	let error = $state('');
-
-	$effect(() => {
-		loadPlaylists();
-	});
-
-	async function loadPlaylists() {
-		loading = true;
-		error = '';
-		try {
-			playlists = await api.get<SourcePlaylistSummary[]>(API.jellyfinLibrary.playlists(200));
-		} catch {
-			error = "Couldn't load playlists.";
-		} finally {
-			loading = false;
-		}
-	}
+	const playlistsQuery = getSourcePlaylistsQuery('jellyfin');
+	let playlists = $derived(playlistsQuery.data ?? []);
 </script>
 
 <div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
@@ -34,12 +15,12 @@
 		<h1 class="text-2xl font-bold">Jellyfin Playlists</h1>
 	</div>
 
-	{#if loading}
+	{#if playlistsQuery.isPending}
 		<div class="flex justify-center py-12">
 			<span class="loading loading-spinner loading-lg"></span>
 		</div>
-	{:else if error}
-		<div class="alert alert-error">{error}</div>
+	{:else if playlistsQuery.isError}
+		<div class="alert alert-error">Couldn't load playlists.</div>
 	{:else if playlists.length === 0}
 		<p class="text-base-content/50 text-center py-12">No playlists were found in Jellyfin.</p>
 	{:else}

--- a/frontend/src/routes/library/navidrome/+page.svelte
+++ b/frontend/src/routes/library/navidrome/+page.svelte
@@ -17,6 +17,7 @@
 	import PlaylistImportBanner from '$lib/components/PlaylistImportBanner.svelte';
 	import NowPlayingWidget from '$lib/components/NowPlayingWidget.svelte';
 	import { nowPlayingMerged } from '$lib/stores/nowPlayingMerged.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import NavidromeIcon from '$lib/components/NavidromeIcon.svelte';
 	import ArtistIndexSidebar from '$lib/components/ArtistIndexSidebar.svelte';
 	import GenreSongsBrowser from '$lib/components/GenreSongsBrowser.svelte';
@@ -77,6 +78,9 @@
 	);
 
 	let navidromeSessions = $derived(nowPlayingMerged.sessionsForSource('navidrome'));
+
+	const playlistsQuery = getSourcePlaylistsQuery('navidrome');
+	let playlists = $derived(playlistsQuery.data ?? []);
 
 	let refreshing = $state(false);
 
@@ -313,9 +317,9 @@
 
 	<BrowseHeroCards cards={browseCards} />
 
-	{#if hub && hub.playlists.length > 0}
+	{#if playlists.length > 0}
 		<PlaylistImportBanner
-			playlists={hub.playlists}
+			{playlists}
 			sourceLabel="Navidrome"
 			playlistsHref="/library/navidrome/playlists"
 		>

--- a/frontend/src/routes/library/navidrome/playlists/+page.svelte
+++ b/frontend/src/routes/library/navidrome/playlists/+page.svelte
@@ -1,30 +1,11 @@
 <script lang="ts">
-	import { API } from '$lib/constants';
-	import { api } from '$lib/api/client';
 	import BackButton from '$lib/components/BackButton.svelte';
 	import SourcePlaylistCard from '$lib/components/SourcePlaylistCard.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import NavidromeIcon from '$lib/components/NavidromeIcon.svelte';
-	import type { SourcePlaylistSummary } from '$lib/types';
 
-	let playlists = $state<SourcePlaylistSummary[]>([]);
-	let loading = $state(true);
-	let error = $state('');
-
-	$effect(() => {
-		loadPlaylists();
-	});
-
-	async function loadPlaylists() {
-		loading = true;
-		error = '';
-		try {
-			playlists = await api.get<SourcePlaylistSummary[]>(API.navidromeLibrary.playlists(200));
-		} catch {
-			error = "Couldn't load playlists.";
-		} finally {
-			loading = false;
-		}
-	}
+	const playlistsQuery = getSourcePlaylistsQuery('navidrome');
+	let playlists = $derived(playlistsQuery.data ?? []);
 </script>
 
 <div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
@@ -34,12 +15,12 @@
 		<h1 class="text-2xl font-bold">Navidrome Playlists</h1>
 	</div>
 
-	{#if loading}
+	{#if playlistsQuery.isPending}
 		<div class="flex justify-center py-12">
 			<span class="loading loading-spinner loading-lg"></span>
 		</div>
-	{:else if error}
-		<div class="alert alert-error">{error}</div>
+	{:else if playlistsQuery.isError}
+		<div class="alert alert-error">Couldn't load playlists.</div>
 	{:else if playlists.length === 0}
 		<p class="text-base-content/50 text-center py-12">No playlists were found in Navidrome.</p>
 	{:else}

--- a/frontend/src/routes/library/plex/+page.svelte
+++ b/frontend/src/routes/library/plex/+page.svelte
@@ -19,6 +19,7 @@
 	import NowPlayingWidget from '$lib/components/NowPlayingWidget.svelte';
 	import ArtistIndexSidebar from '$lib/components/ArtistIndexSidebar.svelte';
 	import { nowPlayingMerged } from '$lib/stores/nowPlayingMerged.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { toastStore } from '$lib/stores/toast';
 	import { buildDiscoveryQueueFromPlex } from '$lib/player/queueHelpers';
@@ -73,6 +74,9 @@
 	);
 
 	let plexSessions = $derived(nowPlayingMerged.sessionsForSource('plex'));
+
+	const playlistsQuery = getSourcePlaylistsQuery('plex');
+	let playlists = $derived(playlistsQuery.data ?? []);
 
 	let refreshing = $state(false);
 
@@ -297,12 +301,8 @@
 
 	<BrowseHeroCards cards={browseCards} />
 
-	{#if hub && hub.playlists.length > 0}
-		<PlaylistImportBanner
-			playlists={hub.playlists}
-			sourceLabel="Plex"
-			playlistsHref="/library/plex/playlists"
-		>
+	{#if playlists.length > 0}
+		<PlaylistImportBanner {playlists} sourceLabel="Plex" playlistsHref="/library/plex/playlists">
 			{#snippet sourceIcon()}
 				<PlexIcon class="h-4 w-4" style="color: rgb(var(--brand-plex));" />
 			{/snippet}

--- a/frontend/src/routes/library/plex/playlists/+page.svelte
+++ b/frontend/src/routes/library/plex/playlists/+page.svelte
@@ -1,30 +1,11 @@
 <script lang="ts">
-	import { API } from '$lib/constants';
-	import { api } from '$lib/api/client';
 	import BackButton from '$lib/components/BackButton.svelte';
 	import SourcePlaylistCard from '$lib/components/SourcePlaylistCard.svelte';
+	import { getSourcePlaylistsQuery } from '$lib/queries/playlists/SourcePlaylistsQuery.svelte';
 	import PlexIcon from '$lib/components/PlexIcon.svelte';
-	import type { SourcePlaylistSummary } from '$lib/types';
 
-	let playlists = $state<SourcePlaylistSummary[]>([]);
-	let loading = $state(true);
-	let error = $state('');
-
-	$effect(() => {
-		loadPlaylists();
-	});
-
-	async function loadPlaylists() {
-		loading = true;
-		error = '';
-		try {
-			playlists = await api.get<SourcePlaylistSummary[]>(API.plexLibrary.playlists(200));
-		} catch {
-			error = "Couldn't load playlists.";
-		} finally {
-			loading = false;
-		}
-	}
+	const playlistsQuery = getSourcePlaylistsQuery('plex');
+	let playlists = $derived(playlistsQuery.data ?? []);
 </script>
 
 <div class="max-w-6xl mx-auto px-4 py-6 space-y-6">
@@ -34,12 +15,12 @@
 		<h1 class="text-2xl font-bold">Plex Playlists</h1>
 	</div>
 
-	{#if loading}
+	{#if playlistsQuery.isPending}
 		<div class="flex justify-center py-12">
 			<span class="loading loading-spinner loading-lg"></span>
 		</div>
-	{:else if error}
-		<div class="alert alert-error">{error}</div>
+	{:else if playlistsQuery.isError}
+		<div class="alert alert-error">Couldn't load playlists.</div>
 	{:else if playlists.length === 0}
 		<p class="text-base-content/50 text-center py-12">No playlists were found in Plex.</p>
 	{:else}


### PR DESCRIPTION
## Summary
When requesting an album whose artist already exists in Lidarr but is **unmonitored**, only the album gets `monitored: true`. The artist stays unmonitored — which breaks fulfillment tools that gate on artist monitored status. **Soularr** is the big one: it only searches wanted albums whose *artist* is also monitored, so these requests silently never download.

Repro:
1. Request album A by a new artist → artist created unmonitored (`_ensure_artist_exists`), album monitored ✅ but artist unmonitored
2. Soularr ignores it forever; same for any subsequent album request for that artist (the `if not is_monitored` path never touches the artist)

## Fix
In the existing-artist path of the album add flow, mirror what `_monitor_artist_and_album(set_artist_monitored=True)` already does for newly-created artists: if the artist is unmonitored, flip `monitored: true` via `artist/editor` while keeping `monitorNewItems: none` — so the album-granular request model is preserved and no discography hunting is triggered.

## Notes
- Marked draft: happy to adjust placement/style, or extend the same guard to the new-artist path if you'd rather centralize it.
- Tested against Lidarr 3.1.3 nightly + Soularr: with this patch a request for an existing-unmonitored artist becomes visible to Soularr and downloads immediately; `monitorNewItems` stays `none`.
- Separate issue I can file too: after container restart, `Settings.lidarr_api_key` holds the *encrypted* config.json value until settings are re-saved (secrets aren't hydrated through `_read_secret` at startup), so every Lidarr call 401s and the circuit breaker opens. I worked around it locally by hydrating in `init_app_state`; will open as its own issue/PR if useful.