### PR TITLE
fix(fingerprint): keep valid fingerprints for tracks shorter than 120s

### DIFF
--- a/backend/infrastructure/audio/fingerprinter.py
+++ b/backend/infrastructure/audio/fingerprinter.py
@@ -27,8 +27,10 @@ from models.audio import FingerprintResult
 
 logger = logging.getLogger(__name__)
 
-# AcoustID recommends >=120s of audio; ``-length`` caps fpcalc at min(120, dur),
-# so short files need no special handling and duration never has to be pre-read.
+# AcoustID recommends >=120s of audio, so ``-length`` caps the fingerprint window at
+# 120s. On files SHORTER than this, fpcalc reads to EOF and exits non-zero
+# ("Error decoding audio frame (End of file)") *after* emitting a valid FINGERPRINT=
+# line - see ``_run_fpcalc``, which tolerates that exit rather than pre-reading duration.
 _FPCALC_LENGTH = "120"
 _FPCALC_TIMEOUT = 30.0
 # Upper bound on concurrent fpcalc subprocesses, core-scaled below. fpcalc is an external
@@ -131,11 +133,16 @@ class AudioFingerprinter:
                 proc.kill()
                 await proc.wait()
                 raise
-            if proc.returncode != 0:
+            output = stdout.decode("utf-8", "ignore")
+            # fpcalc exits non-zero ("Error decoding audio frame (End of file)") on tracks
+            # shorter than ``-length`` seconds, but still writes a valid FINGERPRINT= line to
+            # stdout. Only treat a non-zero exit as a real failure when NO fingerprint was
+            # produced; otherwise use the fingerprint it emitted so sub-120s tracks still match.
+            if proc.returncode != 0 and "FINGERPRINT=" not in output:
                 raise subprocess.CalledProcessError(
                     proc.returncode or -1, "fpcalc", stderr=stderr.decode("utf-8", "ignore")
                 )
-            return self._parse_fpcalc_output(stdout.decode("utf-8", "ignore"))
+            return self._parse_fpcalc_output(output)
 
     @staticmethod
     def _parse_fpcalc_output(output: str) -> tuple[str, int]:

--- a/backend/infrastructure/audio/fingerprinter.py
+++ b/backend/infrastructure/audio/fingerprinter.py
@@ -138,9 +138,20 @@ class AudioFingerprinter:
             # shorter than ``-length`` seconds, but still writes a valid FINGERPRINT= line to
             # stdout. Only treat a non-zero exit as a real failure when NO fingerprint was
             # produced; otherwise use the fingerprint it emitted so sub-120s tracks still match.
-            if proc.returncode != 0 and "FINGERPRINT=" not in output:
-                raise subprocess.CalledProcessError(
-                    proc.returncode or -1, "fpcalc", stderr=stderr.decode("utf-8", "ignore")
+            if proc.returncode != 0:
+                stderr_text = stderr.decode("utf-8", "ignore").strip()
+                if "FINGERPRINT=" not in output:
+                    raise subprocess.CalledProcessError(
+                        proc.returncode or -1, "fpcalc", stderr=stderr_text
+                    )
+                # Tolerated non-zero exit (typically the sub-120s EOF case). Preserve
+                # fpcalc's stderr so a changed/unexpected error is still visible, and
+                # record that a short-track fingerprint was used for observability.
+                logger.warning(
+                    "fpcalc exited %s but emitted a fingerprint for %s; using it (stderr: %s)",
+                    proc.returncode,
+                    path,
+                    stderr_text or "<empty>",
                 )
             return self._parse_fpcalc_output(output)
 

--- a/backend/tests/services/test_audio_fingerprinter.py
+++ b/backend/tests/services/test_audio_fingerprinter.py
@@ -204,6 +204,19 @@ async def test_error_when_fpcalc_nonzero_exit(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_nonzero_exit_with_fingerprint_still_passes(monkeypatch):
+    # fpcalc exits non-zero ("End of file") on sub-120s tracks but still emits a
+    # valid FINGERPRINT= line; the emitted fingerprint must be used, not discarded.
+    _patch_fpcalc(monkeypatch, returncode=2, stdout=_FP_OK)
+    http = _http_client(_pass_payload())
+    fp = _make(http)
+    res = await fp.fingerprint(Path("/short.flac"))
+    assert res.status == FingerprintStatus.PASS
+    _, kwargs = http.post.call_args
+    assert kwargs["data"]["fingerprint"] == "AQADtMmSaEkSRYkG"
+
+
+@pytest.mark.asyncio
 async def test_error_when_fpcalc_output_has_no_fingerprint(monkeypatch):
     _patch_fpcalc(monkeypatch, stdout=b"DURATION=100\n")
     fp = _make(_http_client(_pass_payload()))


### PR DESCRIPTION
## What

Keep valid AcoustID fingerprints for tracks shorter than 120 seconds. `fpcalc`
exits non-zero with "Error decoding audio frame (End of file)" on files shorter
than the `-length 120` window, but still emits a valid `FINGERPRINT=` line to
stdout. `_run_fpcalc` now treats a non-zero exit as a real failure only when no
fingerprint was produced, and uses the emitted fingerprint otherwise.

## Why

Previously any non-zero exit raised `CalledProcessError`, so every sub-120s track
failed to fingerprint and could not be matched — even though fpcalc had already
produced a usable fingerprint before hitting EOF.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

Added `test_nonzero_exit_with_fingerprint_still_passes`: patches fpcalc to exit
non-zero while emitting a valid `FINGERPRINT=` line and asserts the result is a
PASS whose emitted fingerprint reaches the AcoustID request. Backend lint clean;
full backend suite 4065 passed / 3 skipped (fingerprinter suite 21 passed);
frontend lint and type check clean (no frontend changes).

## AI-Assisted Contributions

Claude Code assisted with authoring `backend/infrastructure/audio/fingerprinter.py`
(the `_run_fpcalc` exit-code handling and explanatory comments), adding the
regression test in `backend/tests/services/test_audio_fingerprinter.py`, and running
the verification checks below.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`)
- [x] Frontend lint passes (`make frontend-lint`)
- [x] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript          <!-- N/A: no TS changes -->
- [x] No hardcoded colors             <!-- N/A: no frontend changes -->
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns  <!-- N/A: none added -->
- [x] TanStack Query used for all new data fetching  <!-- N/A: no data fetching -->
- [x] No secrets, tokens, or credentials in source