### PR TITLE
(feat): per-user listen history based weekly mix playlist

### DIFF
--- a/backend/api/v1/routes/me_connections.py
+++ b/backend/api/v1/routes/me_connections.py
@@ -19,6 +19,7 @@ from api.v1.schemas.me_connections import (
     ConnectionsResponse,
     ConnectionStatus,
     ListenBrainzConnectRequest,
+    PersonalMixRefreshResponse,
     ScrobblePreferences,
     ScrobblePreferencesUpdate,
     SpotifyAuthUrlResponse,
@@ -39,6 +40,7 @@ from core.dependencies import (
     get_lastfm_auth_service,
     get_now_playing_service,
     get_per_user_client_factory,
+    get_personal_mix_service,
     get_preferences_service,
     get_settings_service,
     get_user_connections_store,
@@ -58,6 +60,7 @@ from infrastructure.persistence.user_section_prefs_store import UserSectionPrefs
 from middleware import CurrentUserDep
 from services.lastfm_auth_service import LastFmAuthService
 from services.per_user_client_factory import PerUserClientFactory
+from services.personal_mix_service import PersonalMixService
 from services.preferences_service import PreferencesService
 from services.section_catalog import Page, sections_for, valid_keys
 from services.settings_service import SettingsService
@@ -95,6 +98,7 @@ async def get_scrobble_preferences(
         scrobble_to_listenbrainz=prefs.scrobble_to_listenbrainz,
         primary_music_source=prefs.primary_music_source,
         now_playing_visibility=prefs.now_playing_visibility,
+        auto_request_personal_mix=prefs.auto_request_personal_mix,
     )
 
 
@@ -111,6 +115,7 @@ async def update_scrobble_preferences(
         scrobble_to_listenbrainz=body.scrobble_to_listenbrainz,
         primary_music_source=body.primary_music_source,
         now_playing_visibility=body.now_playing_visibility,
+        auto_request_personal_mix=body.auto_request_personal_mix,
     )
     # apply the privacy change to the live presence feed immediately
     if body.now_playing_visibility is not None:
@@ -123,6 +128,24 @@ async def update_scrobble_preferences(
         scrobble_to_listenbrainz=prefs.scrobble_to_listenbrainz,
         primary_music_source=prefs.primary_music_source,
         now_playing_visibility=prefs.now_playing_visibility,
+        auto_request_personal_mix=prefs.auto_request_personal_mix,
+    )
+
+
+@router.post("/personal-mix/refresh", response_model=PersonalMixRefreshResponse)
+async def refresh_personal_mix(
+    current_user: CurrentUserDep,
+    personal_mix_service: PersonalMixService = Depends(get_personal_mix_service),
+) -> PersonalMixRefreshResponse:
+    result = await personal_mix_service.build_for_user(current_user.id, force=True)
+    if result.skipped and result.reason == "listenbrainz_not_linked":
+        raise HTTPException(status_code=400, detail="Connect ListenBrainz first to build Your Weekly Mix")
+    return PersonalMixRefreshResponse(
+        playlist_id=result.playlist_id,
+        track_count=result.track_count,
+        requested_albums=result.requested_albums,
+        skipped=result.skipped,
+        reason=result.reason,
     )
 
 

--- a/backend/api/v1/schemas/me_connections.py
+++ b/backend/api/v1/schemas/me_connections.py
@@ -25,6 +25,7 @@ class ScrobblePreferences(AppStruct):
     primary_music_source: str = "listenbrainz"
     # now-playing presence visibility to other users
     now_playing_visibility: str = "full"
+    auto_request_personal_mix: bool = False
 
 
 class ScrobblePreferencesUpdate(AppStruct):
@@ -32,6 +33,15 @@ class ScrobblePreferencesUpdate(AppStruct):
     scrobble_to_listenbrainz: bool | None = None
     primary_music_source: Literal["listenbrainz", "lastfm"] | None = None
     now_playing_visibility: Literal["full", "track_hidden", "offline"] | None = None
+    auto_request_personal_mix: bool | None = None
+
+
+class PersonalMixRefreshResponse(AppStruct):
+    playlist_id: str | None = None
+    track_count: int = 0
+    requested_albums: int = 0
+    skipped: bool = False
+    reason: str = ""
 
 
 class ListenBrainzConnectRequest(AppStruct):

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -83,6 +83,7 @@ from .service_providers import (  # noqa: F401
     get_artist_service,
     get_follow_service,
     get_new_release_service,
+    get_personal_mix_service,
     get_album_service,
     get_request_service,
     get_requests_page_service,

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -215,6 +215,23 @@ def get_new_release_service() -> "NewReleaseService":
 
 
 @singleton
+def get_personal_mix_service() -> "PersonalMixService":
+    from services.personal_mix_service import PersonalMixService
+    from core.dependencies.auth_providers import get_auth_store
+
+    return PersonalMixService(
+        client_factory=get_per_user_client_factory(),
+        mb_repo=get_musicbrainz_repository(),
+        library_repo=get_library_repository(),
+        playlist_service=get_playlist_service(),
+        download_service=get_download_service(),
+        listening_prefs_store=get_user_listening_prefs_store(),
+        connections_store=get_user_connections_store(),
+        auth_store=get_auth_store(),
+    )
+
+
+@singleton
 def get_album_service() -> "AlbumService":
     from services.album_service import AlbumService
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from infrastructure.persistence.youtube_store import YouTubeStore
     from services.requests_page_service import RequestsPageService
     from services.native.new_release_service import NewReleaseService
+    from services.personal_mix_service import PersonalMixService
     from repositories.coverart_disk_cache import CoverDiskCache
 
 logger = logging.getLogger(__name__)
@@ -921,6 +922,37 @@ def start_poll_new_releases_task(
         poll_followed_artists_new_releases(new_release_service)
     )
     TaskRegistry.get_instance().register("follow-new-release-poll", task)
+    return task
+
+
+_PERSONAL_MIX_REFRESH_INTERVAL = 86400
+_PERSONAL_MIX_INITIAL_DELAY = 300
+
+
+async def refresh_personal_mixes_periodically(
+    personal_mix_service: 'PersonalMixService',
+    interval: int = _PERSONAL_MIX_REFRESH_INTERVAL,
+) -> None:
+    await asyncio.sleep(_PERSONAL_MIX_INITIAL_DELAY)
+
+    while True:
+        try:
+            await personal_mix_service.run_for_all_users()
+        except asyncio.CancelledError:
+            break
+        except Exception as e:
+            logger.error(f"Personal mix refresh failed: {e}", exc_info=True)
+
+        await asyncio.sleep(interval)
+
+
+def start_personal_mix_refresh_task(
+    personal_mix_service: 'PersonalMixService',
+) -> asyncio.Task:
+    task = asyncio.create_task(
+        refresh_personal_mixes_periodically(personal_mix_service)
+    )
+    TaskRegistry.get_instance().register("personal-mix-refresh", task)
     return task
 
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -941,7 +941,7 @@ async def refresh_personal_mixes_periodically(
         except asyncio.CancelledError:
             break
         except Exception as e:
-            logger.error(f"Personal mix refresh failed: {e}", exc_info=True)
+            logger.error("Personal mix refresh failed: %s", e, exc_info=True)
 
         await asyncio.sleep(interval)
 

--- a/backend/infrastructure/persistence/user_connections_store.py
+++ b/backend/infrastructure/persistence/user_connections_store.py
@@ -195,6 +195,16 @@ class UserConnectionsStore:
                 return str(token)
         return None
 
+    async def list_user_ids_for_service(self, service: str) -> list[str]:
+        def operation(conn: sqlite3.Connection) -> list[sqlite3.Row]:
+            return conn.execute(
+                "SELECT user_id FROM user_connections WHERE service = ? AND enabled = 1",
+                (service,),
+            ).fetchall()
+
+        rows = await self._read(operation)
+        return [row["user_id"] for row in rows]
+
     async def set_enabled(self, user_id: str, service: str, enabled: bool) -> None:
         now = datetime.now(timezone.utc).isoformat()
 

--- a/backend/infrastructure/persistence/user_listening_prefs_store.py
+++ b/backend/infrastructure/persistence/user_listening_prefs_store.py
@@ -27,6 +27,7 @@ class UserListeningPrefsRecord(msgspec.Struct, frozen=True):
     scrobble_to_listenbrainz: bool
     primary_music_source: str
     now_playing_visibility: str
+    auto_request_personal_mix: bool
     updated_at: str
 
 
@@ -67,6 +68,14 @@ class UserListeningPrefsStore:
                 conn.execute(
                     "ALTER TABLE user_listening_prefs "
                     "ADD COLUMN now_playing_visibility TEXT NOT NULL DEFAULT 'full'"
+                )
+            except sqlite3.OperationalError:
+                pass  # column already present
+            # additive, idempotent: DBs created before the personal-mix feature lack the column
+            try:
+                conn.execute(
+                    "ALTER TABLE user_listening_prefs "
+                    "ADD COLUMN auto_request_personal_mix INTEGER NOT NULL DEFAULT 0"
                 )
             except sqlite3.OperationalError:
                 pass  # column already present
@@ -114,6 +123,7 @@ class UserListeningPrefsStore:
                 scrobble_to_listenbrainz=False,
                 primary_music_source=_DEFAULT_SOURCE,
                 now_playing_visibility=_DEFAULT_VISIBILITY,
+                auto_request_personal_mix=False,
                 updated_at="",
             )
         return UserListeningPrefsRecord(
@@ -122,6 +132,7 @@ class UserListeningPrefsStore:
             scrobble_to_listenbrainz=bool(row["scrobble_to_listenbrainz"]),
             primary_music_source=row["primary_music_source"],
             now_playing_visibility=row["now_playing_visibility"],
+            auto_request_personal_mix=bool(row["auto_request_personal_mix"]),
             updated_at=row["updated_at"],
         )
 
@@ -133,6 +144,7 @@ class UserListeningPrefsStore:
         scrobble_to_listenbrainz: bool | None = None,
         primary_music_source: str | None = None,
         now_playing_visibility: str | None = None,
+        auto_request_personal_mix: bool | None = None,
     ) -> None:
         """Partial upsert: only the provided fields change; others are preserved."""
         now = datetime.now(timezone.utc).isoformat()
@@ -143,24 +155,32 @@ class UserListeningPrefsStore:
         ins_visibility = (
             now_playing_visibility if now_playing_visibility is not None else _DEFAULT_VISIBILITY
         )
+        ins_auto_request = (
+            int(auto_request_personal_mix) if auto_request_personal_mix is not None else 0
+        )
         # on UPDATE, NULL keeps the existing column value via COALESCE
         upd_lastfm = int(scrobble_to_lastfm) if scrobble_to_lastfm is not None else None
         upd_lb = int(scrobble_to_listenbrainz) if scrobble_to_listenbrainz is not None else None
         upd_source = primary_music_source
         upd_visibility = now_playing_visibility
+        upd_auto_request = (
+            int(auto_request_personal_mix) if auto_request_personal_mix is not None else None
+        )
 
         def operation(conn: sqlite3.Connection) -> None:
             conn.execute(
                 """
                 INSERT INTO user_listening_prefs (
                     user_id, scrobble_to_lastfm, scrobble_to_listenbrainz,
-                    primary_music_source, now_playing_visibility, updated_at
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                    primary_music_source, now_playing_visibility,
+                    auto_request_personal_mix, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(user_id) DO UPDATE SET
                     scrobble_to_lastfm = COALESCE(?, scrobble_to_lastfm),
                     scrobble_to_listenbrainz = COALESCE(?, scrobble_to_listenbrainz),
                     primary_music_source = COALESCE(?, primary_music_source),
                     now_playing_visibility = COALESCE(?, now_playing_visibility),
+                    auto_request_personal_mix = COALESCE(?, auto_request_personal_mix),
                     updated_at = excluded.updated_at
                 """,
                 (
@@ -169,11 +189,13 @@ class UserListeningPrefsStore:
                     ins_lb,
                     ins_source,
                     ins_visibility,
+                    ins_auto_request,
                     now,
                     upd_lastfm,
                     upd_lb,
                     upd_source,
                     upd_visibility,
+                    upd_auto_request,
                 ),
             )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from core.dependencies import (
     init_app_state, 
     cleanup_app_state
 )
-from core.tasks import start_cache_cleanup_task, start_library_auto_scan_task, start_disk_cache_cleanup_task, start_genre_cache_warming_task, start_artist_discovery_cache_warming_task, start_audiodb_sweep_task, start_request_status_sync_task, start_memory_maintenance_task, start_poll_new_releases_task, start_discover_home_warmer_task
+from core.tasks import start_cache_cleanup_task, start_library_auto_scan_task, start_disk_cache_cleanup_task, start_genre_cache_warming_task, start_artist_discovery_cache_warming_task, start_audiodb_sweep_task, start_request_status_sync_task, start_memory_maintenance_task, start_poll_new_releases_task, start_discover_home_warmer_task, start_personal_mix_refresh_task
 from core.task_registry import TaskRegistry
 from core.config import get_settings
 from core.dependencies.auth_providers import get_auth_service, get_auth_store
@@ -525,6 +525,9 @@ async def lifespan(app: FastAPI):
 
     from core.dependencies import get_new_release_service
     start_poll_new_releases_task(get_new_release_service())
+
+    from core.dependencies import get_personal_mix_service
+    start_personal_mix_refresh_task(get_personal_mix_service())
 
     from core.tasks import start_orphan_cover_demotion_task, start_store_prune_task
     from core.dependencies import get_request_history_store, get_mbid_store, get_youtube_store

--- a/backend/services/personal_mix_service.py
+++ b/backend/services/personal_mix_service.py
@@ -143,7 +143,7 @@ class PersonalMixService:
             try:
                 result = await self.build_for_user(user_id)
             except Exception:  # noqa: BLE001 - one user must never kill the run
-                logger.error(f"Personal mix build failed for user {user_id}", exc_info=True)
+                logger.error("Personal mix build failed for user %s", user_id, exc_info=True)
                 errors += 1
                 continue
             if result.skipped:
@@ -153,7 +153,7 @@ class PersonalMixService:
         summary = PersonalMixSummary(
             users_considered=len(user_ids), built=built, skipped=skipped, errors=errors,
         )
-        logger.info(f"Personal mix refresh complete: {summary}")
+        logger.info("Personal mix refresh complete: %s", summary)
         return summary
 
     @staticmethod
@@ -195,7 +195,7 @@ class PersonalMixService:
                 playlist = await lb_repo.get_playlist_tracks(entry["playlist_id"])
             except Exception:  # noqa: BLE001
                 logger.debug(
-                    f"Personal mix: failed to fetch playlist {entry.get('playlist_id')}", exc_info=True,
+                    "Personal mix: failed to fetch playlist %s", entry.get("playlist_id"), exc_info=True,
                 )
                 continue
             if not playlist or not playlist.tracks:
@@ -248,7 +248,7 @@ class PersonalMixService:
         by_rg_recording: dict[tuple[str, str], Any] = {}
         for rg, album_tracks in zip(rg_mbids, results):
             if isinstance(album_tracks, BaseException):
-                logger.debug(f"Personal mix: library lookup failed for {rg}", exc_info=album_tracks)
+                logger.debug("Personal mix: library lookup failed for %s", rg, exc_info=album_tracks)
                 continue
             for lt in album_tracks:
                 if lt.recording_mbid:
@@ -378,12 +378,12 @@ class PersonalMixService:
                 )
             except ConfigurationError:
                 logger.info(
-                    f"Personal mix: download client disabled; not auto-requesting for {user_id}",
+                    "Personal mix: download client disabled; not auto-requesting for %s", user_id,
                 )
                 break  # disabled globally - further attempts this run would fail identically
             except Exception:  # noqa: BLE001 - one failed request must not abort the rest
                 logger.error(
-                    f"Personal mix: failed to auto-request {t.release_group_mbid}", exc_info=True,
+                    "Personal mix: failed to auto-request %s", t.release_group_mbid, exc_info=True,
                 )
                 continue
             if task_id and task_id != ALREADY_IN_LIBRARY:

--- a/backend/services/personal_mix_service.py
+++ b/backend/services/personal_mix_service.py
@@ -35,7 +35,7 @@ _RECOMMENDATION_PATCHES = ("weekly-jams", "weekly-exploration")
 _MAX_SEED_ARTISTS = 8
 _SIMILAR_LIMIT = 10
 _ALBUMS_PER_SEED = 2
-_TRACK_CAP = 40
+_TRACK_CAP = 100
 
 
 class PersonalMixResult(msgspec.Struct, frozen=True):
@@ -62,6 +62,9 @@ class _MixTrack(msgspec.Struct, frozen=True):
     artist_mbid: str | None
     recording_mbid: str | None
     in_library: bool
+    library_file_id: str | None = None
+    track_number: int | None = None
+    disc_number: int = 1
 
 
 class PersonalMixService:
@@ -116,6 +119,7 @@ class PersonalMixService:
                 user_id=user_id, skipped=True, reason="no_tracks",
                 playlist_id=existing.id if existing else None,
             )
+        mix = await self._match_library_files(mix)
 
         owner = await self._auth_store.get_user_by_id(user_id)
         if owner is None:
@@ -231,6 +235,36 @@ class PersonalMixService:
                 ))
         return tracks[:_TRACK_CAP]
 
+    async def _match_library_files(self, mix: list[_MixTrack]) -> list[_MixTrack]:
+        rg_mbids = {t.release_group_mbid for t in mix if t.in_library}
+        if not rg_mbids:
+            return mix
+
+        rg_mbids = list(rg_mbids)
+        results = await asyncio.gather(
+            *(self._library_repo.get_tracks(rg) for rg in rg_mbids),
+            return_exceptions=True,
+        )
+        by_rg_recording: dict[tuple[str, str], Any] = {}
+        for rg, album_tracks in zip(rg_mbids, results):
+            if isinstance(album_tracks, BaseException):
+                logger.debug(f"Personal mix: library lookup failed for {rg}", exc_info=album_tracks)
+                continue
+            for lt in album_tracks:
+                if lt.recording_mbid:
+                    by_rg_recording[(rg, lt.recording_mbid)] = lt
+
+        matched: list[_MixTrack] = []
+        for t in mix:
+            lt = by_rg_recording.get((t.release_group_mbid, t.recording_mbid)) if t.recording_mbid else None
+            if lt is None:
+                matched.append(t)
+                continue
+            matched.append(msgspec.structs.replace(
+                t, library_file_id=lt.id, track_number=lt.track_number, disc_number=lt.disc_number,
+            ))
+        return matched
+
     @staticmethod
     def _pick_seed_artists(tracks: list[_MixTrack]) -> list[str]:
         seen: list[str] = []
@@ -314,9 +348,12 @@ class PersonalMixService:
                 "album_name": t.album_name,
                 "album_id": t.release_group_mbid,
                 "artist_id": t.artist_mbid,
-                "track_source_id": t.recording_mbid,
+                "track_source_id": t.library_file_id or t.recording_mbid,
                 "cover_url": release_group_cover_url(t.release_group_mbid, size=250),
-                "source_type": "",
+                "source_type": "local" if t.library_file_id else "",
+                "track_number": t.track_number,
+                "disc_number": t.disc_number,
+                "library_file_id": t.library_file_id,
             }
             for t in mix
         ]

--- a/backend/services/personal_mix_service.py
+++ b/backend/services/personal_mix_service.py
@@ -1,0 +1,354 @@
+"""Per-user "Your Weekly Mix" playlist.
+
+Seeded from ListenBrainz's own recommendation playlists (weekly-jams +
+weekly-exploration, the same source ``weekly_exploration_service.py`` reads)
+and topped up with a similar-artist expansion (reusing
+``queue_strategies.build_similar_artist_pools``, the same building block
+``radio_service.py`` uses). Missing albums are optionally auto-requested
+through the native download engine, mirroring the auto-download dispatch in
+``new_release_service.py``.
+"""
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import msgspec
+
+from core.exceptions import ConfigurationError
+from infrastructure.cover_urls import release_group_cover_url
+from repositories.listenbrainz_models import ListenBrainzArtist
+from services.discover.mbid_resolution_service import MbidResolutionService
+from services.discover.queue_strategies import (
+    build_similar_artist_pools,
+    round_robin_dedup_select,
+)
+from services.native.download_service import ALREADY_IN_LIBRARY
+
+logger = logging.getLogger(__name__)
+
+_PLAYLIST_NAME = "Your Weekly Mix"
+_SOURCE_REF_PREFIX = "personal-mix:"
+_REFRESH_MIN_INTERVAL = timedelta(days=6)  # LB refreshes weekly-jams/-exploration weekly
+_RECOMMENDATION_PATCHES = ("weekly-jams", "weekly-exploration")
+_MAX_SEED_ARTISTS = 8
+_SIMILAR_LIMIT = 10
+_ALBUMS_PER_SEED = 2
+_TRACK_CAP = 40
+
+
+class PersonalMixResult(msgspec.Struct, frozen=True):
+    user_id: str
+    skipped: bool = False
+    reason: str = ""
+    playlist_id: str | None = None
+    track_count: int = 0
+    requested_albums: int = 0
+
+
+class PersonalMixSummary(msgspec.Struct, frozen=True):
+    users_considered: int = 0
+    built: int = 0
+    skipped: int = 0
+    errors: int = 0
+
+
+class _MixTrack(msgspec.Struct, frozen=True):
+    track_name: str
+    artist_name: str
+    album_name: str
+    release_group_mbid: str
+    artist_mbid: str | None
+    recording_mbid: str | None
+    in_library: bool
+
+
+class PersonalMixService:
+    def __init__(
+        self,
+        client_factory,
+        mb_repo,
+        library_repo,
+        playlist_service,
+        download_service,
+        listening_prefs_store,
+        connections_store,
+        auth_store,
+    ) -> None:
+        self._client_factory = client_factory
+        self._mb_repo = mb_repo
+        self._library_repo = library_repo
+        self._playlists = playlist_service
+        self._downloads = download_service
+        self._prefs = listening_prefs_store
+        self._connections_store = connections_store
+        self._auth_store = auth_store
+
+    async def build_for_user(self, user_id: str, *, force: bool = False) -> PersonalMixResult:
+        lb_repo = await self._client_factory.resolve_listenbrainz(user_id)
+        if lb_repo is None:
+            return PersonalMixResult(user_id=user_id, skipped=True, reason="listenbrainz_not_linked")
+
+        username = await self._client_factory.resolve_listenbrainz_username(user_id)
+        source_ref = f"{_SOURCE_REF_PREFIX}{user_id}"
+        existing = await self._playlists.get_by_source_ref(source_ref, user_id)
+        if not force and existing is not None and self._is_fresh(existing.updated_at):
+            return PersonalMixResult(
+                user_id=user_id, skipped=True, reason="fresh", playlist_id=existing.id,
+            )
+
+        owned = {
+            m.lower() for m in await self._library_repo.get_library_mbids(include_release_ids=False)
+        }
+
+        lb_tracks = await self._from_recommendation_playlists(lb_repo, username, owned)
+        seed_mbids = self._pick_seed_artists(lb_tracks)
+        expansion_tracks: list[_MixTrack] = []
+        if seed_mbids and len(lb_tracks) < _TRACK_CAP:
+            expansion_tracks = await self._from_similar_artists(
+                lb_repo, seed_mbids, owned, needed=_TRACK_CAP - len(lb_tracks),
+            )
+
+        mix = (lb_tracks + expansion_tracks)[:_TRACK_CAP]
+        if not mix:
+            return PersonalMixResult(
+                user_id=user_id, skipped=True, reason="no_tracks",
+                playlist_id=existing.id if existing else None,
+            )
+
+        owner = await self._auth_store.get_user_by_id(user_id)
+        if owner is None:
+            return PersonalMixResult(user_id=user_id, skipped=True, reason="user_not_found")
+
+        playlist_id = await self._upsert_playlist(existing, source_ref, owner, mix)
+
+        requested = 0
+        prefs = await self._prefs.get(user_id)
+        if prefs.auto_request_personal_mix:
+            requested = await self._auto_request_missing(user_id, mix)
+
+        return PersonalMixResult(
+            user_id=user_id, playlist_id=playlist_id, track_count=len(mix), requested_albums=requested,
+        )
+
+    async def run_for_all_users(self) -> PersonalMixSummary:
+        user_ids = await self._connections_store.list_user_ids_for_service("listenbrainz")
+        built = skipped = errors = 0
+        for user_id in user_ids:
+            try:
+                result = await self.build_for_user(user_id)
+            except Exception:  # noqa: BLE001 - one user must never kill the run
+                logger.error(f"Personal mix build failed for user {user_id}", exc_info=True)
+                errors += 1
+                continue
+            if result.skipped:
+                skipped += 1
+            else:
+                built += 1
+        summary = PersonalMixSummary(
+            users_considered=len(user_ids), built=built, skipped=skipped, errors=errors,
+        )
+        logger.info(f"Personal mix refresh complete: {summary}")
+        return summary
+
+    @staticmethod
+    def _is_fresh(updated_at: str) -> bool:
+        if not updated_at:
+            return False
+        try:
+            ts = datetime.fromisoformat(updated_at)
+        except ValueError:
+            return False
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        return datetime.now(timezone.utc) - ts < _REFRESH_MIN_INTERVAL
+
+    async def _from_recommendation_playlists(
+        self, lb_repo, username: str | None, owned: set[str],
+    ) -> list[_MixTrack]:
+        try:
+            playlists = await lb_repo.get_recommendation_playlists(username)
+        except Exception:  # noqa: BLE001
+            logger.warning("Personal mix: failed to fetch LB recommendation playlists", exc_info=True)
+            return []
+        if not playlists:
+            return []
+
+        wanted = []
+        for patch in _RECOMMENDATION_PATCHES:
+            match = next(
+                (p for p in playlists if p.get("source_patch") == patch and p.get("playlist_id")),
+                None,
+            )
+            if match:
+                wanted.append(match)
+
+        tracks: list[_MixTrack] = []
+        seen_recordings: set[str] = set()
+        for entry in wanted:
+            try:
+                playlist = await lb_repo.get_playlist_tracks(entry["playlist_id"])
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    f"Personal mix: failed to fetch playlist {entry.get('playlist_id')}", exc_info=True,
+                )
+                continue
+            if not playlist or not playlist.tracks:
+                continue
+
+            unique_release_ids = list({
+                t.caa_release_mbid for t in playlist.tracks if t.caa_release_mbid
+            })
+            rg_results = await asyncio.gather(
+                *(self._mb_repo.get_release_group_id_from_release(rid) for rid in unique_release_ids),
+                return_exceptions=True,
+            )
+            release_to_rg = {
+                rid: rg for rid, rg in zip(unique_release_ids, rg_results)
+                if isinstance(rg, str) and rg
+            }
+
+            for t in playlist.tracks:
+                if not t.caa_release_mbid:
+                    continue
+                rg_mbid = release_to_rg.get(t.caa_release_mbid)
+                if not rg_mbid:
+                    continue
+                rg_mbid = rg_mbid.lower()
+                if t.recording_mbid:
+                    if t.recording_mbid in seen_recordings:
+                        continue
+                    seen_recordings.add(t.recording_mbid)
+                tracks.append(_MixTrack(
+                    track_name=t.title,
+                    artist_name=t.creator,
+                    album_name=t.album,
+                    release_group_mbid=rg_mbid,
+                    artist_mbid=t.artist_mbids[0] if t.artist_mbids else None,
+                    recording_mbid=t.recording_mbid,
+                    in_library=rg_mbid in owned,
+                ))
+        return tracks[:_TRACK_CAP]
+
+    @staticmethod
+    def _pick_seed_artists(tracks: list[_MixTrack]) -> list[str]:
+        seen: list[str] = []
+        for t in tracks:
+            if t.artist_mbid and t.artist_mbid not in seen:
+                seen.append(t.artist_mbid)
+            if len(seen) >= _MAX_SEED_ARTISTS:
+                break
+        return seen
+
+    async def _from_similar_artists(
+        self, lb_repo, seed_mbids: list[str], owned: set[str], needed: int,
+    ) -> list[_MixTrack]:
+        mbid_svc = MbidResolutionService(
+            musicbrainz_repo=self._mb_repo, library_repo=self._library_repo, listenbrainz_repo=lb_repo,
+        )
+        seeds = [
+            ListenBrainzArtist(artist_name=mbid, artist_mbids=[mbid], listen_count=0)
+            for mbid in seed_mbids
+        ]
+        try:
+            pools = await build_similar_artist_pools(
+                seeds,
+                excluded_mbids=owned,
+                similar_limit=_SIMILAR_LIMIT,
+                albums_per=_ALBUMS_PER_SEED,
+                lb_repo=lb_repo,
+                mbid_svc=mbid_svc,
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning("Personal mix: similar-artist expansion failed", exc_info=True)
+            return []
+
+        # extra headroom: some candidate artists won't have a top-recording hit below
+        candidates = round_robin_dedup_select(pools, needed * 2)
+
+        tracks: list[_MixTrack] = []
+        top_track_cache: dict[str, Any] = {}
+        for item in candidates:
+            if len(tracks) >= needed:
+                break
+            artist_mbid = item.artist_mbid
+            if artist_mbid not in top_track_cache:
+                try:
+                    recordings = await lb_repo.get_artist_top_recordings(artist_mbid, count=1)
+                except Exception:  # noqa: BLE001
+                    recordings = []
+                top_track_cache[artist_mbid] = recordings[0] if recordings else None
+            recording = top_track_cache[artist_mbid]
+            if recording is None:
+                continue
+            tracks.append(_MixTrack(
+                track_name=recording.track_name,
+                artist_name=item.artist_name,
+                album_name=item.album_name,
+                release_group_mbid=item.release_group_mbid,
+                artist_mbid=artist_mbid,
+                recording_mbid=recording.recording_mbid,
+                in_library=False,  # excluded_mbids already filtered owned albums out of the pool
+            ))
+        return tracks
+
+    async def _upsert_playlist(self, existing, source_ref: str, owner, mix: list[_MixTrack]) -> str:
+        if existing is None:
+            playlist = await self._playlists.create_playlist(
+                _PLAYLIST_NAME, source_ref=source_ref, user_id=owner.id,
+            )
+            playlist_id = playlist.id
+        else:
+            playlist_id = existing.id
+            current_tracks = await self._playlists.get_tracks(playlist_id)
+            if current_tracks:
+                await self._playlists.remove_tracks(
+                    playlist_id, owner, [t.id for t in current_tracks],
+                )
+
+        track_dicts = [
+            {
+                "track_name": t.track_name,
+                "artist_name": t.artist_name,
+                "album_name": t.album_name,
+                "album_id": t.release_group_mbid,
+                "artist_id": t.artist_mbid,
+                "track_source_id": t.recording_mbid,
+                "cover_url": release_group_cover_url(t.release_group_mbid, size=250),
+                "source_type": "",
+            }
+            for t in mix
+        ]
+        await self._playlists.add_tracks(playlist_id, owner, track_dicts)
+        return playlist_id
+
+    async def _auto_request_missing(self, user_id: str, mix: list[_MixTrack]) -> int:
+        requested = 0
+        seen_rgs: set[str] = set()
+        for t in mix:
+            if t.in_library or t.release_group_mbid in seen_rgs:
+                continue
+            seen_rgs.add(t.release_group_mbid)
+            try:
+                task_id = await self._downloads.request_album(
+                    user_id=user_id,
+                    release_group_mbid=t.release_group_mbid,
+                    artist_name=t.artist_name,
+                    album_title=t.album_name,
+                    artist_mbid=t.artist_mbid,
+                    origin="user",
+                )
+            except ConfigurationError:
+                logger.info(
+                    f"Personal mix: download client disabled; not auto-requesting for {user_id}",
+                )
+                break  # disabled globally - further attempts this run would fail identically
+            except Exception:  # noqa: BLE001 - one failed request must not abort the rest
+                logger.error(
+                    f"Personal mix: failed to auto-request {t.release_group_mbid}", exc_info=True,
+                )
+                continue
+            if task_id and task_id != ALREADY_IN_LIBRARY:
+                requested += 1
+        return requested

--- a/backend/tests/services/test_personal_mix_service.py
+++ b/backend/tests/services/test_personal_mix_service.py
@@ -1,0 +1,280 @@
+"""PersonalMixService: recommendation-playlist ingestion, similar-artist
+expansion, playlist upsert, and opt-in auto-request."""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from core.exceptions import ConfigurationError
+from services.native.download_service import ALREADY_IN_LIBRARY
+from services.personal_mix_service import PersonalMixService
+
+RG1 = "rg-1111-1111-1111-111111111111"
+RG2 = "rg-2222-2222-2222-222222222222"
+ARTIST_A = "artist-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+ARTIST_B = "artist-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _stale_iso() -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=10)).isoformat()
+
+
+def _mix_track(title, creator, album, caa_release_mbid, artist_mbid, recording_mbid):
+    return SimpleNamespace(
+        title=title, creator=creator, album=album,
+        caa_release_mbid=caa_release_mbid, recording_mbid=recording_mbid,
+        artist_mbids=[artist_mbid] if artist_mbid else None,
+    )
+
+
+def _lb_playlist(tracks):
+    return SimpleNamespace(tracks=tracks)
+
+
+def _playlist_record(id="mix-1", updated_at="2025-01-01T00:00:00+00:00", user_id="user-a"):
+    return SimpleNamespace(id=id, updated_at=updated_at, user_id=user_id)
+
+
+def _track_record(id):
+    return SimpleNamespace(id=id)
+
+
+@pytest.fixture
+def svc():
+    client_factory = AsyncMock()
+    client_factory.resolve_listenbrainz_username = AsyncMock(return_value="alice")
+
+    mb_repo = AsyncMock()
+    mb_repo.get_release_group_id_from_release = AsyncMock(side_effect=lambda rid: rid.replace("caa-", "rg-"))
+
+    library_repo = AsyncMock()
+    library_repo.get_library_mbids = AsyncMock(return_value=set())
+
+    playlist_service = AsyncMock()
+    playlist_service.get_by_source_ref = AsyncMock(return_value=None)
+    playlist_service.create_playlist = AsyncMock(
+        return_value=SimpleNamespace(id="mix-1")
+    )
+    playlist_service.get_tracks = AsyncMock(return_value=[])
+    playlist_service.remove_tracks = AsyncMock(return_value=0)
+    playlist_service.add_tracks = AsyncMock(return_value=[])
+
+    download_service = AsyncMock()
+    download_service.request_album = AsyncMock(return_value="task-1")
+
+    listening_prefs_store = AsyncMock()
+    listening_prefs_store.get = AsyncMock(
+        return_value=SimpleNamespace(auto_request_personal_mix=False)
+    )
+
+    connections_store = AsyncMock()
+    connections_store.list_user_ids_for_service = AsyncMock(return_value=[])
+
+    auth_store = AsyncMock()
+    auth_store.get_user_by_id = AsyncMock(return_value=SimpleNamespace(id="user-a"))
+
+    lb_repo = AsyncMock()
+    lb_repo.get_recommendation_playlists = AsyncMock(return_value=[])
+
+    client_factory.resolve_listenbrainz = AsyncMock(return_value=lb_repo)
+
+    service = PersonalMixService(
+        client_factory=client_factory,
+        mb_repo=mb_repo,
+        library_repo=library_repo,
+        playlist_service=playlist_service,
+        download_service=download_service,
+        listening_prefs_store=listening_prefs_store,
+        connections_store=connections_store,
+        auth_store=auth_store,
+    )
+    return SimpleNamespace(
+        service=service, client_factory=client_factory, mb_repo=mb_repo,
+        library_repo=library_repo, playlist_service=playlist_service,
+        download_service=download_service, listening_prefs_store=listening_prefs_store,
+        connections_store=connections_store, auth_store=auth_store, lb_repo=lb_repo,
+    )
+
+
+def _set_recommendation_tracks(svc, *, jams=None, exploration=None):
+    playlists = []
+    tracks_by_id = {}
+    if jams is not None:
+        playlists.append({"source_patch": "weekly-jams", "playlist_id": "pl-jams"})
+        tracks_by_id["pl-jams"] = jams
+    if exploration is not None:
+        playlists.append({"source_patch": "weekly-exploration", "playlist_id": "pl-expl"})
+        tracks_by_id["pl-expl"] = exploration
+    svc.lb_repo.get_recommendation_playlists.return_value = playlists
+
+    async def _get_playlist_tracks(playlist_id):
+        return _lb_playlist(tracks_by_id[playlist_id])
+
+    svc.lb_repo.get_playlist_tracks = AsyncMock(side_effect=_get_playlist_tracks)
+
+
+@pytest.mark.asyncio
+async def test_not_linked_is_skipped(svc):
+    svc.client_factory.resolve_listenbrainz.return_value = None
+    result = await svc.service.build_for_user("user-a")
+    assert result.skipped is True
+    assert result.reason == "listenbrainz_not_linked"
+    svc.playlist_service.get_by_source_ref.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fresh_playlist_is_skipped_without_force(svc):
+    svc.playlist_service.get_by_source_ref.return_value = _playlist_record(updated_at=_now_iso())
+    result = await svc.service.build_for_user("user-a")
+    assert result.skipped is True
+    assert result.reason == "fresh"
+    svc.lb_repo.get_recommendation_playlists.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_force_bypasses_freshness_guard(svc):
+    svc.playlist_service.get_by_source_ref.return_value = _playlist_record(updated_at=_now_iso())
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist", "Album", "caa-1", ARTIST_A, "rec-1")],
+    )
+    result = await svc.service.build_for_user("user-a", force=True)
+    assert result.skipped is False
+    svc.lb_repo.get_recommendation_playlists.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_builds_new_playlist_from_recommendation_tracks(svc):
+    _set_recommendation_tracks(
+        svc,
+        jams=[_mix_track("Jam Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+        exploration=[_mix_track("Explore Song", "Artist B", "Album B", "caa-2222-2222-2222-222222222222", ARTIST_B, "rec-2")],
+    )
+    result = await svc.service.build_for_user("user-a")
+
+    assert result.skipped is False
+    assert result.track_count == 2
+    svc.playlist_service.create_playlist.assert_awaited_once()
+    svc.playlist_service.remove_tracks.assert_not_called()
+    add_call = svc.playlist_service.add_tracks.await_args
+    playlist_id, owner, track_dicts = add_call.args
+    assert playlist_id == "mix-1"
+    assert owner.id == "user-a"
+    names = {t["track_name"] for t in track_dicts}
+    assert names == {"Jam Song", "Explore Song"}
+    for t in track_dicts:
+        assert t["album_id"] in (RG1, RG2)
+
+
+@pytest.mark.asyncio
+async def test_owned_track_is_marked_in_library_and_not_requested(svc):
+    svc.library_repo.get_library_mbids.return_value = {RG1}
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Jam Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+    svc.listening_prefs_store.get.return_value = SimpleNamespace(auto_request_personal_mix=True)
+
+    result = await svc.service.build_for_user("user-a")
+
+    assert result.track_count == 1
+    assert result.requested_albums == 0
+    svc.download_service.request_album.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_existing_playlist_is_replaced_not_recreated(svc):
+    svc.playlist_service.get_by_source_ref.return_value = _playlist_record(updated_at=_stale_iso())
+    svc.playlist_service.get_tracks.return_value = [_track_record("old-1"), _track_record("old-2")]
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("New Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+
+    result = await svc.service.build_for_user("user-a")
+
+    assert result.playlist_id == "mix-1"
+    svc.playlist_service.create_playlist.assert_not_called()
+    svc.playlist_service.remove_tracks.assert_awaited_once()
+    removed_ids = svc.playlist_service.remove_tracks.await_args.args[2]
+    assert set(removed_ids) == {"old-1", "old-2"}
+
+
+@pytest.mark.asyncio
+async def test_auto_request_off_by_default(svc):
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+    result = await svc.service.build_for_user("user-a")
+    assert result.requested_albums == 0
+    svc.download_service.request_album.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_request_requests_missing_albums_when_opted_in(svc):
+    svc.listening_prefs_store.get.return_value = SimpleNamespace(auto_request_personal_mix=True)
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+    result = await svc.service.build_for_user("user-a")
+    assert result.requested_albums == 1
+    svc.download_service.request_album.assert_awaited_once()
+    kwargs = svc.download_service.request_album.await_args.kwargs
+    assert kwargs["user_id"] == "user-a"
+    assert kwargs["release_group_mbid"] == RG1
+    assert kwargs["origin"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_already_in_library_sentinel_not_counted(svc):
+    svc.listening_prefs_store.get.return_value = SimpleNamespace(auto_request_personal_mix=True)
+    svc.download_service.request_album.return_value = ALREADY_IN_LIBRARY
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+    result = await svc.service.build_for_user("user-a")
+    assert result.requested_albums == 0
+
+
+@pytest.mark.asyncio
+async def test_config_error_stops_auto_request_without_crashing(svc):
+    svc.listening_prefs_store.get.return_value = SimpleNamespace(auto_request_personal_mix=True)
+    svc.download_service.request_album.side_effect = ConfigurationError("download client disabled")
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+    result = await svc.service.build_for_user("user-a")
+    assert result.requested_albums == 0
+
+
+@pytest.mark.asyncio
+async def test_no_tracks_at_all_is_skipped(svc):
+    result = await svc.service.build_for_user("user-a")
+    assert result.skipped is True
+    assert result.reason == "no_tracks"
+    svc.playlist_service.create_playlist.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_run_for_all_users_aggregates_and_isolates_errors(monkeypatch, svc):
+    svc.connections_store.list_user_ids_for_service.return_value = ["user-a", "user-b", "user-c"]
+
+    from services.personal_mix_service import PersonalMixResult
+
+    async def fake_build(user_id, *, force=False):
+        if user_id == "user-a":
+            raise RuntimeError("boom")
+        if user_id == "user-b":
+            return PersonalMixResult(user_id=user_id, skipped=True, reason="fresh")
+        return PersonalMixResult(user_id=user_id, playlist_id="mix-c", track_count=5)
+
+    monkeypatch.setattr(svc.service, "build_for_user", fake_build)
+
+    summary = await svc.service.run_for_all_users()
+    assert summary.users_considered == 3
+    assert summary.errors == 1
+    assert summary.skipped == 1
+    assert summary.built == 1

--- a/backend/tests/services/test_personal_mix_service.py
+++ b/backend/tests/services/test_personal_mix_service.py
@@ -187,6 +187,52 @@ async def test_owned_track_is_marked_in_library_and_not_requested(svc):
 
 
 @pytest.mark.asyncio
+async def test_owned_track_is_linked_to_its_local_file(svc):
+    svc.library_repo.get_library_mbids.return_value = {RG1}
+    svc.library_repo.get_tracks = AsyncMock(
+        return_value=[
+            SimpleNamespace(id="file-1", recording_mbid="rec-1", track_number=3, disc_number=1),
+        ]
+    )
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Jam Song", "Artist A", "Album A", "caa-1111-1111-1111-111111111111", ARTIST_A, "rec-1")],
+    )
+
+    await svc.service.build_for_user("user-a")
+
+    track_dicts = svc.playlist_service.add_tracks.await_args.args[2]
+    assert len(track_dicts) == 1
+    track = track_dicts[0]
+    assert track["source_type"] == "local"
+    assert track["library_file_id"] == "file-1"
+    assert track["track_source_id"] == "file-1"
+    assert track["track_number"] == 3
+    assert track["disc_number"] == 1
+
+
+@pytest.mark.asyncio
+async def test_recording_mbid_collision_on_another_owned_album_is_not_cross_matched(svc):
+    svc.library_repo.get_library_mbids.return_value = {RG1}
+    svc.library_repo.get_tracks = AsyncMock(
+        return_value=[
+            SimpleNamespace(id="file-1", recording_mbid="rec-1", track_number=1, disc_number=1),
+        ]
+    )
+    _set_recommendation_tracks(
+        svc, jams=[_mix_track("Song", "Artist B", "Album B", "caa-2222-2222-2222-222222222222", ARTIST_B, "rec-1")],
+    )
+
+    await svc.service.build_for_user("user-a")
+
+    track_dicts = svc.playlist_service.add_tracks.await_args.args[2]
+    assert len(track_dicts) == 1
+    track = track_dicts[0]
+    assert track["album_id"] == RG2
+    assert track["source_type"] == ""
+    assert track["library_file_id"] is None
+
+
+@pytest.mark.asyncio
 async def test_existing_playlist_is_replaced_not_recreated(svc):
     svc.playlist_service.get_by_source_ref.return_value = _playlist_record(updated_at=_stale_iso())
     svc.playlist_service.get_tracks.return_value = [_track_record("old-1"), _track_record("old-2")]

--- a/backend/tests/services/test_scrobble_service.py
+++ b/backend/tests/services/test_scrobble_service.py
@@ -16,6 +16,7 @@ def _prefs(scrobble_lastfm: bool = True, scrobble_lb: bool = True) -> UserListen
         scrobble_to_listenbrainz=scrobble_lb,
         primary_music_source="listenbrainz",
         now_playing_visibility="full",
+        auto_request_personal_mix=False,
         updated_at="",
     )
 

--- a/frontend/src/lib/components/profile/ScrobblingDiscoveryCard.svelte
+++ b/frontend/src/lib/components/profile/ScrobblingDiscoveryCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Radio, Music, Loader2, ExternalLink, RadioTower, Check } from 'lucide-svelte';
+	import { Radio, Music, Loader2, ExternalLink, RadioTower, Check, Sparkles } from 'lucide-svelte';
 	import { ApiError } from '$lib/api/client';
 	import { getConnectionsQuery } from '$lib/queries/connections/ConnectionsQuery.svelte';
 	import {
@@ -9,7 +9,10 @@
 		createLastFmRequestTokenMutation
 	} from '$lib/queries/connections/ConnectionsMutations.svelte';
 	import { getScrobblePreferencesQuery } from '$lib/queries/scrobble-preferences/ScrobblePreferencesQuery.svelte';
-	import { createUpdateScrobblePreferencesMutation } from '$lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte';
+	import {
+		createRefreshPersonalMixMutation,
+		createUpdateScrobblePreferencesMutation
+	} from '$lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte';
 	import type {
 		NowPlayingVisibility,
 		ScrobblePreferencesUpdate
@@ -30,6 +33,7 @@
 	const connectLbMutation = createConnectListenBrainzMutation();
 	const disconnectMutation = createDisconnectMutation();
 	const updatePrefsMutation = createUpdateScrobblePreferencesMutation();
+	const refreshMixMutation = createRefreshPersonalMixMutation();
 
 	const loading = $derived(connectionsQuery.isPending || prefsQuery.isPending);
 
@@ -51,12 +55,15 @@
 	let scrobbleListenbrainz = $state(false);
 	let primarySource = $state<MusicSource>('listenbrainz');
 	let nowPlayingVisibility = $state<NowPlayingVisibility>('full');
+	let autoRequestPersonalMix = $state(false);
+	let mixRefreshMessage = $state<string | null>(null);
 	$effect(() => {
 		if (prefs) {
 			scrobbleLastfm = prefs.scrobble_to_lastfm;
 			scrobbleListenbrainz = prefs.scrobble_to_listenbrainz;
 			primarySource = (prefs.primary_music_source as MusicSource) ?? 'listenbrainz';
 			nowPlayingVisibility = (prefs.now_playing_visibility as NowPlayingVisibility) ?? 'full';
+			autoRequestPersonalMix = prefs.auto_request_personal_mix;
 		}
 	});
 
@@ -122,6 +129,7 @@
 				scrobbleListenbrainz = prefs.scrobble_to_listenbrainz;
 				primarySource = (prefs.primary_music_source as MusicSource) ?? 'listenbrainz';
 				nowPlayingVisibility = (prefs.now_playing_visibility as NowPlayingVisibility) ?? 'full';
+				autoRequestPersonalMix = prefs.auto_request_personal_mix;
 			}
 		}
 	}
@@ -130,6 +138,23 @@
 		if (src === primarySource) return;
 		primarySource = src;
 		await savePrefs({ primary_music_source: src });
+	}
+
+	async function refreshPersonalMix() {
+		mixRefreshMessage = null;
+		try {
+			const result = await refreshMixMutation.mutateAsync();
+			if (result.skipped) {
+				mixRefreshMessage =
+					result.reason === 'fresh'
+						? 'Your Weekly Mix was already refreshed recently.'
+						: "Couldn't build Your Weekly Mix yet, listen to a bit more first.";
+			} else {
+				mixRefreshMessage = `Your Weekly Mix updated: ${result.track_count} tracks${result.requested_albums ? `, ${result.requested_albums} album(s) requested` : ''}.`;
+			}
+		} catch (e) {
+			mixRefreshMessage = errorMessage(e, "Couldn't refresh Your Weekly Mix.");
+		}
 	}
 </script>
 
@@ -409,6 +434,51 @@
 					<option value="track_hidden">Show I'm listening, hide the track</option>
 					<option value="offline">Don't show my activity</option>
 				</select>
+			</div>
+
+			<div class="section-divider-glow my-1"></div>
+
+			<div class="space-y-2 px-1">
+				<div class="flex items-center gap-2">
+					<Sparkles class="h-4 w-4 text-accent" />
+					<span class="text-sm font-semibold">Your Weekly Mix</span>
+				</div>
+				<p class="text-xs text-base-content/40">
+					A playlist built from your ListenBrainz listening history, refreshed weekly.
+				</p>
+				<label
+					class="flex cursor-pointer items-center justify-between gap-4 rounded-lg py-2 transition-colors hover:bg-base-300/20"
+				>
+					<div>
+						<span class="text-sm font-medium">Auto-request missing music from Your Weekly Mix</span>
+						{#if !lb}
+							<p class="text-xs text-base-content/40">Link ListenBrainz above to enable.</p>
+						{/if}
+					</div>
+					<input
+						type="checkbox"
+						class="toggle toggle-primary toggle-sm"
+						bind:checked={autoRequestPersonalMix}
+						disabled={!lb || updatePrefsMutation.isPending}
+						onchange={() => savePrefs({ auto_request_personal_mix: autoRequestPersonalMix })}
+					/>
+				</label>
+				<div class="flex items-center gap-3">
+					<button
+						type="button"
+						class="btn btn-ghost btn-xs gap-1 rounded-full"
+						onclick={refreshPersonalMix}
+						disabled={!lb || refreshMixMutation.isPending}
+					>
+						{#if refreshMixMutation.isPending}
+							<Loader2 class="h-3.5 w-3.5 animate-spin" />
+						{/if}
+						Refresh my mix
+					</button>
+					{#if mixRefreshMessage}
+						<p class="text-xs text-base-content/50">{mixRefreshMessage}</p>
+					{/if}
+				</div>
 			</div>
 		{/if}
 	</div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -282,7 +282,8 @@ export const API = {
 		listenbrainz: () => '/api/v1/me/connections/listenbrainz',
 		spotifyAuthUrl: () => '/api/v1/me/connections/spotify/auth/url',
 		spotifyPlaylists: () => '/api/v1/me/spotify/playlists',
-		spotifyImport: (playlistId: string) => `/api/v1/me/spotify/playlists/${playlistId}/import`
+		spotifyImport: (playlistId: string) => `/api/v1/me/spotify/playlists/${playlistId}/import`,
+		personalMixRefresh: () => '/api/v1/me/personal-mix/refresh'
 	},
 	scrobble: {
 		nowPlaying: () => '/api/v1/scrobble/now-playing',

--- a/frontend/src/lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte.ts
+++ b/frontend/src/lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte.ts
@@ -3,6 +3,7 @@ import { API } from '$lib/constants';
 import { createMutation } from '@tanstack/svelte-query';
 import { authStore } from '$lib/stores/authStore.svelte';
 import { invalidateQueriesWithPersister } from '../QueryClient';
+import { PlaylistQueryKeyFactory } from '../playlists/PlaylistQueryKeyFactory';
 import { ScrobblePreferencesQueryKeyFactory } from './ScrobblePreferencesQueryKeyFactory';
 import { SCROBBLE_PREFERENCES_ENDPOINTS } from './endpoints';
 import type {
@@ -24,5 +25,15 @@ export const createUpdateScrobblePreferencesMutation = () =>
 
 export const createRefreshPersonalMixMutation = () =>
 	createMutation(() => ({
-		mutationFn: () => api.global.post<PersonalMixRefreshResponse>(API.me.personalMixRefresh(), {})
+		mutationFn: () => api.global.post<PersonalMixRefreshResponse>(API.me.personalMixRefresh(), {}),
+		onSuccess: (data) => {
+			invalidateQueriesWithPersister({
+				queryKey: PlaylistQueryKeyFactory.list(authStore.user?.id)
+			});
+			if (data.playlist_id) {
+				invalidateQueriesWithPersister({
+					queryKey: PlaylistQueryKeyFactory.detail(authStore.user?.id, data.playlist_id)
+				});
+			}
+		}
 	}));

--- a/frontend/src/lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte.ts
+++ b/frontend/src/lib/queries/scrobble-preferences/ScrobblePreferencesMutations.svelte.ts
@@ -1,10 +1,15 @@
 import { api } from '$lib/api/client';
+import { API } from '$lib/constants';
 import { createMutation } from '@tanstack/svelte-query';
 import { authStore } from '$lib/stores/authStore.svelte';
 import { invalidateQueriesWithPersister } from '../QueryClient';
 import { ScrobblePreferencesQueryKeyFactory } from './ScrobblePreferencesQueryKeyFactory';
 import { SCROBBLE_PREFERENCES_ENDPOINTS } from './endpoints';
-import type { ScrobblePreferences, ScrobblePreferencesUpdate } from './types';
+import type {
+	PersonalMixRefreshResponse,
+	ScrobblePreferences,
+	ScrobblePreferencesUpdate
+} from './types';
 
 // invalidate so the card + (Phase 5) home/discover re-read the new primary source
 export const createUpdateScrobblePreferencesMutation = () =>
@@ -15,4 +20,9 @@ export const createUpdateScrobblePreferencesMutation = () =>
 			invalidateQueriesWithPersister({
 				queryKey: ScrobblePreferencesQueryKeyFactory.get(authStore.user?.id)
 			})
+	}));
+
+export const createRefreshPersonalMixMutation = () =>
+	createMutation(() => ({
+		mutationFn: () => api.global.post<PersonalMixRefreshResponse>(API.me.personalMixRefresh(), {})
 	}));

--- a/frontend/src/lib/queries/scrobble-preferences/types.ts
+++ b/frontend/src/lib/queries/scrobble-preferences/types.ts
@@ -9,6 +9,7 @@ export interface ScrobblePreferences {
 	scrobble_to_listenbrainz: boolean;
 	primary_music_source: string;
 	now_playing_visibility: string;
+	auto_request_personal_mix: boolean;
 }
 
 export interface ScrobblePreferencesUpdate {
@@ -16,4 +17,13 @@ export interface ScrobblePreferencesUpdate {
 	scrobble_to_listenbrainz?: boolean;
 	primary_music_source?: MusicSource;
 	now_playing_visibility?: NowPlayingVisibility;
+	auto_request_personal_mix?: boolean;
+}
+
+export interface PersonalMixRefreshResponse {
+	playlist_id: string | null;
+	track_count: number;
+	requested_albums: number;
+	skipped: boolean;
+	reason: string;
 }


### PR DESCRIPTION
## What
Per-user listen history based weekly mix playlist

## Why
Makes a playlist weekly of history based music, can be set to auto request missing albums.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

## AI-Assisted Contributions

If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`)
- [x] Frontend lint passes (`make frontend-lint`)
- [x] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source
