### PR TITLE
feat(discover): Taste Graph - recommendations from the user's own signals via MusicBrainz relationships

### DIFF
--- a/backend/api/v1/routes/taste_graph.py
+++ b/backend/api/v1/routes/taste_graph.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+
+from api.v1.schemas.taste_graph import TasteGraphResponse
+from core.dependencies import get_taste_graph_service
+from core.dependencies.type_aliases import CurrentUserDep
+from infrastructure.msgspec_fastapi import MsgSpecRoute
+from services.taste_graph_service import TasteGraphService
+
+router = APIRouter(route_class=MsgSpecRoute, prefix="/discover", tags=["discover"])
+
+
+@router.get("/taste-graph", response_model=TasteGraphResponse)
+async def get_taste_graph(
+    current_user: CurrentUserDep,
+    service: TasteGraphService = Depends(get_taste_graph_service),
+) -> TasteGraphResponse:
+    """Recommendations built ONLY from this user's own signals (library, follows,
+    play history) expanded through canonical MusicBrainz metadata — never charts,
+    global popularity, or other users' listens. An empty library returns a
+    graceful cold-start response."""
+    return await service.get_taste_graph(current_user.id)

--- a/backend/api/v1/schemas/taste_graph.py
+++ b/backend/api/v1/schemas/taste_graph.py
@@ -1,0 +1,38 @@
+"""Taste Graph — recommendations derived ONLY from this user's own signals
+(library, follows, play history) expanded through canonical MusicBrainz
+metadata. No external charts, no global popularity, no other users' data."""
+
+from typing import Literal
+
+from infrastructure.msgspec_fastapi import AppStruct
+
+
+class TasteGraphReason(AppStruct):
+    type: Literal["collaborator", "member", "label", "scene"]
+    label: str
+    via_mbid: str | None = None
+    via_name: str | None = None
+
+
+class TasteGraphSeed(AppStruct):
+    artist_mbid: str
+    name: str
+    weight: float
+
+
+class TasteGraphItem(AppStruct):
+    kind: Literal["artist", "album"]
+    mbid: str
+    name: str
+    score: float
+    reasons: list[TasteGraphReason] = []
+    artist_mbid: str | None = None
+    artist_name: str | None = None
+    in_library: bool = False
+
+
+class TasteGraphResponse(AppStruct):
+    cold_start: bool = False
+    generated_at: str = ""
+    seeds: list[TasteGraphSeed] = []
+    items: list[TasteGraphItem] = []

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -124,6 +124,7 @@ from .service_providers import (  # noqa: F401
     get_scrobble_service,
     get_discover_service,
     get_discover_queue_manager,
+    get_taste_graph_service,
     get_discovery_batch_service,
     get_jellyfin_playback_service,
     get_local_files_service,

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -844,6 +844,20 @@ def get_scrobble_service() -> "ScrobbleService":
 
 
 @singleton
+def get_taste_graph_service() -> "TasteGraphService":
+    from services.taste_graph_service import TasteGraphService
+
+    return TasteGraphService(
+        library_db=get_library_db(),
+        follow_store=get_follow_store(),
+        play_history_store=get_play_history_store(),
+        mb_repo=get_musicbrainz_repository(),
+        cache=get_cache(),
+        genre_index=get_genre_index(),
+    )
+
+
+@singleton
 def get_discover_service() -> "DiscoverService":
     from services.discover_service import DiscoverService
     from services.discover.radio_service import DiscoverRadioService

--- a/backend/infrastructure/cache/cache_keys.py
+++ b/backend/infrastructure/cache/cache_keys.py
@@ -15,6 +15,10 @@ MB_RECORDING_TO_RG_PREFIX = "mb:recording_to_rg:"
 MB_ARTIST_RELS_PREFIX = "mb:artist_rels:"
 MB_ARTISTS_BY_TAG_PREFIX = "mb_artists_by_tag:"
 MB_RG_BY_TAG_PREFIX = "mb_rg_by_tag:"
+MB_ARTIST_EXPANSION_PREFIX = "mb:artist_expansion:"
+MB_LABEL_RELEASES_PREFIX = "mb:label_releases:"
+
+TASTE_GRAPH_PREFIX = "taste_graph:"
 
 LB_PREFIX = "lb_"
 
@@ -96,6 +100,8 @@ def musicbrainz_prefixes() -> list[str]:
         MB_ARTIST_RELS_PREFIX,
         MB_ARTISTS_BY_TAG_PREFIX,
         MB_RG_BY_TAG_PREFIX,
+        MB_ARTIST_EXPANSION_PREFIX,
+        MB_LABEL_RELEASES_PREFIX,
     ]
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from api.v1.routes import (
 from api.v1.routes import (
     discovery_batches as discovery_batches_routes
 )
+from api.v1.routes import taste_graph as taste_graph_routes
 from api.v1.routes import library_scan as library_scan_routes
 from api.v1.routes import cache as cache_routes
 from api.v1.routes import cache_status as cache_status_routes
@@ -729,6 +730,9 @@ v1_router.include_router(wrapped.router)
 # literal /discover/batches paths registered before the discover router (which owns
 # the broader /discover prefix) so they can never be shadowed
 v1_router.include_router(discovery_batches_routes.router)
+# literal /discover/taste-graph path, registered alongside the other literal
+# /discover/* routers before the main discover router
+v1_router.include_router(taste_graph_routes.router)
 v1_router.include_router(discover.router)
 v1_router.include_router(youtube_routes.router)
 v1_router.include_router(cache_routes.router)

--- a/backend/repositories/musicbrainz_artist.py
+++ b/backend/repositories/musicbrainz_artist.py
@@ -12,6 +12,7 @@ from infrastructure.cache.memory_cache import CacheInterface
 from infrastructure.cache.cache_keys import (
     mb_artist_search_key, mb_artist_detail_key,
     MB_ARTISTS_BY_TAG_PREFIX, MB_ARTIST_RELS_PREFIX,
+    MB_ARTIST_EXPANSION_PREFIX, MB_LABEL_RELEASES_PREFIX,
 )
 from infrastructure.queue.priority_queue import RequestPriority
 from infrastructure.resilience.retry import CircuitOpenError
@@ -256,6 +257,60 @@ class MusicBrainzArtistMixin:
                 await self.get_release_group_by_id(rg_id, priority=RequestPriority.BACKGROUND_SYNC)
             except (CircuitOpenError, ExternalServiceError, httpx.HTTPError):
                 pass
+
+    async def get_artist_expansion(self, mbid: str) -> dict | None:
+        """Artist relationships (band members, collaborations, tributes), label
+        relations, and tags — the taste-graph expansion payload. One MB call per
+        artist per 24h (cached + deduplicated); BACKGROUND_SYNC priority so it can
+        never starve user-initiated lookups."""
+        cache_key = f"{MB_ARTIST_EXPANSION_PREFIX}{mbid}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        return await mb_deduplicator.dedupe(
+            cache_key, lambda: self._fetch_artist_expansion(mbid, cache_key)
+        )
+
+    async def _fetch_artist_expansion(self, mbid: str, cache_key: str) -> dict | None:
+        try:
+            result = await mb_api_get(
+                f"/artist/{mbid}",
+                params={"inc": "artist-rels+label-rels+tags"},
+                priority=RequestPriority.BACKGROUND_SYNC,
+            )
+            if not result:
+                return None
+            await self._cache.set(cache_key, result, ttl_seconds=86400)
+            return result
+        except Exception as e:  # noqa: BLE001 - one seed failing must not sink the graph
+            logger.error(f"Failed to fetch artist expansion {mbid}: {e}")
+            _record_mb_degradation(f"artist expansion failed: {e}")
+            return None
+
+    async def get_label_releases(self, label_mbid: str, limit: int = 25) -> list[dict[str, Any]]:
+        """Releases on a label (with release-groups + artist credits), for
+        label-mate discovery. Cached 24h; BACKGROUND_SYNC priority."""
+        cache_key = f"{MB_LABEL_RELEASES_PREFIX}{label_mbid}:{limit}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        try:
+            result = await mb_api_get(
+                "/release",
+                params={
+                    "label": label_mbid,
+                    "inc": "release-groups+artist-credits",
+                    "limit": min(100, limit),
+                },
+                priority=RequestPriority.BACKGROUND_SYNC,
+            )
+            releases = result.get("releases", []) if isinstance(result, dict) else []
+            await self._cache.set(cache_key, releases, ttl_seconds=86400)
+            return releases
+        except Exception as e:  # noqa: BLE001 - one label failing must not sink the graph
+            logger.error(f"Failed to fetch label releases {label_mbid}: {e}")
+            _record_mb_degradation(f"label releases failed: {e}")
+            return []
 
     async def get_artist_release_groups(
         self,

--- a/backend/services/discover/genre_balance.py
+++ b/backend/services/discover/genre_balance.py
@@ -1,0 +1,312 @@
+"""Genre-balance helpers shared by Discover and the Taste Graph.
+
+A library skewed toward one genre (say 40% K-pop) used to dominate every
+recommendation zone because seeds were picked by raw play/album counts.
+These pure helpers fix that in three ways:
+
+- ``genre_family``       - normalises genre spellings ("k-pop", "kpop",
+                           "korean pop") into one family so caps and prefs
+                           apply to the family, not each spelling.
+- ``balanced_seed_selection`` - picks seeds round-robin across genre
+                           families with sqrt-damped family weights instead
+                           of raw frequency order.
+- ``cap_genre_share``    - enforces a per-zone share cap (~35%) for any one
+                           family, and excludes muted families entirely.
+- ``diverse_genre_selection`` - reorders (genre, count) rows for genre-seeded
+                           builders (daily mixes) with the same damping.
+
+User control arrives as :class:`GenrePrefs` levels per family:
+"reduce" halves a family's weight/allowance, "mute" excludes it.
+Items whose genres are unknown are never penalised - they pass through.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Iterable, Sequence, TypeVar
+
+T = TypeVar("T")
+
+# Default per-zone share cap for a single genre family (~a third of a zone).
+GENRE_SHARE_CAP = 0.35
+
+GENRE_PREF_LEVELS = ("normal", "reduce", "mute")
+
+# Alias map applied AFTER _canon() (lowercase, separators collapsed to single
+# spaces), so one entry covers "k-pop"/"K Pop"/"k_pop". Keep it small and
+# focused: the token rules below catch the systematic "k-"/"j-" prefixes.
+_FAMILY_ALIASES: dict[str, str] = {
+    "kpop": "k-pop",
+    "k pop": "k-pop",
+    "korean pop": "k-pop",
+    "korean idol": "k-pop",
+    "jpop": "j-pop",
+    "j pop": "j-pop",
+    "japanese pop": "j-pop",
+    "hiphop": "hip hop",
+    "hip hop": "hip hop",
+    "rap": "hip hop",
+    "rnb": "r&b",
+    "r&b": "r&b",
+    "r and b": "r&b",
+    "contemporary r&b": "r&b",
+    "electronica": "electronic",
+    "edm": "electronic",
+}
+
+
+def _canon(genre: str) -> str:
+    lowered = genre.strip().lower()
+    for sep in ("-", "_", "/"):
+        lowered = lowered.replace(sep, " ")
+    return " ".join(lowered.split())
+
+
+def genre_family(genre: str | None) -> str:
+    """Canonical family name for a genre string; "" when unknown/blank."""
+    if not isinstance(genre, str) or not genre.strip():
+        return ""
+    canon = _canon(genre)
+    alias = _FAMILY_ALIASES.get(canon)
+    if alias:
+        return alias
+    tokens = canon.split()
+    # "korean ballad", "k rock" style spellings group under the Korean family;
+    # same for Japanese. This is deliberately broad: the point of the family is
+    # the balance cap, not taxonomy.
+    if "korean" in tokens or tokens[0] == "kpop":
+        return "k-pop"
+    if "japanese" in tokens or tokens[0] == "jpop":
+        return "j-pop"
+    if len(tokens) > 1 and tokens[0] == "k":
+        return "k-pop"
+    if len(tokens) > 1 and tokens[0] == "j":
+        return "j-pop"
+    return canon
+
+
+class GenrePrefs:
+    """Per-user genre-family preference levels ("reduce" / "mute").
+
+    Families not present are "normal". Keys are normalised through
+    :func:`genre_family` so any spelling stored still matches.
+    """
+
+    __slots__ = ("_levels",)
+
+    def __init__(self, levels: dict[str, str] | None = None) -> None:
+        self._levels: dict[str, str] = {}
+        for raw_family, level in (levels or {}).items():
+            family = genre_family(raw_family)
+            if family and level in ("reduce", "mute"):
+                self._levels[family] = level
+
+    def is_empty(self) -> bool:
+        return not self._levels
+
+    def level(self, family: str) -> str:
+        return self._levels.get(family, "normal")
+
+    def is_muted(self, family: str) -> bool:
+        return self._levels.get(family) == "mute"
+
+    def multiplier(self, family: str) -> float:
+        level = self._levels.get(family)
+        if level == "mute":
+            return 0.0
+        if level == "reduce":
+            return 0.5
+        return 1.0
+
+    def levels(self) -> dict[str, str]:
+        return dict(self._levels)
+
+
+EMPTY_GENRE_PREFS = GenrePrefs()
+
+
+def primary_family(genres: Iterable[str] | None) -> str:
+    """First known family among an item's genres; "" for unknown."""
+    for g in genres or []:
+        family = genre_family(g)
+        if family:
+            return family
+    return ""
+
+
+def balanced_seed_selection(
+    candidates: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+) -> list[T]:
+    """Pick up to ``limit`` seeds spread across genre families.
+
+    ``candidates`` arrive in preference order (most-played first). Candidates
+    are grouped by primary family; families are ordered by sqrt-damped size
+    times the user's pref multiplier (so a 40%-of-library family no longer
+    swamps the seed set, and "reduce" halves its priority); seeds are then
+    taken round-robin across families. Muted families are excluded. Unknown-
+    genre candidates share one "" bucket, so with no genre data at all this
+    degrades to the original take-the-first-``limit`` behaviour.
+    """
+    if limit <= 0 or not candidates:
+        return []
+
+    buckets: dict[str, list[T]] = {}
+    order: dict[str, int] = {}
+    for index, candidate in enumerate(candidates):
+        family = primary_family(genres_of(candidate))
+        if family and prefs.is_muted(family):
+            continue
+        buckets.setdefault(family, []).append(candidate)
+        order.setdefault(family, index)
+
+    if not buckets:
+        return []
+
+    def family_weight(item: tuple[str, list[T]]) -> tuple[float, int]:
+        family, members = item
+        multiplier = prefs.multiplier(family) if family else 1.0
+        return (-(multiplier * math.sqrt(len(members))), order[family])
+
+    ordered_families = [members for _, members in sorted(buckets.items(), key=family_weight)]
+
+    selected: list[T] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for members in ordered_families:
+            if round_index < len(members):
+                selected.append(members[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def cap_genre_share(
+    items: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    *,
+    cap_ratio: float = GENRE_SHARE_CAP,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    target_size: int | None = None,
+    counts: dict[str, int] | None = None,
+    total_allowed: int | None = None,
+) -> list[T]:
+    """Order-preserving filter enforcing mute + a per-family share cap.
+
+    Any single family keeps at most ``max(1, ceil(cap_ratio * size))`` items
+    where ``size`` is ``target_size`` (or the input length); a reduced family
+    keeps half that. Unknown-genre items always pass. Items skipped for being
+    over-cap simply yield their slot to the next (other-genre) items in the
+    list - the backfill.
+
+    ``counts``/``total_allowed`` allow a caller to thread page-wide family
+    counters through multiple zones so the cap also holds across the whole
+    assembled page, not just inside one zone.
+    """
+    size = target_size if target_size is not None else len(items)
+    if size <= 0:
+        return list(items)
+    base_allowance = max(1, math.ceil(cap_ratio * size))
+
+    local_counts: dict[str, int] = {}
+    kept: list[T] = []
+    for item in items:
+        family = primary_family(genres_of(item))
+        if not family:
+            kept.append(item)
+            continue
+        if prefs.is_muted(family):
+            continue
+        allowance = base_allowance
+        if prefs.level(family) == "reduce":
+            allowance = max(1, base_allowance // 2)
+        if local_counts.get(family, 0) >= allowance:
+            continue
+        if counts is not None and total_allowed is not None:
+            if counts.get(family, 0) >= total_allowed:
+                continue
+            counts[family] = counts.get(family, 0) + 1
+        local_counts[family] = local_counts.get(family, 0) + 1
+        kept.append(item)
+    return kept
+
+
+def diverse_genre_selection(
+    top_genres: Sequence[tuple[str, int]],
+    *,
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    max_per_family: int = 2,
+) -> list[tuple[str, int]]:
+    """Rebalance (genre, count) rows for genre-seeded builders.
+
+    Counts are sqrt-damped and scaled by the user's pref multiplier, muted
+    families drop out, and at most ``max_per_family`` genres of one family
+    survive - so five K-pop spellings can't claim five daily-mix clusters.
+    Families are interleaved (best genre of each family first) so the result
+    leads with breadth.
+    """
+    if limit <= 0:
+        return []
+
+    weighted: list[tuple[float, int, str, int]] = []
+    for index, (genre, count) in enumerate(top_genres):
+        family = genre_family(genre)
+        multiplier = prefs.multiplier(family) if family else 1.0
+        if multiplier <= 0.0:
+            continue
+        weighted.append((multiplier * math.sqrt(max(count, 0) + 1), index, genre, count))
+    weighted.sort(key=lambda row: (-row[0], row[1]))
+
+    per_family: dict[str, list[tuple[str, int]]] = {}
+    family_order: list[str] = []
+    for _, _, genre, count in weighted:
+        family = genre_family(genre) or genre
+        rows = per_family.setdefault(family, [])
+        if family not in family_order:
+            family_order.append(family)
+        if len(rows) < max_per_family:
+            rows.append((genre, count))
+
+    selected: list[tuple[str, int]] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for family in family_order:
+            rows = per_family[family]
+            if round_index < len(rows):
+                selected.append(rows[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def genres_lookup(
+    genres_by_artist: dict[str, list[str]] | None,
+) -> Callable[[Any], list[str]]:
+    """genres_of adapter for HomeArtist/HomeAlbum/TopPickItem-shaped items,
+    resolving through a {artist_mbid_lower: [genres]} map."""
+    mapping = genres_by_artist or {}
+
+    def lookup(item: Any) -> list[str]:
+        mbid = getattr(item, "artist_mbid", None) or getattr(item, "mbid", None)
+        if not mbid:
+            album = getattr(item, "album", None)
+            if album is not None:
+                mbid = getattr(album, "artist_mbid", None)
+        if not mbid:
+            return []
+        return mapping.get(str(mbid).lower(), [])
+
+    return lookup

--- a/backend/services/taste_graph_service.py
+++ b/backend/services/taste_graph_service.py
@@ -1,0 +1,541 @@
+"""Taste Graph — self-contained discovery from the user's OWN signals only.
+
+Seeds are weighted from this user's library (artists + album counts), followed
+artists, and recent play history (followed > recently played > library
+presence). The top seeds are expanded through canonical MusicBrainz metadata
+only: artist relationships (band members, collaborations, tributes), shared
+labels, and shared tags. HARD RULE (by design): no ListenBrainz/Last.fm charts,
+no sitewide/global popularity, no other users' listens anywhere in this path.
+
+MB call budget per build: <= _MAX_SEEDS expansion lookups + _MAX_LABELS label
+browses + _MAX_TAGS tag searches (~14 worst case), every one 24h-cached inside
+the MusicBrainz repository, and the assembled graph itself is cached per user
+for 24h — so steady state is zero MB calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from datetime import datetime, timezone
+
+from api.v1.schemas.taste_graph import (
+    TasteGraphItem,
+    TasteGraphReason,
+    TasteGraphResponse,
+    TasteGraphSeed,
+)
+from infrastructure.cache.cache_keys import TASTE_GRAPH_PREFIX
+from services.discover.genre_balance import (
+    EMPTY_GENRE_PREFS,
+    GenrePrefs,
+    balanced_seed_selection,
+    genre_family,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_SEEDS = 10
+_MAX_LABELS = 2
+_MAX_TAGS = 2
+_MAX_ITEMS = 30
+_MAX_PER_SEED = 3  # diversity: max candidates attributed to one seed
+_GENRE_CAP_RATIO = 0.4  # diversity: max 40% of items sharing one genre
+_GRAPH_TTL_SECONDS = 86400
+# on a completely cold MB cache the expansion is rate-limited (~1 req/s); bound the
+# request so the endpoint stays responsive and the next request reuses the MB-layer
+# cache entries that did land.
+_BUILD_BUDGET_SECONDS = 60
+
+_RECENT_PLAYS_LIMIT = 200
+
+# signal weights: followed > recently played > library presence
+_FOLLOW_WEIGHT = 3.0
+_RECENT_PLAY_WEIGHT = 0.2  # per play, capped
+_RECENT_PLAY_MAX = 2.0
+_LIBRARY_BASE_WEIGHT = 1.0
+_LIBRARY_ALBUM_WEIGHT = 0.25  # per owned album, capped at 8
+
+# relationship strength: member/collab > label-mate > shared tag
+_MEMBER_STRENGTH = 1.0
+_COLLAB_STRENGTH = 0.9
+_LABEL_STRENGTH = 0.7
+_SCENE_STRENGTH = 0.5
+
+_MEMBER_REL_TYPES = {"member of band", "founder", "subgroup"}
+_COLLAB_REL_TYPES = {
+    "collaboration",
+    "is person",
+    "tribute",
+    "supporting musician",
+    "instrumental supporting musician",
+    "vocal supporting musician",
+    "voice actor",
+}
+_ARTIST_LABEL_REL_TYPES = {"recording contract", "label founder", "publishing"}
+
+# never recommend these placeholder artists
+_FILTERED_CANDIDATE_NAMES = {"various artists", "[unknown]", "/v/"}
+
+
+class _Seed:
+    __slots__ = ("mbid", "name", "weight", "norm_weight", "top_tag")
+
+    def __init__(self, mbid: str, name: str, weight: float):
+        self.mbid = mbid
+        self.name = name
+        self.weight = weight
+        self.norm_weight = 1.0
+        self.top_tag: str = ""
+
+
+class _Candidate:
+    __slots__ = ("kind", "mbid", "name", "artist_mbid", "artist_name", "score", "reasons", "genre")
+
+    def __init__(self, kind, mbid, name, artist_mbid, artist_name, score, reason, genre):
+        self.kind = kind
+        self.mbid = mbid
+        self.name = name
+        self.artist_mbid = artist_mbid
+        self.artist_name = artist_name
+        self.score = score
+        self.reasons: list[TasteGraphReason] = [reason]
+        self.genre = genre
+
+
+class TasteGraphService:
+    def __init__(
+        self,
+        library_db,
+        follow_store,
+        play_history_store,
+        mb_repo,
+        cache,
+        genre_index=None,
+        genre_prefs_store=None,
+    ) -> None:
+        self._library_db = library_db
+        self._follow_store = follow_store
+        self._play_history = play_history_store
+        self._mb_repo = mb_repo
+        self._cache = cache
+        # optional: library genre index for breadth-based seed balancing, and the
+        # user's genre reduce/mute levels; both degrade to the old behaviour when absent
+        self._genre_index = genre_index
+        self._genre_prefs_store = genre_prefs_store
+
+    async def get_taste_graph(self, user_id: str) -> TasteGraphResponse:
+        cache_key = f"{TASTE_GRAPH_PREFIX}{user_id}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        response = await self._build(user_id)
+        # a timed-out/failed expansion returns seeds with no items — don't pin
+        # that for 24h, let the next request retry on the warmed MB cache
+        if response.cold_start or response.items:
+            await self._cache.set(cache_key, response, ttl_seconds=_GRAPH_TTL_SECONDS)
+        return response
+
+    async def _build(self, user_id: str) -> TasteGraphResponse:
+        generated_at = datetime.now(timezone.utc).isoformat()
+        prefs = await self._load_genre_prefs(user_id)
+        seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names = (
+            await self._collect_seeds(user_id, prefs)
+        )
+        if not seeds:
+            return TasteGraphResponse(
+                cold_start=True, generated_at=generated_at, seeds=[], items=[]
+            )
+
+        try:
+            items = await asyncio.wait_for(
+                self._expand(
+                    seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names, prefs
+                ),
+                timeout=_BUILD_BUDGET_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Taste graph expansion exceeded its budget for user %s", user_id[:8])
+            items = []
+        except Exception:  # noqa: BLE001 - the endpoint must degrade, not 500
+            logger.error("Taste graph expansion failed for user %s", user_id[:8], exc_info=True)
+            items = []
+
+        return TasteGraphResponse(
+            cold_start=False,
+            generated_at=generated_at,
+            seeds=[
+                TasteGraphSeed(artist_mbid=s.mbid, name=s.name, weight=round(s.norm_weight, 4))
+                for s in seeds
+            ],
+            items=items,
+        )
+
+    # ------------------------------------------------------------------ seeds
+
+    async def _load_genre_prefs(self, user_id: str) -> GenrePrefs:
+        if self._genre_prefs_store is None:
+            return EMPTY_GENRE_PREFS
+        try:
+            return GenrePrefs(await self._genre_prefs_store.get_levels(user_id))
+        except Exception:  # noqa: BLE001 - prefs must never break the graph
+            return EMPTY_GENRE_PREFS
+
+    async def _collect_seeds(
+        self, user_id: str, prefs: GenrePrefs = EMPTY_GENRE_PREFS
+    ) -> tuple[list[_Seed], set[str], set[str], set[str]]:
+        artists, albums_for_matching, album_mbids, followed, recent = await asyncio.gather(
+            self._library_db.get_artists(),
+            self._library_db.get_all_albums_for_matching(),
+            self._library_db.get_all_album_mbids(),
+            self._follow_store.list_followed_artists(user_id),
+            self._play_history.recent(user_id, limit=_RECENT_PLAYS_LIMIT),
+        )
+
+        owned_artist_mbids = {
+            str(a.get("mbid", "")).lower() for a in artists if a.get("mbid")
+        }
+        owned_artist_names = {
+            str(a.get("name", "")).lower() for a in artists if a.get("name")
+        }
+        owned_album_mbids = {m.lower() for m in album_mbids}
+
+        album_counts: dict[str, int] = {}
+        for _title, _artist_name, _album_mbid, artist_mbid in albums_for_matching:
+            key = artist_mbid.lower()
+            if key:
+                album_counts[key] = album_counts.get(key, 0) + 1
+
+        name_to_mbid = {
+            str(a.get("name", "")).lower(): str(a.get("mbid", ""))
+            for a in artists
+            if a.get("name") and a.get("mbid")
+        }
+        play_counts: dict[str, int] = {}
+        for record in recent:
+            mbid = name_to_mbid.get((record.artist_name or "").lower())
+            if mbid:
+                play_counts[mbid.lower()] = play_counts.get(mbid.lower(), 0) + 1
+
+        weights: dict[str, float] = {}
+        names: dict[str, str] = {}
+
+        for a in artists:
+            mbid = str(a.get("mbid", "")).lower()
+            if not mbid:
+                continue
+            names[mbid] = str(a.get("name", "")) or mbid
+            weights[mbid] = _LIBRARY_BASE_WEIGHT + _LIBRARY_ALBUM_WEIGHT * min(
+                album_counts.get(mbid, 0), 8
+            )
+
+        for mbid, plays in play_counts.items():
+            weights[mbid] = weights.get(mbid, 0.0) + min(
+                plays * _RECENT_PLAY_WEIGHT, _RECENT_PLAY_MAX
+            )
+
+        for f in followed:
+            mbid = f.artist_mbid.lower()
+            names.setdefault(mbid, f.artist_name)
+            weights[mbid] = weights.get(mbid, 0.0) + _FOLLOW_WEIGHT
+
+        if not weights:
+            return [], owned_artist_mbids, owned_album_mbids, owned_artist_names
+
+        candidates = sorted(weights.items(), key=lambda kv: kv[1], reverse=True)
+        top = await self._balance_seed_candidates(candidates, prefs)
+        if not top:
+            return [], owned_artist_mbids, owned_album_mbids, owned_artist_names
+        max_weight = max(w for _, w in top) or 1.0
+        seeds = [_Seed(mbid, names.get(mbid, mbid), weight) for mbid, weight in top]
+        for s in seeds:
+            s.norm_weight = s.weight / max_weight
+        return seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names
+
+    async def _balance_seed_candidates(
+        self, candidates: list[tuple[str, float]], prefs: GenrePrefs
+    ) -> list[tuple[str, float]]:
+        """Breadth-based seeding: instead of the raw top-N by weight (which a
+        genre-skewed library dominates), spread the _MAX_SEEDS picks round-robin
+        across genre FAMILIES, sqrt-damped, from a 3x-deep candidate pool. The
+        user's prefs apply first: muted families are dropped, reduced families'
+        weights halved. Without a genre index this stays the plain top-N."""
+        pool = candidates[: _MAX_SEEDS * 3]
+        genres: dict[str, list[str]] = {}
+        if self._genre_index is not None and pool:
+            try:
+                genres = await self._genre_index.get_genres_for_artists(
+                    [mbid for mbid, _ in pool]
+                )
+            except Exception:  # noqa: BLE001 - genre data is best-effort
+                genres = {}
+
+        if not prefs.is_empty():
+            adjusted: list[tuple[str, float]] = []
+            for mbid, weight in pool:
+                families = {genre_family(g) for g in genres.get(mbid, [])} - {""}
+                if families and all(prefs.is_muted(f) for f in families):
+                    continue
+                live = [prefs.multiplier(f) for f in families if not prefs.is_muted(f)]
+                adjusted.append((mbid, weight * (min(live) if live else 1.0)))
+            adjusted.sort(key=lambda kv: kv[1], reverse=True)
+            pool = adjusted
+
+        if not genres:
+            return pool[:_MAX_SEEDS]
+        selected = balanced_seed_selection(
+            pool, lambda kv: genres.get(kv[0], []), _MAX_SEEDS, prefs
+        )
+        # keep the seed list weight-ordered so norm_weight scoring stays intuitive
+        selected.sort(key=lambda kv: kv[1], reverse=True)
+        return selected
+
+    # -------------------------------------------------------------- expansion
+
+    async def _expand(
+        self,
+        seeds: list[_Seed],
+        owned_artist_mbids: set[str],
+        owned_album_mbids: set[str],
+        owned_artist_names: set[str],
+        prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    ) -> list[TasteGraphItem]:
+        expansions = await asyncio.gather(
+            *(self._mb_repo.get_artist_expansion(s.mbid) for s in seeds),
+            return_exceptions=True,
+        )
+
+        candidates: dict[str, _Candidate] = {}
+        per_seed_count: dict[str, int] = {}
+        # label_mbid -> (label_name, best seed)
+        labels: dict[str, tuple[str, _Seed]] = {}
+        # tag -> best seed
+        tags: dict[str, tuple[float, _Seed]] = {}
+
+        seed_mbids = {s.mbid.lower() for s in seeds}
+
+        for seed, expansion in zip(seeds, expansions):
+            if not isinstance(expansion, dict):
+                continue
+            seed_tags = sorted(
+                expansion.get("tags") or [],
+                key=lambda t: int(t.get("count", 0) or 0),
+                reverse=True,
+            )
+            seed.top_tag = str(seed_tags[0].get("name", "")).lower() if seed_tags else ""
+            for tag in seed_tags[:3]:
+                name = str(tag.get("name", "")).lower()
+                if not name:
+                    continue
+                score = seed.norm_weight * (1 + int(tag.get("count", 0) or 0))
+                if name not in tags or score > tags[name][0]:
+                    tags[name] = (score, seed)
+
+            for rel in expansion.get("relations") or []:
+                rel_type = str(rel.get("type", "")).lower()
+                target = rel.get("artist")
+                if isinstance(target, dict) and target.get("id"):
+                    self._consider_related_artist(
+                        seed, rel_type, target, candidates, per_seed_count,
+                        owned_artist_mbids, seed_mbids,
+                    )
+                    continue
+                label = rel.get("label")
+                if (
+                    isinstance(label, dict)
+                    and label.get("id")
+                    and rel_type in _ARTIST_LABEL_REL_TYPES
+                ):
+                    label_id = str(label["id"])
+                    if label_id not in labels or seed.norm_weight > labels[label_id][1].norm_weight:
+                        labels[label_id] = (str(label.get("name", "")), seed)
+
+        top_labels = sorted(
+            labels.items(), key=lambda kv: kv[1][1].norm_weight, reverse=True
+        )[:_MAX_LABELS]
+        top_tags = sorted(tags.items(), key=lambda kv: kv[1][0], reverse=True)[:_MAX_TAGS]
+
+        label_results, tag_results = await asyncio.gather(
+            asyncio.gather(
+                *(self._mb_repo.get_label_releases(label_id) for label_id, _ in top_labels),
+                return_exceptions=True,
+            ),
+            asyncio.gather(
+                *(self._mb_repo.search_release_groups_by_tag(tag, limit=15) for tag, _ in top_tags),
+                return_exceptions=True,
+            ),
+        )
+
+        for (label_id, (label_name, seed)), releases in zip(top_labels, label_results):
+            if not isinstance(releases, list):
+                continue
+            self._consider_label_releases(
+                seed, label_id, label_name, releases, candidates, per_seed_count,
+                owned_artist_mbids, owned_album_mbids, seed_mbids,
+            )
+
+        for (tag, (_score, seed)), results in zip(top_tags, tag_results):
+            if not isinstance(results, list):
+                continue
+            self._consider_scene_release_groups(
+                seed, tag, results, candidates, per_seed_count,
+                owned_album_mbids, owned_artist_names,
+            )
+
+        return self._select_items(candidates, prefs)
+
+    def _consider_related_artist(
+        self, seed, rel_type, target, candidates, per_seed_count,
+        owned_artist_mbids, seed_mbids,
+    ) -> None:
+        if rel_type in _MEMBER_REL_TYPES:
+            reason_type, strength = "member", _MEMBER_STRENGTH
+            reason_label = f"Band-member connection with {seed.name}"
+        elif rel_type in _COLLAB_REL_TYPES:
+            reason_type, strength = "collaborator", _COLLAB_STRENGTH
+            reason_label = f"Collaborated with {seed.name}"
+        else:
+            return
+
+        mbid = str(target["id"]).lower()
+        name = str(target.get("name", ""))
+        if (
+            mbid in owned_artist_mbids  # novelty: not already in the library
+            or mbid in seed_mbids
+            or name.lower() in _FILTERED_CANDIDATE_NAMES
+        ):
+            return
+        reason = TasteGraphReason(
+            type=reason_type, label=reason_label, via_mbid=seed.mbid, via_name=seed.name
+        )
+        self._add_candidate(
+            candidates, per_seed_count, seed,
+            _Candidate(
+                kind="artist", mbid=mbid, name=name, artist_mbid=None, artist_name=None,
+                score=seed.norm_weight * strength, reason=reason, genre=seed.top_tag,
+            ),
+        )
+
+    def _consider_label_releases(
+        self, seed, label_id, label_name, releases, candidates, per_seed_count,
+        owned_artist_mbids, owned_album_mbids, seed_mbids,
+    ) -> None:
+        for rank, release in enumerate(releases):
+            if not isinstance(release, dict):
+                continue
+            rg = release.get("release-group") or {}
+            rg_mbid = str(rg.get("id", "")).lower()
+            credits = release.get("artist-credit") or []
+            first = credits[0] if credits and isinstance(credits[0], dict) else {}
+            credit_artist = first.get("artist") or {}
+            artist_mbid = str(credit_artist.get("id", "")).lower()
+            artist_name = str(first.get("name") or credit_artist.get("name") or "")
+            if (
+                not rg_mbid
+                or rg_mbid in owned_album_mbids  # novelty
+                or not artist_mbid
+                or artist_mbid in owned_artist_mbids
+                or artist_mbid in seed_mbids
+                or artist_name.lower() in _FILTERED_CANDIDATE_NAMES
+            ):
+                continue
+            reason = TasteGraphReason(
+                type="label",
+                label=f"On {label_name or 'the same label'} with {seed.name}",
+                via_mbid=label_id,
+                via_name=label_name or None,
+            )
+            decay = 1.0 / (1.0 + 0.1 * rank)
+            self._add_candidate(
+                candidates, per_seed_count, seed,
+                _Candidate(
+                    kind="album", mbid=rg_mbid, name=str(rg.get("title") or release.get("title", "")),
+                    artist_mbid=artist_mbid, artist_name=artist_name,
+                    score=seed.norm_weight * _LABEL_STRENGTH * decay,
+                    reason=reason, genre=seed.top_tag,
+                ),
+            )
+
+    def _consider_scene_release_groups(
+        self, seed, tag, results, candidates, per_seed_count,
+        owned_album_mbids, owned_artist_names,
+    ) -> None:
+        for rank, result in enumerate(results):
+            rg_mbid = (result.musicbrainz_id or "").lower()
+            artist_name = result.artist or ""
+            if (
+                not rg_mbid
+                or rg_mbid in owned_album_mbids  # novelty
+                or artist_name.lower() in owned_artist_names
+                or artist_name.lower() in _FILTERED_CANDIDATE_NAMES
+            ):
+                continue
+            reason = TasteGraphReason(
+                type="scene",
+                label=f"From the {tag} scene, like {seed.name}",
+                via_mbid=seed.mbid,
+                via_name=tag,
+            )
+            decay = 1.0 / (1.0 + 0.15 * rank)
+            self._add_candidate(
+                candidates, per_seed_count, seed,
+                _Candidate(
+                    kind="album", mbid=rg_mbid, name=result.title,
+                    artist_mbid=None, artist_name=artist_name or None,
+                    score=seed.norm_weight * _SCENE_STRENGTH * decay,
+                    reason=reason, genre=tag,
+                ),
+            )
+
+    @staticmethod
+    def _add_candidate(candidates, per_seed_count, seed, candidate: _Candidate) -> None:
+        existing = candidates.get(candidate.mbid)
+        if existing is not None:
+            # corroborated by multiple connections: merge the reason, small bonus
+            if len(existing.reasons) < 3 and all(
+                r.label != candidate.reasons[0].label for r in existing.reasons
+            ):
+                existing.reasons.append(candidate.reasons[0])
+                existing.score = max(existing.score, candidate.score) + 0.05
+            return
+        if per_seed_count.get(seed.mbid, 0) >= _MAX_PER_SEED:
+            return  # diversity: this seed already placed its quota
+        per_seed_count[seed.mbid] = per_seed_count.get(seed.mbid, 0) + 1
+        candidates[candidate.mbid] = candidate
+
+    @staticmethod
+    def _select_items(
+        candidates: dict[str, _Candidate], prefs: GenrePrefs = EMPTY_GENRE_PREFS
+    ) -> list[TasteGraphItem]:
+        genre_cap = max(1, math.ceil(_MAX_ITEMS * _GENRE_CAP_RATIO))
+        genre_counts: dict[str, int] = {}
+        items: list[TasteGraphItem] = []
+        for c in sorted(candidates.values(), key=lambda c: c.score, reverse=True):
+            if len(items) >= _MAX_ITEMS:
+                break
+            if c.genre:
+                # the cap counts genre FAMILIES ("k-pop"/"korean pop"/"kpop" are one),
+                # and the user's mute/reduce levels apply: muted families are excluded,
+                # reduced families get half the cap
+                family = genre_family(c.genre) or c.genre
+                if prefs.is_muted(family):
+                    continue
+                cap = genre_cap
+                if prefs.level(family) == "reduce":
+                    cap = max(1, genre_cap // 2)
+                if genre_counts.get(family, 0) >= cap:
+                    continue  # diversity: max 40% of items from one genre family
+                genre_counts[family] = genre_counts.get(family, 0) + 1
+            items.append(TasteGraphItem(
+                kind=c.kind,
+                mbid=c.mbid,
+                name=c.name,
+                artist_mbid=c.artist_mbid or None,
+                artist_name=c.artist_name or None,
+                score=round(c.score, 4),
+                reasons=c.reasons,
+                in_library=False,  # candidates are novelty-filtered against the library
+            ))
+        return items

--- a/backend/tests/routes/test_taste_graph_routes.py
+++ b/backend/tests/routes/test_taste_graph_routes.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1.routes.taste_graph import router
+from api.v1.schemas.taste_graph import (
+    TasteGraphItem,
+    TasteGraphReason,
+    TasteGraphResponse,
+    TasteGraphSeed,
+)
+from core.dependencies import get_taste_graph_service
+from tests.helpers import override_user_auth
+
+_UID = "test-user-id"
+
+
+def _make_response() -> TasteGraphResponse:
+    return TasteGraphResponse(
+        cold_start=False,
+        generated_at="2026-07-10T00:00:00+00:00",
+        seeds=[TasteGraphSeed(artist_mbid="seed-1", name="Seed Artist", weight=1.0)],
+        items=[
+            TasteGraphItem(
+                kind="artist",
+                mbid="candidate-1",
+                name="Candidate Artist",
+                score=0.9,
+                reasons=[
+                    TasteGraphReason(
+                        type="member",
+                        label="Band-member connection with Seed Artist",
+                        via_mbid="seed-1",
+                        via_name="Seed Artist",
+                    )
+                ],
+                in_library=False,
+            ),
+            TasteGraphItem(
+                kind="album",
+                mbid="rg-1",
+                name="Candidate Album",
+                artist_mbid="candidate-2",
+                artist_name="Label Mate",
+                score=0.7,
+                reasons=[
+                    TasteGraphReason(
+                        type="label",
+                        label="On Test Label with Seed Artist",
+                        via_mbid="label-1",
+                        via_name="Test Label",
+                    )
+                ],
+                in_library=False,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def mock_service():
+    mock = AsyncMock()
+    mock.get_taste_graph = AsyncMock(return_value=_make_response())
+    return mock
+
+
+@pytest.fixture
+def client(mock_service):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_taste_graph_service] = lambda: mock_service
+    override_user_auth(app, user_id=_UID)
+    return TestClient(app)
+
+
+class TestTasteGraphRoute:
+    def test_builds_for_current_user(self, client, mock_service):
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        mock_service.get_taste_graph.assert_awaited_once_with(_UID)
+
+    def test_response_shape(self, client):
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cold_start"] is False
+        assert data["generated_at"]
+        assert data["seeds"][0] == {
+            "artist_mbid": "seed-1",
+            "name": "Seed Artist",
+            "weight": 1.0,
+        }
+        artist_item = data["items"][0]
+        assert artist_item["kind"] == "artist"
+        assert artist_item["mbid"] == "candidate-1"
+        assert artist_item["in_library"] is False
+        assert artist_item["reasons"][0]["type"] == "member"
+        album_item = data["items"][1]
+        assert album_item["kind"] == "album"
+        assert album_item["artist_mbid"] == "candidate-2"
+        assert album_item["reasons"][0]["type"] == "label"
+        assert album_item["reasons"][0]["via_name"] == "Test Label"
+
+    def test_cold_start_shape(self, client, mock_service):
+        mock_service.get_taste_graph = AsyncMock(
+            return_value=TasteGraphResponse(
+                cold_start=True, generated_at="2026-07-10T00:00:00+00:00",
+            )
+        )
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cold_start"] is True
+        assert data["seeds"] == []
+        assert data["items"] == []

--- a/backend/tests/services/test_taste_graph_service.py
+++ b/backend/tests/services/test_taste_graph_service.py
@@ -1,0 +1,230 @@
+"""TasteGraphService — seeds weighted from the user's own signals only,
+expanded through MusicBrainz relations/labels/tags, with novelty + diversity."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from infrastructure.cache.memory_cache import InMemoryCache
+from infrastructure.persistence.follow_store import FollowedArtist
+from infrastructure.persistence.play_history_store import PlayHistoryRecord
+from models.search import SearchResult
+from services.taste_graph_service import TasteGraphService
+
+_SEED_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_SEED_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_FOLLOWED = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+def _followed(mbid: str, name: str) -> FollowedArtist:
+    return FollowedArtist(
+        artist_mbid=mbid,
+        artist_name=name,
+        auto_download=False,
+        auto_download_state="none",
+        followed_at=1000.0,
+    )
+
+
+def _play(artist_name: str, i: int) -> PlayHistoryRecord:
+    return PlayHistoryRecord(
+        id=f"play-{artist_name}-{i}",
+        user_id="u1",
+        track_name=f"Track {i}",
+        artist_name=artist_name,
+        played_at=f"2026-07-0{(i % 9) + 1}T00:00:00Z",
+    )
+
+
+def _library_db(artists=(), albums_for_matching=(), album_mbids=()):
+    db = AsyncMock()
+    db.get_artists = AsyncMock(return_value=list(artists))
+    db.get_all_albums_for_matching = AsyncMock(return_value=list(albums_for_matching))
+    db.get_all_album_mbids = AsyncMock(return_value=set(album_mbids))
+    return db
+
+
+def _mb_repo(expansions=None, label_releases=None, tag_results=None):
+    repo = AsyncMock()
+    repo.get_artist_expansion = AsyncMock(
+        side_effect=lambda mbid: (expansions or {}).get(mbid)
+    )
+    repo.get_label_releases = AsyncMock(
+        side_effect=lambda label_mbid, limit=25: (label_releases or {}).get(label_mbid, [])
+    )
+    repo.search_release_groups_by_tag = AsyncMock(
+        side_effect=lambda tag, limit=15: (tag_results or {}).get(tag, [])
+    )
+    return repo
+
+
+def _service(library_db=None, followed=(), plays=(), mb_repo=None):
+    follow_store = AsyncMock()
+    follow_store.list_followed_artists = AsyncMock(return_value=list(followed))
+    play_history = AsyncMock()
+    play_history.recent = AsyncMock(return_value=list(plays))
+    return TasteGraphService(
+        library_db=library_db or _library_db(),
+        follow_store=follow_store,
+        play_history_store=play_history,
+        mb_repo=mb_repo or _mb_repo(),
+        cache=InMemoryCache(max_entries=100),
+    )
+
+
+class TestColdStart:
+    @pytest.mark.asyncio
+    async def test_empty_everything_is_graceful_cold_start(self):
+        service = _service()
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is True
+        assert result.seeds == []
+        assert result.items == []
+        assert result.generated_at
+
+
+class TestSeedWeighting:
+    @pytest.mark.asyncio
+    async def test_followed_outweighs_played_outweighs_library(self):
+        library_db = _library_db(
+            artists=[
+                {"mbid": _SEED_A, "name": "Library Only"},
+                {"mbid": _SEED_B, "name": "Library Played"},
+            ],
+        )
+        service = _service(
+            library_db=library_db,
+            followed=[_followed(_FOLLOWED, "Followed Artist")],
+            plays=[_play("Library Played", i) for i in range(5)],
+        )
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is False
+        ordered = [s.artist_mbid for s in result.seeds]
+        assert ordered == [_FOLLOWED, _SEED_B, _SEED_A]
+        assert result.seeds[0].weight == 1.0  # normalized to the top seed
+
+
+class TestExpansion:
+    @pytest.mark.asyncio
+    async def test_member_collab_label_scene_candidates(self):
+        expansions = {
+            _SEED_A: {
+                "tags": [{"name": "shoegaze", "count": 5}],
+                "relations": [
+                    {
+                        "type": "member of band",
+                        "artist": {"id": "member-1", "name": "New Member"},
+                    },
+                    {
+                        "type": "collaboration",
+                        "artist": {"id": "collab-1", "name": "New Collaborator"},
+                    },
+                    {
+                        # novelty: already in library, must be filtered out
+                        "type": "member of band",
+                        "artist": {"id": _SEED_B, "name": "Library Played"},
+                    },
+                ],
+            },
+            _SEED_B: {
+                "tags": [],
+                "relations": [
+                    {
+                        "type": "recording contract",
+                        "label": {"id": "label-1", "name": "Test Label"},
+                    },
+                ],
+            },
+        }
+        label_releases = {
+            "label-1": [
+                {
+                    "title": "Label Album",
+                    "release-group": {"id": "rg-label-1", "title": "Label Album"},
+                    "artist-credit": [
+                        {"name": "Label Mate", "artist": {"id": "mate-1", "name": "Label Mate"}}
+                    ],
+                }
+            ]
+        }
+        tag_results = {
+            "shoegaze": [
+                SearchResult(
+                    type="album",
+                    title="Scene Album",
+                    musicbrainz_id="rg-scene-1",
+                    artist="Scene Artist",
+                )
+            ]
+        }
+        library_db = _library_db(
+            artists=[
+                {"mbid": _SEED_A, "name": "Seed Artist"},
+                {"mbid": _SEED_B, "name": "Library Played"},
+            ],
+        )
+        service = _service(
+            library_db=library_db,
+            mb_repo=_mb_repo(expansions, label_releases, tag_results),
+        )
+        result = await service.get_taste_graph("u1")
+
+        by_mbid = {i.mbid: i for i in result.items}
+        assert _SEED_B not in by_mbid  # novelty filter
+        assert by_mbid["member-1"].kind == "artist"
+        assert by_mbid["member-1"].reasons[0].type == "member"
+        assert by_mbid["member-1"].reasons[0].via_mbid == _SEED_A
+        assert by_mbid["collab-1"].reasons[0].type == "collaborator"
+        assert by_mbid["rg-label-1"].kind == "album"
+        assert by_mbid["rg-label-1"].artist_mbid == "mate-1"
+        assert by_mbid["rg-label-1"].reasons[0].type == "label"
+        assert by_mbid["rg-label-1"].reasons[0].via_name == "Test Label"
+        assert by_mbid["rg-scene-1"].reasons[0].type == "scene"
+        assert by_mbid["rg-scene-1"].reasons[0].via_name == "shoegaze"
+        # member/collab outrank label-mates which outrank scene matches
+        assert by_mbid["member-1"].score > by_mbid["rg-label-1"].score > by_mbid["rg-scene-1"].score
+        assert all(i.in_library is False for i in result.items)
+        assert len(result.items) <= 30
+
+    @pytest.mark.asyncio
+    async def test_per_seed_diversity_cap(self):
+        expansions = {
+            _SEED_A: {
+                "tags": [],
+                "relations": [
+                    {"type": "member of band", "artist": {"id": f"m-{i}", "name": f"M {i}"}}
+                    for i in range(6)
+                ],
+            },
+        }
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        service = _service(library_db=library_db, mb_repo=_mb_repo(expansions))
+        result = await service.get_taste_graph("u1")
+        assert len(result.items) == 3  # max 3 candidates per seed
+
+    @pytest.mark.asyncio
+    async def test_graph_is_cached_per_user(self):
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        mb_repo = _mb_repo({
+            _SEED_A: {
+                "tags": [],
+                "relations": [
+                    {"type": "member of band", "artist": {"id": "m-1", "name": "M 1"}}
+                ],
+            }
+        })
+        service = _service(library_db=library_db, mb_repo=mb_repo)
+        first = await service.get_taste_graph("u1")
+        second = await service.get_taste_graph("u1")
+        assert first == second
+        mb_repo.get_artist_expansion.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mb_failure_degrades_without_500(self):
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        mb_repo = AsyncMock()
+        mb_repo.get_artist_expansion = AsyncMock(side_effect=RuntimeError("mb down"))
+        service = _service(library_db=library_db, mb_repo=mb_repo)
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is False
+        assert result.items == []
+        assert [s.artist_mbid for s in result.seeds] == [_SEED_A]

--- a/frontend/src/lib/components/discover/TasteGraphZone.svelte
+++ b/frontend/src/lib/components/discover/TasteGraphZone.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	/*
+	 * TasteGraphZone — recommendations grown from the user's own collection via
+	 * canonical MusicBrainz relationships (collaborators, members, labels,
+	 * scenes). No charts, no crowds. Old backends lack the route, so any fetch
+	 * error settles into the same quiet invitation panel as a cold start.
+	 */
+	import { Network, Check } from 'lucide-svelte';
+	import { integrationStore } from '$lib/stores/integration';
+	import AlbumImage from '$lib/components/AlbumImage.svelte';
+	import ArtistImage from '$lib/components/ArtistImage.svelte';
+	import AlbumRequestButton from '$lib/components/AlbumRequestButton.svelte';
+	import RadioPlayButton from '$lib/components/discover/RadioPlayButton.svelte';
+	import { getTasteGraphQuery } from '$lib/queries/discover/TasteGraphQuery.svelte';
+
+	const tasteGraphQuery = getTasteGraphQuery();
+	const data = $derived(tasteGraphQuery.data ?? null);
+	const loading = $derived(tasteGraphQuery.isLoading);
+	// error (incl. 404 from old backends) and cold start share the invitation panel
+	const showInvitation = $derived(
+		!!tasteGraphQuery.error || (!!data && (data.cold_start || data.items.length === 0))
+	);
+</script>
+
+<section aria-label="Your taste graph">
+	<h3
+		class="mb-1 flex items-center gap-2.5 font-mono text-[0.68rem] font-bold uppercase tracking-[0.2em] text-base-content/50"
+	>
+		<Network class="h-4 w-4 text-accent" />
+		Your Taste Graph
+	</h3>
+	<p class="mb-5 text-xs text-base-content/50">
+		Grown from your collection and canonical MusicBrainz relationships — no charts, no crowds.
+	</p>
+
+	{#if loading}
+		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+			{#each Array(10) as _, i (`taste-graph-skeleton-${i}`)}
+				<div class="rounded-2xl border border-base-content/8 bg-base-200/50 p-3">
+					<div class="skeleton skeleton-shimmer aspect-square w-full rounded-xl"></div>
+					<div class="skeleton skeleton-shimmer mt-3 h-4 w-3/4"></div>
+					<div class="skeleton skeleton-shimmer mt-2 h-3 w-1/2"></div>
+				</div>
+			{/each}
+		</div>
+	{:else if showInvitation}
+		<div
+			class="flex flex-col items-center rounded-2xl border border-dashed border-base-content/12 px-6 py-10 text-center"
+		>
+			<Network class="mb-3 h-8 w-8 text-base-content/40" />
+			<p class="max-w-md text-sm text-base-content/60">
+				The graph grows from your music — scan your library or follow artists and check back.
+			</p>
+		</div>
+	{:else if data}
+		{#if data.seeds.length > 0}
+			<div class="mb-5 flex flex-wrap items-center gap-2">
+				<span
+					class="font-mono text-[0.62rem] font-bold uppercase tracking-[0.2em] text-base-content/40"
+					>Seeded by:</span
+				>
+				{#each data.seeds as seed (seed.artist_mbid)}
+					<span
+						class="rounded-full border border-base-content/10 px-2.5 py-0.5 text-xs text-base-content/60"
+						>{seed.name}</span
+					>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+			{#each data.items as item (`${item.kind}-${item.mbid}`)}
+				<div
+					class="group flex flex-col rounded-2xl border border-base-content/8 bg-base-200/50 p-3 transition-colors hover:border-primary/30"
+				>
+					<a
+						href={item.kind === 'album' ? `/album/${item.mbid}` : `/artist/${item.mbid}`}
+						data-sveltekit-preload-data="hover"
+						class="min-w-0"
+					>
+						<div class="aspect-square w-full overflow-hidden rounded-xl">
+							{#if item.kind === 'album'}
+								<AlbumImage mbid={item.mbid} alt={item.name} size="md" className="h-full w-full" />
+							{:else}
+								<ArtistImage
+									mbid={item.mbid}
+									alt={item.name}
+									size="md"
+									rounded="lg"
+									className="h-full w-full"
+								/>
+							{/if}
+						</div>
+						<h4 class="mt-3 truncate font-display text-sm font-semibold tracking-tight">
+							{item.name}
+						</h4>
+						{#if item.kind === 'album' && item.artist_name}
+							<p class="mt-0.5 truncate text-xs text-base-content/50">{item.artist_name}</p>
+						{/if}
+					</a>
+
+					{#if item.reasons.length > 0 || item.in_library}
+						<div class="mt-2 flex flex-wrap gap-1">
+							{#if item.in_library}
+								<span
+									class="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 font-mono text-[0.55rem] font-bold uppercase tracking-[0.15em] text-accent"
+								>
+									<Check class="h-2.5 w-2.5" />
+									In collection
+								</span>
+							{/if}
+							{#each item.reasons as reason, i (`${item.mbid}-reason-${i}`)}
+								<span
+									class="rounded-full border border-base-content/10 px-2 py-0.5 font-mono text-[0.55rem] font-bold uppercase tracking-[0.15em] text-base-content/50"
+									>{reason.label}</span
+								>
+							{/each}
+						</div>
+					{/if}
+
+					<div class="mt-auto flex items-center justify-end gap-2 pt-2">
+						{#if item.kind === 'artist'}
+							<RadioPlayButton
+								seed={{ seed_type: 'artist', seed_id: item.mbid }}
+								size="sm"
+								label=""
+							/>
+						{:else if !item.in_library && $integrationStore.download_client}
+							<AlbumRequestButton
+								mbid={item.mbid}
+								artistName={item.artist_name ?? ''}
+								albumName={item.name}
+								artistMbid={item.artist_mbid ?? undefined}
+							/>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</section>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -254,6 +254,7 @@ export const API = {
 		`/api/v1/discover/album-preview?artist=${encodeURIComponent(artist)}&album=${encodeURIComponent(album)}`,
 	discoverPlaylistSuggestions: () => '/api/v1/discover/playlist-suggestions',
 	discoverGenreDetail: (tag: string) => `/api/v1/discover/genres/${encodeURIComponent(tag)}`,
+	discoverTasteGraph: () => '/api/v1/discover/taste-graph',
 	youtube: {
 		generate: () => '/api/v1/youtube/generate',
 		link: (albumId: string) => `/api/v1/youtube/link/${albumId}`,

--- a/frontend/src/lib/queries/discover/TasteGraphQuery.svelte.ts
+++ b/frontend/src/lib/queries/discover/TasteGraphQuery.svelte.ts
@@ -1,0 +1,57 @@
+import { api } from '$lib/api/client';
+import { API } from '$lib/constants';
+import { authStore } from '$lib/stores/authStore.svelte';
+import { createQuery } from '@tanstack/svelte-query';
+import { DiscoverQueryKeyFactory } from './DiscoverQueryKeyFactory';
+
+export interface TasteGraphReason {
+	type: 'collaborator' | 'member' | 'label' | 'scene';
+	label: string;
+	via_mbid?: string | null;
+	via_name?: string | null;
+}
+
+export interface TasteGraphSeed {
+	artist_mbid: string;
+	name: string;
+	weight: number;
+}
+
+export interface TasteGraphItem {
+	kind: 'artist' | 'album';
+	mbid: string;
+	name: string;
+	artist_mbid?: string | null;
+	artist_name?: string | null;
+	score: number;
+	reasons: TasteGraphReason[];
+	in_library: boolean;
+}
+
+export interface TasteGraphResponse {
+	cold_start: boolean;
+	generated_at: string;
+	seeds: TasteGraphSeed[];
+	items: TasteGraphItem[];
+}
+
+// The graph is rebuilt server-side on library changes at a slow cadence, so a
+// long client staleTime is fine. retry: false — old backends lack the route and
+// a 404 should settle into the quiet invitation state immediately. Focus refetch
+// is off: an errored query is permanently stale, so a missing route would
+// otherwise re-404 on every tab focus.
+const TASTE_GRAPH_STALE_MS = 24 * 60 * 60 * 1000;
+
+export const getTasteGraphQuery = () =>
+	createQuery(() => ({
+		staleTime: TASTE_GRAPH_STALE_MS,
+		retry: false,
+		refetchOnWindowFocus: false,
+		queryKey: [
+			...DiscoverQueryKeyFactory.prefix,
+			authStore.user?.id ?? null,
+			'taste-graph'
+		] as const,
+		queryFn: ({ signal }) =>
+			api.global.get<TasteGraphResponse>(API.discoverTasteGraph(), { signal })
+	}));


### PR DESCRIPTION
## What

A new Discover zone: **Taste Graph** — recommendations built ONLY from the user's own signals (library, follows, play history), expanded through canonical MusicBrainz relationships (band members, collaborations, label mates, tags). No charts, no global popularity, no other users' listens. Cold-starts gracefully on an empty library.

- `backend/services/taste_graph_service.py` + `api/v1/routes/taste_graph.py` (`GET /api/v1/discover/taste-graph`) + `api/v1/schemas/taste_graph.py`
- `repositories/musicbrainz_artist.py`: `get_artist_expansion()` / `get_label_releases()` — cached 24h, deduplicated, BACKGROUND_SYNC priority so they can never starve user-initiated MB lookups
- `services/discover/genre_balance.py`: a dependency-free helper module (genre families, balanced selection) the taste graph uses for seed breadth. Introduced here; the user-facing per-genre controls arrive in a follow-up PR that builds on it.
- Frontend: `TasteGraphZone.svelte` + `TasteGraphQuery.svelte.ts` + API constant. The zone is mounted on the Discover page by the UI-redesign PR; the component itself only uses existing building blocks (AlbumImage/ArtistImage/RadioPlayButton).

## Why

Every existing Discover zone leans on external charts or listener similarity. Self-hosters with no ListenBrainz/Last.fm connection deserve a recommendation surface that works fully offline-ish (one MB call per artist per day) and explains *why* each item was suggested (reason chips per edge).

## How tested

`tests/services/test_taste_graph_service.py` + `tests/routes/test_taste_graph_routes.py` — 9 passed (Windows, Python 3.13). Covers expansion scoring, cold start, cache hits, and route auth/shape.

Note: `TasteGraphService` accepts an optional `genre_prefs_store` (defaults to None here); the genre-prefs PR wires it.
