### PR TITLE
feat(scrobbling): self-hosted ListenBrainz/Last.fm endpoint URLs

### DIFF
--- a/backend/api/v1/schemas/settings.py
+++ b/backend/api/v1/schemas/settings.py
@@ -9,6 +9,27 @@ from infrastructure.msgspec_fastapi import AppStruct
 
 LASTFM_SECRET_MASK = "••••••••"
 
+# Official hosts; overridable per-instance for self-hosted/compatible services
+# (libre.fm, Maloja, a self-hosted ListenBrainz) - mirrors the MusicBrainz
+# api_url pattern below.
+DEFAULT_LISTENBRAINZ_API_URL = "https://api.listenbrainz.org"
+DEFAULT_LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/"
+DEFAULT_LASTFM_AUTH_URL = "https://www.last.fm/api/auth/"
+
+
+def _normalize_endpoint_url(url: str, default: str, *, trailing_slash: bool = False) -> str:
+    """Normalize a user-supplied service endpoint URL exactly like the
+    MusicBrainz api_url: strip whitespace, silently fall back to the official
+    default when the value isn't an http(s) URL, and normalize the trailing
+    slash (Last.fm-style roots keep exactly one; ListenBrainz-style keep none)."""
+    url = (url or "").strip()
+    if not url or not url.startswith(("http://", "https://")):
+        url = default
+    url = url.rstrip("/")
+    if trailing_slash:
+        url += "/"
+    return url
+
 
 def _mask_secret(value: str) -> str:
     if not value:
@@ -24,6 +45,16 @@ class LastFmConnectionSettings(AppStruct):
     session_key: str = ""
     username: str = ""
     enabled: bool = False
+    api_url: str = DEFAULT_LASTFM_API_URL
+    auth_url: str = DEFAULT_LASTFM_AUTH_URL
+
+    def __post_init__(self) -> None:
+        self.api_url = _normalize_endpoint_url(
+            self.api_url, DEFAULT_LASTFM_API_URL, trailing_slash=True
+        )
+        self.auth_url = _normalize_endpoint_url(
+            self.auth_url, DEFAULT_LASTFM_AUTH_URL, trailing_slash=True
+        )
 
 
 class LastFmConnectionSettingsResponse(AppStruct):
@@ -32,6 +63,8 @@ class LastFmConnectionSettingsResponse(AppStruct):
     session_key: str = ""
     username: str = ""
     enabled: bool = False
+    api_url: str = DEFAULT_LASTFM_API_URL
+    auth_url: str = DEFAULT_LASTFM_AUTH_URL
 
     @classmethod
     def from_settings(cls, settings: LastFmConnectionSettings) -> "LastFmConnectionSettingsResponse":
@@ -41,6 +74,8 @@ class LastFmConnectionSettingsResponse(AppStruct):
             session_key=_mask_secret(settings.session_key),
             username=settings.username,
             enabled=settings.enabled,
+            api_url=settings.api_url,
+            auth_url=settings.auth_url,
         )
 
 
@@ -480,6 +515,10 @@ class ListenBrainzConnectionSettings(AppStruct):
     username: str = ""
     user_token: str = ""
     enabled: bool = False
+    api_url: str = DEFAULT_LISTENBRAINZ_API_URL
+
+    def __post_init__(self) -> None:
+        self.api_url = _normalize_endpoint_url(self.api_url, DEFAULT_LISTENBRAINZ_API_URL)
 
 
 class YouTubeConnectionSettings(AppStruct):

--- a/backend/core/dependencies/repo_providers.py
+++ b/backend/core/dependencies/repo_providers.py
@@ -94,6 +94,7 @@ def get_listenbrainz_repository() -> "ListenBrainzRepository":
         username=lb_settings.username if lb_settings.enabled else "",
         user_token=lb_settings.user_token if lb_settings.enabled else "",
         fallback_token_provider=fallback_token_provider,
+        base_url=lb_settings.api_url,
     )
 
 
@@ -240,6 +241,7 @@ def get_lastfm_repository() -> "LastFmRepository":
         api_key=lf_settings.api_key,
         shared_secret=lf_settings.shared_secret,
         session_key=lf_settings.session_key,
+        base_url=lf_settings.api_url,
     )
 
 

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -803,7 +803,8 @@ def get_lastfm_auth_service() -> "LastFmAuthService":
     from services.lastfm_auth_service import LastFmAuthService
 
     lastfm_repo = get_lastfm_repository()
-    return LastFmAuthService(lastfm_repo=lastfm_repo)
+    auth_url = get_preferences_service().get_lastfm_connection().auth_url
+    return LastFmAuthService(lastfm_repo=lastfm_repo, auth_url=auth_url)
 
 
 @singleton

--- a/backend/repositories/lastfm_repository.py
+++ b/backend/repositories/lastfm_repository.py
@@ -108,12 +108,16 @@ class LastFmRepository:
         api_key: str = "",
         shared_secret: str = "",
         session_key: str = "",
+        base_url: str = LASTFM_API_URL,
     ):
         self._client = http_client
         self._cache = cache
         self._api_key = api_key
         self._shared_secret = shared_secret
         self._session_key = session_key
+        # admin-configurable API root (libre.fm, Maloja, other audioscrobbler-
+        # compatible endpoints); official ws.audioscrobbler.com default
+        self._base_url = base_url or LASTFM_API_URL
 
     @property
     def _can_sign(self) -> bool:
@@ -186,13 +190,13 @@ class LastFmRepository:
         try:
             if http_method == "POST":
                 response = await self._client.post(
-                    LASTFM_API_URL,
+                    self._base_url,
                     data=request_params,
                     timeout=15.0,
                 )
             else:
                 response = await self._client.get(
-                    LASTFM_API_URL,
+                    self._base_url,
                     params=request_params,
                     timeout=15.0,
                 )

--- a/backend/repositories/listenbrainz_repository.py
+++ b/backend/repositories/listenbrainz_repository.py
@@ -131,12 +131,14 @@ class ListenBrainzRepository:
         username: str = "",
         user_token: str = "",
         fallback_token_provider: "Callable[[], Awaitable[str | None]] | None" = None,
+        base_url: str = LISTENBRAINZ_API_URL,
     ):
         self._client = http_client
         self._cache = cache
         self._username = username
         self._user_token = user_token
-        self._base_url = LISTENBRAINZ_API_URL
+        # admin-configurable endpoint (self-hosted ListenBrainz); official host default
+        self._base_url = base_url.rstrip("/") if base_url else LISTENBRAINZ_API_URL
         self._request_semaphore = asyncio.Semaphore(2)
         # borrowed token for PUBLIC reads when this (usually global/enrichment) repo
         # has none of its own; LB now anti-scraper-gates anonymous popularity calls.

--- a/backend/services/lastfm_auth_service.py
+++ b/backend/services/lastfm_auth_service.py
@@ -17,8 +17,11 @@ class TokenEntry(msgspec.Struct):
 
 
 class LastFmAuthService:
-    def __init__(self, lastfm_repo: LastFmRepositoryProtocol):
+    def __init__(self, lastfm_repo: LastFmRepositoryProtocol, auth_url: str = LASTFM_AUTH_URL):
         self._repo = lastfm_repo
+        # admin-configurable auth root for Last.fm-compatible services
+        # (libre.fm etc.); official www.last.fm default
+        self._auth_url = auth_url or LASTFM_AUTH_URL
         self._pending_tokens: dict[str, TokenEntry] = {}
 
     def _evict_expired(self) -> None:
@@ -42,7 +45,7 @@ class LastFmAuthService:
 
         self._pending_tokens[token] = TokenEntry(token=token, created_at=time.time())
 
-        auth_url = f"{LASTFM_AUTH_URL}?api_key={api_key}&token={token}"
+        auth_url = f"{self._auth_url}?api_key={api_key}&token={token}"
         return token, auth_url
 
     async def exchange_session(self, token: str) -> tuple[str, str, str]:

--- a/backend/services/per_user_client_factory.py
+++ b/backend/services/per_user_client_factory.py
@@ -66,6 +66,7 @@ class PerUserClientFactory:
             cache=self._cache,
             username=data.get("username", ""),
             user_token=user_token,
+            base_url=self._preferences_service.get_listenbrainz_connection().api_url,
         )
 
     async def resolve_lastfm(self, user_id: str) -> "LastFmRepository | None":
@@ -94,6 +95,7 @@ class PerUserClientFactory:
             api_key=lf.api_key,
             shared_secret=lf.shared_secret,
             session_key=session_key,
+            base_url=lf.api_url,
         )
 
     async def resolve_lastfm_username(self, user_id: str) -> str | None:

--- a/backend/services/preferences_service.py
+++ b/backend/services/preferences_service.py
@@ -675,6 +675,7 @@ class PreferencesService:
             username=lb_data.get("username", ""),
             user_token=user_token,
             enabled=lb_data.get("enabled", False),
+            api_url=lb_data.get("api_url", ""),
         )
 
     def save_listenbrainz_connection(self, settings: ListenBrainzConnectionSettings) -> None:
@@ -684,6 +685,7 @@ class PreferencesService:
                 "username": settings.username,
                 "user_token": encrypt(settings.user_token),
                 "enabled": settings.enabled,
+                "api_url": settings.api_url,
             }
             self._save_config(config)
         except Exception as e:  # noqa: BLE001
@@ -771,6 +773,8 @@ class PreferencesService:
             session_key=self._read_secret(("lastfm_settings", "session_key"), data.get("session_key", "")),
             username=data.get("username", ""),
             enabled=data.get("enabled", False),
+            api_url=data.get("api_url", ""),
+            auth_url=data.get("auth_url", ""),
         )
 
     def save_lastfm_connection(self, settings: LastFmConnectionSettings) -> None:
@@ -803,6 +807,8 @@ class PreferencesService:
                 session_key=encrypt(session_key),
                 username=username,
                 enabled=enabled,
+                api_url=settings.api_url,
+                auth_url=settings.auth_url,
             )
             self._save_section("lastfm_settings", resolved)
         except Exception as e:  # noqa: BLE001

--- a/backend/services/settings_service.py
+++ b/backend/services/settings_service.py
@@ -125,7 +125,9 @@ class SettingsService:
             http_client = get_http_client(app_settings)
             temp_cache = InMemoryCache(max_entries=100)
 
-            temp_repo = ListenBrainzRepository(http_client=http_client, cache=temp_cache)
+            temp_repo = ListenBrainzRepository(
+                http_client=http_client, cache=temp_cache, base_url=settings.api_url
+            )
             temp_repo.configure(
                 username=settings.username,
                 user_token=settings.user_token
@@ -357,6 +359,7 @@ class SettingsService:
                 api_key=settings.api_key,
                 shared_secret=shared_secret,
                 session_key=session_key,
+                base_url=settings.api_url,
             )
             valid, message = await temp_repo.validate_api_key()
             if not valid:

--- a/backend/tests/services/test_endpoint_settings.py
+++ b/backend/tests/services/test_endpoint_settings.py
@@ -1,0 +1,259 @@
+"""Self-hosted endpoint settings for ListenBrainz and Last.fm.
+
+Mirrors the MusicBrainz api_url pattern: admin-configurable endpoint URLs with
+official hosts as defaults, silent fallback to the default on invalid input,
+trailing-slash normalization, persistence via PreferencesService, and threading
+into the repositories so a custom base URL is actually used on the wire.
+Behavior with defaults must be byte-identical to the previous hardcoded hosts.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from api.v1.schemas.settings import (
+    DEFAULT_LASTFM_API_URL,
+    DEFAULT_LASTFM_AUTH_URL,
+    DEFAULT_LISTENBRAINZ_API_URL,
+    LastFmConnectionSettings,
+    LastFmConnectionSettingsResponse,
+    ListenBrainzConnectionSettings,
+)
+from core.config import Settings
+from repositories.lastfm_repository import LASTFM_API_URL, LastFmRepository
+from repositories.listenbrainz_repository import (
+    LISTENBRAINZ_API_URL,
+    ListenBrainzRepository,
+)
+from services.lastfm_auth_service import LASTFM_AUTH_URL, LastFmAuthService
+from services.preferences_service import PreferencesService
+
+
+def _prefs(tmp_path: Path) -> PreferencesService:
+    settings = Settings()
+    settings.config_file_path = tmp_path / "config.json"
+    return PreferencesService(settings)
+
+
+class TestSchemaDefaultsAndNormalization:
+    def test_listenbrainz_default_matches_hardcoded_host(self):
+        s = ListenBrainzConnectionSettings()
+        assert s.api_url == DEFAULT_LISTENBRAINZ_API_URL == LISTENBRAINZ_API_URL
+        assert s.api_url == "https://api.listenbrainz.org"
+
+    def test_lastfm_defaults_match_hardcoded_hosts(self):
+        s = LastFmConnectionSettings()
+        assert s.api_url == DEFAULT_LASTFM_API_URL == LASTFM_API_URL
+        assert s.api_url == "https://ws.audioscrobbler.com/2.0/"
+        assert s.auth_url == DEFAULT_LASTFM_AUTH_URL == LASTFM_AUTH_URL
+        assert s.auth_url == "https://www.last.fm/api/auth/"
+
+    def test_listenbrainz_trailing_slash_stripped(self):
+        s = ListenBrainzConnectionSettings(api_url="https://lb.example.com/")
+        assert s.api_url == "https://lb.example.com"
+
+    def test_listenbrainz_whitespace_stripped(self):
+        s = ListenBrainzConnectionSettings(api_url="  https://lb.example.com  ")
+        assert s.api_url == "https://lb.example.com"
+
+    @pytest.mark.parametrize("bad", ["", "   ", "ftp://lb.example.com", "not a url"])
+    def test_listenbrainz_invalid_falls_back_to_default(self, bad: str):
+        s = ListenBrainzConnectionSettings(api_url=bad)
+        assert s.api_url == DEFAULT_LISTENBRAINZ_API_URL
+
+    def test_lastfm_api_url_gets_single_trailing_slash(self):
+        s = LastFmConnectionSettings(api_url="https://libre.fm/2.0")
+        assert s.api_url == "https://libre.fm/2.0/"
+        s = LastFmConnectionSettings(api_url="https://maloja.example.com/apis/mlj/2.0//")
+        assert s.api_url == "https://maloja.example.com/apis/mlj/2.0/"
+
+    def test_lastfm_auth_url_gets_single_trailing_slash(self):
+        s = LastFmConnectionSettings(auth_url="https://libre.fm/api/auth")
+        assert s.auth_url == "https://libre.fm/api/auth/"
+
+    @pytest.mark.parametrize("bad", ["", "gopher://x", "ws.audioscrobbler.com"])
+    def test_lastfm_invalid_urls_fall_back_to_defaults(self, bad: str):
+        s = LastFmConnectionSettings(api_url=bad, auth_url=bad)
+        assert s.api_url == DEFAULT_LASTFM_API_URL
+        assert s.auth_url == DEFAULT_LASTFM_AUTH_URL
+
+    def test_lastfm_response_exposes_endpoint_urls(self):
+        s = LastFmConnectionSettings(
+            api_key="k",
+            shared_secret="s",
+            api_url="https://libre.fm/2.0/",
+            auth_url="https://libre.fm/api/auth/",
+        )
+        resp = LastFmConnectionSettingsResponse.from_settings(s)
+        assert resp.api_url == "https://libre.fm/2.0/"
+        assert resp.auth_url == "https://libre.fm/api/auth/"
+
+
+class TestPreferencesRoundTrip:
+    def test_listenbrainz_api_url_round_trip(self, tmp_path: Path):
+        settings = Settings()
+        settings.config_file_path = tmp_path / "config.json"
+        _prefs(tmp_path).save_listenbrainz_connection(
+            ListenBrainzConnectionSettings(
+                username="alice",
+                user_token="tok",
+                enabled=True,
+                api_url="https://lb.example.com/",
+            )
+        )
+        reloaded = PreferencesService(settings)
+        lb = reloaded.get_listenbrainz_connection()
+        assert lb.api_url == "https://lb.example.com"
+        assert lb.username == "alice"
+        assert lb.user_token == "tok"
+        assert lb.enabled is True
+
+    def test_listenbrainz_legacy_config_defaults(self, tmp_path: Path):
+        # a config saved before api_url existed must read back as the official host
+        prefs = _prefs(tmp_path)
+        config = prefs._load_config().copy()
+        config["listenbrainz_settings"] = {"username": "bob", "user_token": "", "enabled": False}
+        prefs._save_config(config)
+        assert prefs.get_listenbrainz_connection().api_url == DEFAULT_LISTENBRAINZ_API_URL
+
+    def test_lastfm_endpoint_urls_round_trip(self, tmp_path: Path):
+        settings = Settings()
+        settings.config_file_path = tmp_path / "config.json"
+        _prefs(tmp_path).save_lastfm_connection(
+            LastFmConnectionSettings(
+                api_key="key",
+                shared_secret="secret",
+                api_url="https://maloja.example.com/apis/mlj/2.0",
+                auth_url="https://maloja.example.com/api/auth",
+            )
+        )
+        lf = PreferencesService(settings).get_lastfm_connection()
+        assert lf.api_url == "https://maloja.example.com/apis/mlj/2.0/"
+        assert lf.auth_url == "https://maloja.example.com/api/auth/"
+        assert lf.api_key == "key"
+        assert lf.shared_secret == "secret"
+
+    def test_lastfm_legacy_config_defaults(self, tmp_path: Path):
+        prefs = _prefs(tmp_path)
+        config = prefs._load_config().copy()
+        config["lastfm_settings"] = {"api_key": "", "shared_secret": "", "enabled": False}
+        prefs._save_config(config)
+        lf = prefs.get_lastfm_connection()
+        assert lf.api_url == DEFAULT_LASTFM_API_URL
+        assert lf.auth_url == DEFAULT_LASTFM_AUTH_URL
+
+
+def _lb_repo(base_url: str | None = None) -> tuple[ListenBrainzRepository, AsyncMock]:
+    http_client = AsyncMock(spec=httpx.AsyncClient)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    kwargs = {} if base_url is None else {"base_url": base_url}
+    repo = ListenBrainzRepository(
+        http_client=http_client,
+        cache=cache,
+        username="user",
+        user_token="tok",
+        **kwargs,
+    )
+    return repo, http_client
+
+
+def _lb_ok_response(json_data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_data or {"status": "ok"}
+    resp.content = None
+    resp.text = ""
+    return resp
+
+
+class TestListenBrainzCustomBaseUrl:
+    @pytest.mark.asyncio
+    async def test_scrobble_submit_uses_custom_base_url(self):
+        repo, http_client = _lb_repo(base_url="https://lb.example.com")
+        http_client.request = AsyncMock(return_value=_lb_ok_response())
+        ok = await repo.submit_now_playing(artist_name="Artist", track_name="Track")
+        assert ok is True
+        called_url = http_client.request.call_args.args[1]
+        assert called_url == "https://lb.example.com/1/submit-listens"
+
+    @pytest.mark.asyncio
+    async def test_default_base_url_byte_identical(self):
+        repo, http_client = _lb_repo()
+        http_client.request = AsyncMock(return_value=_lb_ok_response())
+        await repo.submit_now_playing(artist_name="A", track_name="T")
+        called_url = http_client.request.call_args.args[1]
+        assert called_url == "https://api.listenbrainz.org/1/submit-listens"
+
+    def test_trailing_slash_normalized_at_construction(self):
+        repo, _ = _lb_repo(base_url="https://lb.example.com/")
+        assert repo._base_url == "https://lb.example.com"
+
+
+def _lfm_ok_response(json_data=None):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = json_data if json_data is not None else {"artists": {"artist": []}}
+    resp.content = None
+    resp.text = ""
+    return resp
+
+
+def _lfm_repo(base_url: str | None = None) -> tuple[LastFmRepository, AsyncMock]:
+    LastFmRepository.reset_circuit_breaker()
+    http_client = AsyncMock(spec=httpx.AsyncClient)
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=None)
+    cache.set = AsyncMock()
+    kwargs = {} if base_url is None else {"base_url": base_url}
+    repo = LastFmRepository(
+        http_client=http_client,
+        cache=cache,
+        api_key="key",
+        shared_secret="secret",
+        **kwargs,
+    )
+    return repo, http_client
+
+
+class TestLastFmCustomBaseUrl:
+    @pytest.mark.asyncio
+    async def test_request_uses_custom_base_url(self):
+        repo, http_client = _lfm_repo(base_url="https://libre.fm/2.0/")
+        http_client.get = AsyncMock(return_value=_lfm_ok_response())
+        valid, _ = await repo.validate_api_key()
+        assert valid is True
+        assert http_client.get.call_args.args[0] == "https://libre.fm/2.0/"
+
+    @pytest.mark.asyncio
+    async def test_default_base_url_byte_identical(self):
+        repo, http_client = _lfm_repo()
+        http_client.get = AsyncMock(return_value=_lfm_ok_response())
+        await repo.validate_api_key()
+        assert http_client.get.call_args.args[0] == "https://ws.audioscrobbler.com/2.0/"
+
+
+class TestLastFmAuthServiceAuthUrl:
+    @pytest.mark.asyncio
+    async def test_custom_auth_url_in_authorize_link(self):
+        token_result = MagicMock()
+        token_result.token = "tok-1"
+        repo = MagicMock()
+        repo.get_token = AsyncMock(return_value=token_result)
+        svc = LastFmAuthService(lastfm_repo=repo, auth_url="https://libre.fm/api/auth/")
+        token, auth_url = await svc.request_token("api-key")
+        assert token == "tok-1"
+        assert auth_url == "https://libre.fm/api/auth/?api_key=api-key&token=tok-1"
+
+    @pytest.mark.asyncio
+    async def test_default_auth_url_byte_identical(self):
+        token_result = MagicMock()
+        token_result.token = "tok-2"
+        repo = MagicMock()
+        repo.get_token = AsyncMock(return_value=token_result)
+        svc = LastFmAuthService(lastfm_repo=repo)
+        _, auth_url = await svc.request_token("k")
+        assert auth_url == "https://www.last.fm/api/auth/?api_key=k&token=tok-2"

--- a/backend/tests/services/test_per_user_client_factory.py
+++ b/backend/tests/services/test_per_user_client_factory.py
@@ -40,7 +40,11 @@ def _factory(store: UserConnectionsStore, *, app_key: str = "appkey", app_secret
         http_timeout=10, http_connect_timeout=5, http_max_connections=200
     )
     prefs.get_lastfm_connection.return_value = SimpleNamespace(
-        api_key=app_key, shared_secret=app_secret
+        api_key=app_key, shared_secret=app_secret,
+        api_url="https://ws.audioscrobbler.com/2.0/",
+    )
+    prefs.get_listenbrainz_connection.return_value = SimpleNamespace(
+        api_url="https://api.listenbrainz.org"
     )
     return PerUserClientFactory(
         connections_store=store,

--- a/frontend/src/lib/components/settings/SettingsLastFmApp.svelte
+++ b/frontend/src/lib/components/settings/SettingsLastFmApp.svelte
@@ -4,14 +4,36 @@
 	import { Radio, ExternalLink } from 'lucide-svelte';
 	import { onMount, onDestroy } from 'svelte';
 
+	const DEFAULT_API_URL = 'https://ws.audioscrobbler.com/2.0/';
+	const DEFAULT_AUTH_URL = 'https://www.last.fm/api/auth/';
+
+	type LastFmTestResult = { valid: boolean; message: string };
+
 	// instance-wide app credentials only; per-user OAuth session + scrobble toggles
 	// live in the profile's "Scrobbling & Discovery" card
 	const form = createSettingsForm<LastFmConnectionSettingsResponse>({
 		loadEndpoint: '/api/v1/settings/lastfm',
-		saveEndpoint: '/api/v1/settings/lastfm'
+		saveEndpoint: '/api/v1/settings/lastfm',
+		testEndpoint: '/api/v1/settings/lastfm/verify'
 	});
 
 	let showSecret = $state(false);
+
+	const testResult = $derived(form.testResult as LastFmTestResult | null);
+
+	const isDefaultEndpoint = $derived(
+		form.data
+			? form.data.api_url === DEFAULT_API_URL && form.data.auth_url === DEFAULT_AUTH_URL
+			: true
+	);
+
+	function resetEndpointToDefault() {
+		if (form.data) {
+			form.data.api_url = DEFAULT_API_URL;
+			form.data.auth_url = DEFAULT_AUTH_URL;
+			form.testResult = null;
+		}
+	}
 
 	onMount(() => {
 		form.load();
@@ -92,6 +114,71 @@
 				<ExternalLink class="h-3 w-3" /> Register an app to get a key + secret
 			</a>
 
+			<div class="mt-2 space-y-3 border-t border-base-300/50 pt-4">
+				<div class="flex items-center justify-between">
+					<span
+						class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.2em] text-base-content/50"
+					>
+						API endpoint
+					</span>
+					{#if !isDefaultEndpoint}
+						<button
+							type="button"
+							class="btn btn-ghost btn-xs rounded-full"
+							onclick={resetEndpointToDefault}
+						>
+							Reset to default
+						</button>
+					{/if}
+				</div>
+				<p class="text-xs text-base-content/50">
+					Point at any Last.fm-compatible API (libre.fm, Maloja) — leave default for last.fm
+				</p>
+
+				<label class="form-control w-full">
+					<span
+						class="label-text mb-1 text-xs font-semibold uppercase tracking-wider text-base-content/50"
+					>
+						API URL
+					</span>
+					<input
+						type="text"
+						class="input input-soft w-full font-mono text-sm"
+						bind:value={form.data.api_url}
+						placeholder={DEFAULT_API_URL}
+						autocomplete="off"
+					/>
+				</label>
+
+				<label class="form-control w-full">
+					<span
+						class="label-text mb-1 text-xs font-semibold uppercase tracking-wider text-base-content/50"
+					>
+						Auth URL
+					</span>
+					<input
+						type="text"
+						class="input input-soft w-full font-mono text-sm"
+						bind:value={form.data.auth_url}
+						placeholder={DEFAULT_AUTH_URL}
+						autocomplete="off"
+					/>
+					<span class="mt-1 text-xs text-base-content/40">
+						Where users are sent to approve the app during sign-in.
+					</span>
+				</label>
+			</div>
+
+			{#if testResult}
+				<div
+					class="alert"
+					class:alert-success={testResult.valid}
+					class:alert-error={!testResult.valid}
+				>
+					<span>{testResult.message}</span>
+				</div>
+			{/if}
+
 			{#if form.message}
 				<div
 					class="alert"
@@ -102,7 +189,18 @@
 				</div>
 			{/if}
 
-			<div class="flex justify-end pt-1">
+			<div class="flex justify-end gap-2 pt-1">
+				<button
+					type="button"
+					class="btn btn-ghost gap-2 rounded-full"
+					onclick={() => void form.test()}
+					disabled={form.testing || !form.data.api_key}
+				>
+					{#if form.testing}
+						<span class="loading loading-spinner loading-sm"></span>
+					{/if}
+					Test connection
+				</button>
 				<button
 					type="button"
 					class="btn btn-primary glow-primary-soft gap-2 rounded-full"

--- a/frontend/src/lib/components/settings/SettingsMusicSource.svelte
+++ b/frontend/src/lib/components/settings/SettingsMusicSource.svelte
@@ -1,5 +1,8 @@
 <script lang="ts">
+	import type { ListenBrainzConnectionSettings } from '$lib/types';
 	import { musicSourceStore, type MusicSource } from '$lib/stores/musicSource';
+	import { createSettingsForm } from '$lib/utils/settingsForm.svelte';
+	import { onDestroy } from 'svelte';
 	import { fromStore } from 'svelte/store';
 
 	const source = fromStore(musicSourceStore);
@@ -8,6 +11,28 @@
 	let message = $state('');
 
 	const currentSource = $derived(source.current.source);
+
+	const DEFAULT_LISTENBRAINZ_API_URL = 'https://api.listenbrainz.org';
+
+	// endpoint rides on the same instance-wide ListenBrainz settings the backend
+	// already persists (username/token stay untouched by loading + saving the
+	// full object)
+	const endpointForm = createSettingsForm<ListenBrainzConnectionSettings>({
+		loadEndpoint: '/api/v1/settings/listenbrainz',
+		saveEndpoint: '/api/v1/settings/listenbrainz'
+	});
+
+	const isDefaultEndpoint = $derived(
+		endpointForm.data ? endpointForm.data.api_url === DEFAULT_LISTENBRAINZ_API_URL : true
+	);
+
+	function resetEndpointToDefault() {
+		if (endpointForm.data) {
+			endpointForm.data.api_url = DEFAULT_LISTENBRAINZ_API_URL;
+		}
+	}
+
+	onDestroy(() => endpointForm.cleanup());
 
 	async function handleChange(event: Event) {
 		const target = event.target as HTMLSelectElement;
@@ -29,6 +54,10 @@
 
 	$effect(() => {
 		musicSourceStore.load();
+	});
+
+	$effect(() => {
+		endpointForm.load();
 	});
 </script>
 
@@ -69,6 +98,80 @@
 					{message}
 				</span>
 			</div>
+		{/if}
+	</div>
+</div>
+
+<div class="card bg-base-200 mt-6">
+	<div class="card-body">
+		<h2 class="card-title text-2xl">ListenBrainz Endpoint</h2>
+		<p class="text-base-content/70 mb-4">
+			Where charts, recommendations, and scrobbles are sent when ListenBrainz is the source.
+		</p>
+
+		{#if endpointForm.loading}
+			<div class="flex justify-center items-center py-8">
+				<span class="loading loading-spinner loading-lg"></span>
+			</div>
+		{:else if endpointForm.data}
+			<div class="space-y-4">
+				<div class="form-control w-full">
+					<div class="mb-1 flex items-center justify-between">
+						<label
+							class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.2em] text-base-content/50"
+							for="lb-api-url"
+						>
+							API URL
+						</label>
+						{#if !isDefaultEndpoint}
+							<button
+								type="button"
+								class="btn btn-ghost btn-xs rounded-full"
+								onclick={resetEndpointToDefault}
+							>
+								Reset to default
+							</button>
+						{/if}
+					</div>
+					<input
+						id="lb-api-url"
+						type="text"
+						class="input w-full font-mono text-sm"
+						bind:value={endpointForm.data.api_url}
+						placeholder={DEFAULT_LISTENBRAINZ_API_URL}
+						autocomplete="off"
+					/>
+					<p class="text-xs text-base-content/50 mt-1 ml-1">
+						Self-hosted ListenBrainz supported — leave default for listenbrainz.org
+					</p>
+				</div>
+
+				{#if endpointForm.message}
+					<div
+						class="alert"
+						class:alert-success={endpointForm.messageType === 'success'}
+						class:alert-error={endpointForm.messageType === 'error'}
+					>
+						<span>{endpointForm.message}</span>
+					</div>
+				{/if}
+
+				<div class="flex justify-end">
+					<button
+						type="button"
+						class="btn btn-primary"
+						onclick={() => void endpointForm.save()}
+						disabled={endpointForm.saving}
+					>
+						{#if endpointForm.saving}
+							<span class="loading loading-spinner loading-sm"></span>
+						{/if}
+						Save Endpoint
+					</button>
+				</div>
+			</div>
+		{:else if endpointForm.message}
+			<div class="alert alert-error"><span>{endpointForm.message}</span></div>
 		{/if}
 	</div>
 </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1092,6 +1092,16 @@ export type LastFmConnectionSettingsResponse = {
 	session_key: string;
 	username: string;
 	enabled: boolean;
+	api_url: string;
+	auth_url: string;
+};
+
+// mirrors backend api/v1/schemas/settings.py (ListenBrainzConnectionSettings)
+export type ListenBrainzConnectionSettings = {
+	username: string;
+	user_token: string;
+	enabled: boolean;
+	api_url: string;
 };
 
 export type SpotifySettings = {


### PR DESCRIPTION
## What

Admin-configurable endpoint URLs for the two scrobble services, mirroring the existing MusicBrainz `api_url` pattern:

- ListenBrainz: `api_url` (default `https://api.listenbrainz.org`) - points charts, recommendations, and scrobbles at a self-hosted ListenBrainz
- Last.fm: `api_url` + `auth_url` (defaults `https://ws.audioscrobbler.com/2.0/` / `https://www.last.fm/api/auth/`) - works with libre.fm, Maloja, and other audioscrobbler-compatible services
- URLs are normalized on load/save (`_normalize_endpoint_url`): non-http(s) values silently fall back to the official default, trailing slashes normalized per service style
- Threaded through: global repositories, per-user client factory, Last.fm auth flow (`LastFmAuthService` sends users to the configured auth root), and the settings verify path (`SettingsService` tests against the configured URL)
- Settings UI: endpoint fields with a "Reset to default" affordance on the Last.fm app card and a ListenBrainz Endpoint card on the music-source page

## Why

Self-hosters increasingly run their own scrobble stack. Hardcoded official hosts made DroppedNeedle the only piece of their setup that couldn't point at it.

## How tested

`tests/services/test_endpoint_settings.py` (new) + `tests/services/test_per_user_client_factory.py` - 32 passed (Windows, Python 3.13): normalization rules, default fallbacks, repo wiring, per-user client propagation, auth-URL construction. Frontend: `pnpm check` on this branch - 0 errors, 0 warnings.

No migration needed: absent `api_url` keys deserialize to the official defaults, so existing configs behave identically.
