### PR TITLE
perf(scanner): batch library-file upserts and parallelize file prep

### DIFF
--- a/backend/infrastructure/persistence/library_db.py
+++ b/backend/infrastructure/persistence/library_db.py
@@ -673,57 +673,79 @@ class LibraryDB(PersistenceBase):
         row identity. UPDATE preserves id/imported_at/download_task_id and clears
         deleted_at (re-import un-deletes). Returns the row id."""
         now = time.time()
-        file_path = row["file_path"]
 
         def operation(conn: sqlite3.Connection) -> str:
-            # partial unique index only constrains non-deleted rows, so a path can
-            # have several soft-deleted rows; prefer active then most recent so
-            # re-import deterministically revives the right one
-            existing = conn.execute(
-                "SELECT id FROM library_files WHERE file_path = ? "
-                "ORDER BY deleted_at IS NULL DESC, imported_at DESC LIMIT 1",
-                (file_path,),
-            ).fetchone()
-            value_params = [row.get(col) for col in _LIBRARY_FILE_VALUE_COLUMNS]
-            # folded mirrors are written via SQL fold() - the same function used at
-            # search time - so the stored values never drift from the query side
-            folded_params = [row.get(src) for src in _LIBRARY_FILE_FOLDED_COLUMNS.values()]
-            if existing is not None:
-                set_clause = ", ".join(f"{col} = ?" for col in _LIBRARY_FILE_VALUE_COLUMNS)
-                folded_clause = ", ".join(
-                    f"{col} = fold(?)" for col in _LIBRARY_FILE_FOLDED_COLUMNS
-                )
-                conn.execute(
-                    f"UPDATE library_files SET {set_clause}, {folded_clause}, "
-                    "deleted_at = NULL WHERE id = ?",
-                    (*value_params, *folded_params, existing["id"]),
-                )
-                return str(existing["id"])
-            new_id = uuid4().hex
-            columns = (
-                "id",
-                "download_task_id",
-                *_LIBRARY_FILE_VALUE_COLUMNS,
-                "imported_at",
-                *_LIBRARY_FILE_FOLDED_COLUMNS,
-            )
-            placeholders = ", ".join(
-                ["?"] * (len(columns) - len(_LIBRARY_FILE_FOLDED_COLUMNS))
-                + ["fold(?)"] * len(_LIBRARY_FILE_FOLDED_COLUMNS)
-            )
-            conn.execute(
-                f"INSERT INTO library_files ({', '.join(columns)}) VALUES ({placeholders})",
-                (
-                    new_id,
-                    row.get("download_task_id"),
-                    *value_params,
-                    row.get("imported_at") or now,
-                    *folded_params,
-                ),
-            )
-            return new_id
+            return self._upsert_library_file_op(conn, row, now)
 
         return await self._write(operation)
+
+    async def upsert_library_files(
+        self, rows: list[dict[str, Any]], artists: list[tuple[str, str]] | None = None
+    ) -> list[str]:
+        """Batch upsert: every file row (plus their ``library_artists`` rows) in
+        ONE write transaction - the scanner's per-album-folder flush. Same per-row
+        semantics as ``upsert_library_file``; one connection + commit instead of
+        several per file (profiled: connection churn dominated large scans)."""
+        now = time.time()
+
+        def operation(conn: sqlite3.Connection) -> list[str]:
+            ids = [self._upsert_library_file_op(conn, row, now) for row in rows]
+            for mbid, name in artists or []:
+                self._upsert_artist_op(conn, mbid, name, int(now))
+            return ids
+
+        return await self._write(operation)
+
+    @staticmethod
+    def _upsert_library_file_op(conn: sqlite3.Connection, row: dict[str, Any], now: float) -> str:
+        """One file's read-then-update-or-insert, on the caller's connection."""
+        file_path = row["file_path"]
+        # partial unique index only constrains non-deleted rows, so a path can
+        # have several soft-deleted rows; prefer active then most recent so
+        # re-import deterministically revives the right one
+        existing = conn.execute(
+            "SELECT id FROM library_files WHERE file_path = ? "
+            "ORDER BY deleted_at IS NULL DESC, imported_at DESC LIMIT 1",
+            (file_path,),
+        ).fetchone()
+        value_params = [row.get(col) for col in _LIBRARY_FILE_VALUE_COLUMNS]
+        # folded mirrors are written via SQL fold() - the same function used at
+        # search time - so the stored values never drift from the query side
+        folded_params = [row.get(src) for src in _LIBRARY_FILE_FOLDED_COLUMNS.values()]
+        if existing is not None:
+            set_clause = ", ".join(f"{col} = ?" for col in _LIBRARY_FILE_VALUE_COLUMNS)
+            folded_clause = ", ".join(
+                f"{col} = fold(?)" for col in _LIBRARY_FILE_FOLDED_COLUMNS
+            )
+            conn.execute(
+                f"UPDATE library_files SET {set_clause}, {folded_clause}, "
+                "deleted_at = NULL WHERE id = ?",
+                (*value_params, *folded_params, existing["id"]),
+            )
+            return str(existing["id"])
+        new_id = uuid4().hex
+        columns = (
+            "id",
+            "download_task_id",
+            *_LIBRARY_FILE_VALUE_COLUMNS,
+            "imported_at",
+            *_LIBRARY_FILE_FOLDED_COLUMNS,
+        )
+        placeholders = ", ".join(
+            ["?"] * (len(columns) - len(_LIBRARY_FILE_FOLDED_COLUMNS))
+            + ["fold(?)"] * len(_LIBRARY_FILE_FOLDED_COLUMNS)
+        )
+        conn.execute(
+            f"INSERT INTO library_files ({', '.join(columns)}) VALUES ({placeholders})",
+            (
+                new_id,
+                row.get("download_task_id"),
+                *value_params,
+                row.get("imported_at") or now,
+                *folded_params,
+            ),
+        )
+        return new_id
 
     async def get_albums_aggregated(
         self,
@@ -1682,18 +1704,22 @@ class LibraryDB(PersistenceBase):
         ``'{}'`` (only the legacy outbound sync populates real MB json). An
         existing row is left untouched so a re-scan never clobbers an aggregated
         album_count or a real-MB row."""
-        normalized = _normalize(mbid)
         now = int(time.time())
 
         def operation(conn: sqlite3.Connection) -> None:
-            conn.execute(
-                "INSERT INTO library_artists "
-                "(mbid_lower, mbid, name, album_count, date_added, raw_json) "
-                "VALUES (?, ?, ?, 0, ?, '{}') ON CONFLICT(mbid_lower) DO NOTHING",
-                (normalized, mbid, name, now),
-            )
+            self._upsert_artist_op(conn, mbid, name, now)
 
         await self._write(operation)
+
+    @staticmethod
+    def _upsert_artist_op(conn: sqlite3.Connection, mbid: str, name: str, now: int) -> None:
+        """One artist's idempotent insert, on the caller's connection."""
+        conn.execute(
+            "INSERT INTO library_artists "
+            "(mbid_lower, mbid, name, album_count, date_added, raw_json) "
+            "VALUES (?, ?, ?, 0, ?, '{}') ON CONFLICT(mbid_lower) DO NOTHING",
+            (_normalize(mbid), mbid, name, now),
+        )
 
     async def get_artists_aggregated(
         self,

--- a/backend/services/native/library_manager.py
+++ b/backend/services/native/library_manager.py
@@ -415,6 +415,77 @@ class LibraryManager(LibraryStub):
             await self._upsert_artist_rows(row)
             return file_id
 
+    async def upsert_files_batch(self, items: list[dict]) -> None:
+        """Scanner batch write: build each row exactly as ``upsert_file`` does, then
+        write the whole folder - file rows plus their ``library_artists`` rows - in
+        ONE transaction instead of a connection + commit per file (the profiled
+        dominant cost of a large first scan). Each item carries ``upsert_file``'s
+        arguments: ``audio_path``/``tag``/``info`` plus the keyword fields."""
+        if not items:
+            return
+        rows: list[dict] = []
+        artists: list[tuple[str, str]] = []
+        seen_artists: set[str] = set()
+        # one album-artist inherit lookup per release group, not per file
+        override_cache: dict[str, tuple[str, str] | None] = {}
+        for item in items:
+            tag: AudioTag = item["tag"]
+            release_group_mbid = item["release_group_mbid"]
+            if release_group_mbid is None and item.get("source") != "manual_review":
+                raise ValueError(
+                    "upsert_file requires release_group_mbid unless source='manual_review'"
+                )
+            album_artist_override = None
+            if (
+                release_group_mbid
+                and _real_mbid(tag.musicbrainz_album_artist_id) is None
+                and not _tag_is_compilation(tag)
+            ):
+                if release_group_mbid not in override_cache:
+                    override_cache[release_group_mbid] = (
+                        await self._db.get_album_artist_for_release_group(release_group_mbid)
+                    )
+                album_artist_override = override_cache[release_group_mbid]
+            row = self._build_row(
+                item["audio_path"],
+                tag,
+                item["info"],
+                release_group_mbid=release_group_mbid,
+                release_mbid=item.get("release_mbid"),
+                recording_mbid=item.get("recording_mbid"),
+                confidence=item.get("confidence", 1.0),
+                source=item.get("source", "scan"),
+                download_task_id=None,
+                file_mtime=item.get("file_mtime"),
+                album_artist_override=album_artist_override,
+            )
+            # a row carrying the group's real (dashed) artist identity is what a later
+            # sibling in this batch would have inherited via the per-file lookup
+            if (
+                release_group_mbid
+                and override_cache.get(release_group_mbid) is None
+                and not row["is_compilation"]
+                and _real_mbid(row["album_artist_mbid"]) is not None
+                and row["album_artist_name"]
+            ):
+                override_cache[release_group_mbid] = (
+                    row["album_artist_mbid"],
+                    row["album_artist_name"],
+                )
+            rows.append(row)
+            # mirror _upsert_artist_rows (ON CONFLICT DO NOTHING makes dedupe safe)
+            for mbid_key, name_key in (
+                ("artist_mbid", "artist_name"),
+                ("album_artist_mbid", "album_artist_name"),
+            ):
+                mbid = row.get(mbid_key)
+                if not mbid or mbid in seen_artists:
+                    continue
+                seen_artists.add(mbid)
+                artists.append((mbid, (row.get(name_key) or "").strip() or "Unknown Artist"))
+        async with self._library_write_lock:
+            await self._db.upsert_library_files(rows, artists)
+
     async def _upsert_artist_rows(self, row: dict) -> None:
         """Ensure a library_artists row exists for the track + album artist (Q14).
         Idempotent; needed by compat browse-by-id and the lazy-MB discovery cache,

--- a/backend/services/native/library_scanner.py
+++ b/backend/services/native/library_scanner.py
@@ -51,6 +51,9 @@ _TEXT_MATCH_THRESHOLD = 0.85
 _FINGERPRINT_SCORE_THRESHOLD = 0.70
 _LEDGER_BATCH_SIZE = 100
 _PROGRESS_INTERVAL_SECONDS = 2.0
+# Bounded parallelism for the local-only stat + tag-read stage (profiled: the file
+# open dominates a scan's local cost). Identification stays strictly sequential.
+_TAG_READ_CONCURRENCY = 8
 # Folders larger than this are treated as a flat dump, not an album.
 _MAX_ALBUM_FILES = 60
 _ARTIST_RECONCILE_PASSES = 8
@@ -468,20 +471,39 @@ class LibraryScanner:
                     continue
 
                 if len(todo) > _MAX_ALBUM_FILES:
-                    # Too big to be one album - identify per file.
-                    for path in todo:
+                    # Too big to be one album - identify per file, in ledger-sized
+                    # chunks so tag reads parallelise and writes share a transaction.
+                    for start in range(0, len(todo), _LEDGER_BATCH_SIZE):
                         if self._cancel.is_set():
                             cancelled = True
                             break
-                        await self._process_one(path, file_index, stats)
-                        await tick(str(path))
+                        chunk = todo[start : start + _LEDGER_BATCH_SIZE]
+                        prepared = await self._prepare_files(chunk, file_index, stats)
+                        existing = await self._library.get_attributions_for_paths(
+                            [str(e.path) for e in prepared if e is not None]
+                        )
+                        chunk_batch: list[dict] = []
+                        done: list[str] = []
+                        for path, entry in zip(chunk, prepared):
+                            if self._cancel.is_set():
+                                cancelled = True
+                                break
+                            if entry is not None:
+                                await self._identify_and_persist(
+                                    entry, stats, existing=existing, batch=chunk_batch
+                                )
+                            done.append(str(path))
+                        await self._flush_persist_batch(chunk_batch)
+                        for spath in done:
+                            await tick(spath)
                     if cancelled:
                         break
                     continue
 
                 entries: list[_FileEntry] = []
-                for path in todo:
-                    entry = await self._prepare_file(path, file_index, stats)
+                for path, entry in zip(
+                    todo, await self._prepare_files(todo, file_index, stats)
+                ):
                     if entry is None:
                         await tick(str(path))
                     else:
@@ -639,13 +661,32 @@ class LibraryScanner:
         tag = self._enrich_tag_from_path(path, tag)
         return _FileEntry(path=path, tag=tag, info=info, mtime=stat.st_mtime)
 
-    async def _process_one(
-        self, path: Path, file_index: dict[str, tuple[float, int]], stats: ScanStats
-    ) -> None:
-        entry = await self._prepare_file(path, file_index, stats)
-        if entry is not None:
-            existing = await self._library.get_attributions_for_paths([str(path)])
-            await self._identify_and_persist(entry, stats, existing=existing)
+    async def _prepare_files(
+        self,
+        paths: list[Path],
+        file_index: dict[str, tuple[float, int]],
+        stats: ScanStats,
+    ) -> list[_FileEntry | None]:
+        """``_prepare_file`` for a folder's files with bounded parallelism - the
+        stat + tag read are local-only work, so reading several files at once is
+        safe; identification stays strictly sequential downstream. Results keep
+        the input order (one slot per path, ``None`` where skipped/errored)."""
+        if len(paths) == 1:
+            return [await self._prepare_file(paths[0], file_index, stats)]
+        semaphore = asyncio.Semaphore(_TAG_READ_CONCURRENCY)
+
+        async def prepare(path: Path) -> _FileEntry | None:
+            async with semaphore:
+                return await self._prepare_file(path, file_index, stats)
+
+        return list(await asyncio.gather(*(prepare(path) for path in paths)))
+
+    async def _flush_persist_batch(self, batch: list[dict]) -> None:
+        """Write a folder's buffered attributions in ONE transaction (see
+        ``LibraryManager.upsert_files_batch``), then clear the buffer."""
+        if batch:
+            await self._library.upsert_files_batch(batch)
+            batch.clear()
 
     async def _identify_entries(
         self, entries: list[_FileEntry], stats: ScanStats, *, force: bool = False
@@ -730,6 +771,7 @@ class LibraryScanner:
 
         # Per-file fallback for anything not claimed as part of an album. Reuse any
         # fingerprint already taken above so Tier 3 doesn't fingerprint the file twice.
+        batch: list[dict] = []
         for entry in entries:
             if str(entry.path) in claimed:
                 continue
@@ -740,8 +782,11 @@ class LibraryScanner:
                 stats,
                 precomputed_fp=fp_by_path.get(str(entry.path)),
                 existing=existing,
+                batch=batch,
             )
             persisted.append(str(entry.path))
+        # Flush before returning so the ledger never records an unwritten path.
+        await self._flush_persist_batch(batch)
         return persisted
 
     def _incumbent_rg(self, existing: dict[str, dict]) -> str | None:
@@ -818,27 +863,45 @@ class LibraryScanner:
         recording_mbid: str | None,
         confidence: float,
         source: str,
+        batch: list[dict] | None = None,
     ) -> None:
         """Persist a scan attribution for one file, unless a prior confident attribution
         should stand (Phase 1 guard). When the prior stands the row is left untouched -
-        never downgraded - and still counted as matched."""
+        never downgraded - and still counted as matched. With ``batch`` the write is
+        buffered for a single per-folder transaction (``_flush_persist_batch``)
+        instead of committed per file."""
         prior = existing.get(str(entry.path))
         if prior is not None and await self._should_keep_prior(
             prior, release_group_mbid, confidence
         ):
             stats.matched += 1
             return
-        await self._library.upsert_file(
-            entry.path,
-            entry.tag,
-            entry.info,
-            release_group_mbid=release_group_mbid,
-            release_mbid=release_mbid,
-            recording_mbid=recording_mbid,
-            confidence=confidence,
-            source=source,
-            file_mtime=entry.mtime,
-        )
+        if batch is not None:
+            batch.append(
+                {
+                    "audio_path": entry.path,
+                    "tag": entry.tag,
+                    "info": entry.info,
+                    "release_group_mbid": release_group_mbid,
+                    "release_mbid": release_mbid,
+                    "recording_mbid": recording_mbid,
+                    "confidence": confidence,
+                    "source": source,
+                    "file_mtime": entry.mtime,
+                }
+            )
+        else:
+            await self._library.upsert_file(
+                entry.path,
+                entry.tag,
+                entry.info,
+                release_group_mbid=release_group_mbid,
+                release_mbid=release_mbid,
+                recording_mbid=recording_mbid,
+                confidence=confidence,
+                source=source,
+                file_mtime=entry.mtime,
+            )
         stats.matched += 1
         self._note_attribution_change(prior, release_group_mbid, release_mbid)
 
@@ -883,6 +946,7 @@ class LibraryScanner:
         attribution protects (Phase 1 guard), are left as-is."""
         mapped_confidence = round(1.0 - match.distance, 4)
         claimed_here = False
+        batch: list[dict] = []
         for entry in entries:
             key = str(entry.path)
             if key in claimed:
@@ -899,10 +963,14 @@ class LibraryScanner:
                 recording_mbid=(match.assignments.get(key) or None) if mapped else None,
                 confidence=mapped_confidence if mapped else _UNMAPPED_ALBUM_CONFIDENCE,
                 source="scan",
+                batch=batch,
             )
             claimed.add(key)
             persisted.append(key)
             claimed_here = True
+        # One transaction for the whole folder; must land before the artist stamp
+        # below so set_album_artist sees the rows it updates.
+        await self._flush_persist_batch(batch)
         # Stamp the canonical artist now so this album needs no end-of-scan lookup.
         if claimed_here and match.artist_mbid and match.artist_name:
             try:
@@ -966,6 +1034,7 @@ class LibraryScanner:
         stats: ScanStats,
         precomputed_fp: "FingerprintResult | None" = None,
         existing: dict[str, dict] | None = None,
+        batch: list[dict] | None = None,
     ) -> None:
         result = await self._identify_tiered(
             entry.path, entry.tag, entry.info, precomputed_fp=precomputed_fp
@@ -980,6 +1049,7 @@ class LibraryScanner:
                 recording_mbid=result.recording_mbid,
                 confidence=result.confidence,
                 source="scan",
+                batch=batch,
             )
             logger.debug(
                 self._TIER_MATCH_EVENTS.get(result.tier, "scan.matched"),

--- a/backend/tests/services/test_cutoff_unmet.py
+++ b/backend/tests/services/test_cutoff_unmet.py
@@ -106,7 +106,9 @@ async def test_cutoff_boundary_at_tier_is_satisfied(manager: LibraryManager):
 
 @pytest.mark.asyncio
 async def test_soft_deleted_files_do_not_count(manager: LibraryManager):
-    await _add_file(manager, "/music/d/01.mp3", "rg-del", "mp3", 128)
-    await manager._db.soft_delete_library_file("/music/d/01.mp3")
+    path = "/music/d/01.mp3"
+    await _add_file(manager, path, "rg-del", "mp3", 128)
+    # soft-delete must match the stored path exactly (str(Path(...)) uses "\" on Windows)
+    await manager._db.soft_delete_library_file(str(Path(path)))
 
     assert await manager.list_cutoff_unmet("lossless") == []

--- a/backend/tests/services/test_library_scanner.py
+++ b/backend/tests/services/test_library_scanner.py
@@ -267,13 +267,13 @@ async def test_incremental_second_scan_skips_unchanged(tmp_path):
     await scanner.scan([music])
 
     calls = {"n": 0}
-    original = manager.upsert_file
+    original = manager.upsert_files_batch
 
-    async def spy(*args, **kwargs):
-        calls["n"] += 1
-        return await original(*args, **kwargs)
+    async def spy(items, *args, **kwargs):
+        calls["n"] += len(items)
+        return await original(items, *args, **kwargs)
 
-    manager.upsert_file = spy
+    manager.upsert_files_batch = spy
     await scanner.scan([music])
     assert calls["n"] == 0  # nothing changed -> nothing re-upserted
 
@@ -285,13 +285,13 @@ async def test_force_rescan_reidentifies_unchanged(tmp_path):
     await scanner.scan([music])
 
     calls = {"n": 0}
-    original = manager.upsert_file
+    original = manager.upsert_files_batch
 
-    async def spy(*args, **kwargs):
-        calls["n"] += 1
-        return await original(*args, **kwargs)
+    async def spy(items, *args, **kwargs):
+        calls["n"] += len(items)
+        return await original(items, *args, **kwargs)
 
-    manager.upsert_file = spy
+    manager.upsert_files_batch = spy
     await scanner.scan([music], force=True)
     assert calls["n"] > 0  # force bypasses the unchanged-file skip -> files re-upserted
 
@@ -569,13 +569,13 @@ async def test_incremental_reimports_changed_file(tmp_path):
     os.utime(paths[0], (st.st_atime, st.st_mtime + 10))
 
     calls = {"n": 0}
-    original = manager.upsert_file
+    original = manager.upsert_files_batch
 
-    async def spy(*args, **kwargs):
-        calls["n"] += 1
-        return await original(*args, **kwargs)
+    async def spy(items, *args, **kwargs):
+        calls["n"] += len(items)
+        return await original(items, *args, **kwargs)
 
-    manager.upsert_file = spy
+    manager.upsert_files_batch = spy
     await scanner.scan([music])
     assert calls["n"] == 1  # changed file is re-imported
 


### PR DESCRIPTION
## What

## Why

## Testing

- [ ] I have tested these changes locally
- [ ] I have added or updated tests

## AI-Assisted Contributions

If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

## Checklist

- [ ] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`)
- [ ] Frontend lint passes (`make frontend-lint`)
- [ ] Frontend type check passes (`make frontend-check`)
- [ ] No `any` in TypeScript
- [ ] No hardcoded colors (design tokens only)
- [ ] All external API calls have timeouts
- [ ] New msgspec structs follow existing patterns
- [ ] TanStack Query used for all new data fetching
- [ ] No secrets, tokens, or credentials in source
