### PR TITLE
fix(verify+naming): accept collab/remix artist credits; drop empty-year "()" from folder names

### DIFF
--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -27,6 +27,7 @@ from rapidfuzz import fuzz
 
 from infrastructure.msgspec_fastapi import AppStruct
 from models.audio import AudioInfo, AudioTag
+from infrastructure.audio.fingerprinter import split_artist_credit
 from models.download_manifest import DownloadManifest, ExpectedFile, ExpectedTrack
 from services.native.quality_tiers import tier_for, tier_rank
 from services.native.recycle_bin import recycle
@@ -309,8 +310,26 @@ def _fingerprint_disagrees(fp, expected_track, expected_artist: str | None) -> b
     # Wrong artist - but skip for various-artists compilations, where the album artist
     # legitimately differs from a track's performing artist.
     if fp_artist and expected_artist and "various" not in expected_artist.lower():
-        if fuzz.token_set_ratio(fp_artist, expected_artist) < 55:
-            return True
+        # A collab credit ("Artist A; Artist B") is NOT a wrong artist when the
+        # requested artist is any credited member - compare every credit token on
+        # both sides plus the full strings (token_set_ratio alone scores "Artist A"
+        # vs "Artist A; Artist B" under the gate: the separator glues tokens).
+        # This wires split_artist_credit into the verify path, per its plan note.
+        fp_credits = split_artist_credit(fp_artist) + [fp_artist]
+        expected_credits = split_artist_credit(expected_artist) + [expected_artist]
+        best = max(
+            fuzz.token_set_ratio(fp_credit, expected_credit)
+            for fp_credit in fp_credits
+            for expected_credit in expected_credits
+        )
+        if best < 55:
+            # Remix: AcoustID credits the ORIGINAL artist - "Song (Artist B
+            # remix)" carries the credit of "Song"'s artist. The requested artist
+            # named in the track title is positive evidence of the right
+            # recording, not a wrong-artist hit.
+            titles = f"{expected_title or ''} {fp_title or ''}".lower()
+            if expected_artist.lower() not in titles:
+                return True
     return False
 
 

--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -291,6 +291,36 @@ def _tag_conflict_reason(tag, info, manifest, expected_track) -> str | None:  # 
     return None
 
 
+# Keywords that mark a bracketed title group as a remix/credit annotation.
+# "feat"/"ft"/"featuring" cover explicit guest credits ("Song (feat. Artist)").
+_REMIX_CREDIT_WORDS = frozenset(
+    {"remix", "mix", "edit", "bootleg", "rework", "vip", "flip", "dub",
+     "feat", "ft", "featuring"}
+)
+_TITLE_BRACKET_GROUP = re.compile(r"[(\[]([^)\]]*)[)\]]")
+
+
+def _title_credits_artist(artist: str, *titles: str | None) -> bool:
+    """True when a bracketed group in any title names ``artist`` as whole words
+    alongside a remix/credit keyword - "Song (Artist remix)", "Song (feat.
+    Artist)". AcoustID credits remixes to the ORIGINAL artist, so such a credit
+    is positive evidence the audio is the requested remix, not a wrong-artist
+    recording. A bare substring is deliberately NOT enough: expected artist
+    "Air" must not match the title "Airbag"."""
+    name = re.escape(artist.strip().lower())
+    if not name:
+        return False
+    whole_word = re.compile(rf"(?<!\w){name}(?!\w)")
+    for title in titles:
+        if not title:
+            continue
+        for group in _TITLE_BRACKET_GROUP.findall(title.lower()):
+            group_words = set(re.findall(r"[a-z0-9]+", group))
+            if group_words & _REMIX_CREDIT_WORDS and whole_word.search(group):
+                return True
+    return False
+
+
 def _fingerprint_disagrees(fp, expected_track, expected_artist: str | None) -> bool:
     """True only when AcoustID CONFIDENTLY (status=pass) identified the audio as a clearly
     different SONG, or a clearly different ARTIST, than expected. Release-group/edition is
@@ -324,11 +354,11 @@ def _fingerprint_disagrees(fp, expected_track, expected_artist: str | None) -> b
         )
         if best < 55:
             # Remix: AcoustID credits the ORIGINAL artist - "Song (Artist B
-            # remix)" carries the credit of "Song"'s artist. The requested artist
-            # named in the track title is positive evidence of the right
-            # recording, not a wrong-artist hit.
-            titles = f"{expected_title or ''} {fp_title or ''}".lower()
-            if expected_artist.lower() not in titles:
+            # remix)" carries the credit of "Song"'s artist. Only an explicit
+            # bracketed remix/credit naming the requested artist counts as
+            # evidence (see _title_credits_artist) - a bare substring would let
+            # common-word artist names waive confident wrong-artist results.
+            if not _title_credits_artist(expected_artist, expected_title, fp_title):
                 return True
     return False
 

--- a/backend/services/native/naming.py
+++ b/backend/services/native/naming.py
@@ -91,9 +91,15 @@ class NamingTemplateEngine:
                 result.append(self._INVALID_FS_CHARS.sub("_", value))
             else:
                 result.append(part)
+        rendered = "".join(result)
+        # An empty variable leaves bracket litter from its template decoration -
+        # "{album} ({year})" with no year renders "Album ()". Collapse empty
+        # (), [] and {} groups (and their leading spaces) instead of shipping
+        # them into folder names.
+        rendered = re.sub(r"\s*(\(\s*\)|\[\s*\]|\{\s*\})", "", rendered)
         # Literals already carry the "/" separators; Path() splits them into
         # components, which _normalize then cleans individually.
-        return Path("".join(result))
+        return Path(rendered)
 
     def _lookup(self, var: str, tag: AudioTag, ext: str) -> str:
         match var:

--- a/backend/tests/services/test_file_processor.py
+++ b/backend/tests/services/test_file_processor.py
@@ -724,12 +724,41 @@ def test_fingerprint_allows_requested_collab_when_credit_names_one_member():
 
 def test_fingerprint_allows_remix_credited_to_original_artist():
     # AcoustID credits the original performer of a remix; the requested artist
-    # (the remixer) is named in the track title - that's the right recording.
+    # (the remixer) is named in a bracketed remix credit - right recording.
     from models.download_manifest import ExpectedTrack
     from services.native.file_processor import _fingerprint_disagrees
     track = ExpectedTrack(track_number=1, title="Higher Love (Kygo Remix)")
     fp = _fp(title="Higher Love (Kygo remix)", artist="Whitney Houston")
     assert _fingerprint_disagrees(fp, track, "Kygo") is False
+
+
+def test_fingerprint_allows_bracketed_feat_credit():
+    # "(feat. Artist)" is an explicit guest credit - same evidence as a remix.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Some Song (feat. Air)")
+    fp = _fp(title="Some Song (feat. Air)", artist="Lead Performer")
+    assert _fingerprint_disagrees(fp, track, "Air") is False
+
+
+def test_fingerprint_rejects_substring_artist_match_in_title():
+    # A bare substring is NOT remix evidence: expected artist "Air" appearing
+    # inside the word "Airbag" must not waive a confident wrong-artist result.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Airbag")
+    fp = _fp(title="Airbag", artist="Radiohead")
+    assert _fingerprint_disagrees(fp, track, "Air")
+
+
+def test_fingerprint_rejects_bracketed_artist_without_credit_keyword():
+    # The artist's name in brackets with no remix/feat keyword is ambiguous -
+    # not enough to overrule AcoustID's confident different-artist verdict.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Some Song (Air)")
+    fp = _fp(title="Some Song (Air)", artist="Radiohead")
+    assert _fingerprint_disagrees(fp, track, "Air")
 
 
 def test_fingerprint_still_rejects_unrelated_artist_with_matching_title():

--- a/backend/tests/services/test_file_processor.py
+++ b/backend/tests/services/test_file_processor.py
@@ -685,6 +685,72 @@ def test_fingerprint_skips_artist_check_for_various_artists():
     assert _fingerprint_disagrees(fp, None, "Various Artists") is False
 
 
+# --- fingerprint collab & remix credit handling --------------------------------------------
+
+def test_fingerprint_allows_collab_credit_containing_requested_artist():
+    # AcoustID credits the full collaboration; the request is for one member.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Electricity")
+    fp = _fp(title="Electricity", artist="Silk City; Dua Lipa")
+    assert _fingerprint_disagrees(fp, track, "Dua Lipa") is False
+
+
+def test_fingerprint_allows_collab_across_separator_styles():
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Song")
+    for credit in (
+        "Someone feat. Mark Ronson",
+        "Someone ft. Mark Ronson",
+        "Someone & Mark Ronson",
+        "Someone, Mark Ronson",
+        "Someone vs. Mark Ronson",
+        "Someone x Mark Ronson",
+        "Someone with Mark Ronson",
+    ):
+        fp = _fp(title="Song", artist=credit)
+        assert _fingerprint_disagrees(fp, track, "Mark Ronson") is False, credit
+
+
+def test_fingerprint_allows_requested_collab_when_credit_names_one_member():
+    # Mirror case: the REQUEST carries the collab credit, AcoustID names a member.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Song")
+    fp = _fp(title="Song", artist="Mark Ronson")
+    assert _fingerprint_disagrees(fp, track, "Mark Ronson & Diplo") is False
+
+
+def test_fingerprint_allows_remix_credited_to_original_artist():
+    # AcoustID credits the original performer of a remix; the requested artist
+    # (the remixer) is named in the track title - that's the right recording.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Higher Love (Kygo Remix)")
+    fp = _fp(title="Higher Love (Kygo remix)", artist="Whitney Houston")
+    assert _fingerprint_disagrees(fp, track, "Kygo") is False
+
+
+def test_fingerprint_still_rejects_unrelated_artist_with_matching_title():
+    # The collab/remix allowances must not weaken the plain wrong-artist case:
+    # same title, artist unrelated on both sides, not named in the title.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Hello")
+    fp = _fp(title="Hello", artist="Adele")
+    assert _fingerprint_disagrees(fp, track, "Metallica")
+
+
+def test_fingerprint_still_rejects_wrong_song_from_collab_member():
+    # The title gate has precedence: right artist member, clearly different song.
+    from models.download_manifest import ExpectedTrack
+    from services.native.file_processor import _fingerprint_disagrees
+    track = ExpectedTrack(track_number=1, title="Electricity")
+    fp = _fp(title="Find U Again", artist="Silk City; Dua Lipa")
+    assert _fingerprint_disagrees(fp, track, "Dua Lipa")
+
+
 # --- import-time wrong-album guard (#1, tagless-safe) -------------------------------------
 
 def _fc(album: str, *, artist: str = "Led Zeppelin", album_artist: str | None = None) -> _FolderCandidate:

--- a/backend/tests/services/test_naming_template_engine.py
+++ b/backend/tests/services/test_naming_template_engine.py
@@ -51,9 +51,27 @@ def test_track_without_format_spec_is_unpadded(engine):
     assert result == Path("7")
 
 
-def test_year_empty_when_none(engine):
+def test_year_empty_when_none_leaves_no_bracket_litter(engine):
+    # An empty variable must not leave its template decoration behind:
+    # "{album} ({year})" with no year renders "OK Computer", not "OK Computer ()".
     result = engine.format_path("{album} ({year})", _tag(year=None), "flac")
-    assert result == Path("OK Computer ()")
+    assert result == Path("OK Computer")
+
+
+def test_default_template_without_year_has_no_empty_parens(engine):
+    result = engine.format_path(engine.DEFAULT, _tag(year=None), "flac")
+    assert result == Path("Radiohead/OK Computer/0101 Airbag.flac")
+
+
+def test_empty_square_bracket_group_collapsed(engine):
+    result = engine.format_path("{album} [{year}]/{title}.{ext}", _tag(year=None), "flac")
+    assert result == Path("OK Computer/Airbag.flac")
+
+
+def test_year_present_keeps_its_brackets(engine):
+    # Only EMPTY groups are collapsed - a populated year renders as before.
+    result = engine.format_path("{album} ({year})", _tag(year=1997), "flac")
+    assert result == Path("OK Computer (1997)")
 
 
 def test_unknown_variable_renders_empty(engine):


### PR DESCRIPTION
## What

Two small fixes in the native download engine, found while running DroppedNeedle against a real Soulseek library:

### 1. Fingerprint verify: collaboration and remix credits are held as "wrong artist"

`_fingerprint_disagrees()` compares the AcoustID artist credit against the requested artist with a single `token_set_ratio`. That scores `"Artist A"` vs `"Artist A; Artist B"` **below the 55 gate** (the separator glues tokens), so every collab track requested under a solo artist — and every remix, where AcoustID credits the *original* artist — lands in Held for review despite being the correct recording.

This PR wires in `split_artist_credit()` — which already existed in `fingerprinter.py` with a docstring noting it was *"not yet wired into the scanner"* — exactly as its plan note intended:

- The artist check now takes the best `token_set_ratio` across the cross-product of split credits on **both** sides (plus the full strings), so a request for any credited member of a collab passes.
- Remix rule: when the requested artist is named in the track title itself (`Song (Artist B remix)` credited to the original artist of `Song`), that's positive evidence of the right recording, not a wrong-artist hit.
- The **title gate is unchanged** — genuinely mislabeled files are still held.

### 2. Naming: unknown year renders `Album ()`

`{album} ({year})` with no year produced folders like `Album ()`. `_render()` now collapses empty `()`, `[]` and `{}` groups (and their leading spaces) left behind by empty variables.

## Testing

Verified against 16 real-world held items from a live instance:
- 15 collab/remix cases (two- and four-artist credits, plus remixes credited to their original artists) become import-eligible
- 1 true mislabel (a file whose audio fingerprints as a different song by a different artist, AcoustID 0.97) is **still held** ✔
- Various-artists skip and non-pass fail-open behaviour unchanged
- Naming renders correctly both with a year (`Artist/Album (2015)/0101 Title.flac`) and without (`Artist/Album/0101 Title.flac`)

## AI-Assisted Contributions

This PR was written with heavy AI assistance: Claude (via Claude Code) diagnosed the held-queue behaviour on my live instance, wrote both patches and the commit, and ran the verification cases above against the container image. I directed the work, reviewed the changes, and I'm running the patched build in production — but reviewers should calibrate scrutiny accordingly, per CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
