### PR TITLE
perf(discover): instant cold start, persistent discover cache, parallel zone builds

### DIFF
--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -904,6 +904,7 @@ def get_discover_service() -> "DiscoverService":
         follow_service=get_follow_service(),
         cover_repo=get_coverart_repository(),
         preview_repo=get_preview_repository(),
+        disk_cache=get_disk_cache(),
     )
 
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -495,7 +495,8 @@ def start_artist_discovery_cache_warming_task(
 # and banks them to mbid_store so the following normal-budget build finds them cached. One
 # loop, ONE user at a time (the single global MB 1/s queue makes concurrency pointless), and
 # it yields whenever a user is actively browsing.
-DISCOVER_WARMER_STARTUP_DELAY = 180       # let boot + first on-demand traffic settle
+DISCOVER_WARMER_STARTUP_DELAY = 10        # start warming right after boot: a restart-wiped
+                                          # cache must repopulate before users notice, not 3min later
 DISCOVER_WARMER_INTERVAL = 90             # floor between per-user warm ticks
 DISCOVER_WARMER_ENUM_TTL = 600            # re-enumerate eligible users at most this often
 DISCOVER_WARMER_REFRESH_INTERVAL = 6 * 3600   # re-warm a converged user this often

--- a/backend/infrastructure/cache/disk_cache.py
+++ b/backend/infrastructure/cache/disk_cache.py
@@ -41,6 +41,9 @@ class DiskMetadataCache:
         self._recent_audiodb_albums_dir = self.base_path / "recent" / "audiodb_albums"
         self._persistent_audiodb_artists_dir = self.base_path / "persistent" / "audiodb_artists"
         self._persistent_audiodb_albums_dir = self.base_path / "persistent" / "audiodb_albums"
+        # per-user Discover pages: persistent so a restart reloads them instantly
+        self._recent_discover_dir = self.base_path / "recent" / "discover"
+        self._persistent_discover_dir = self.base_path / "persistent" / "discover"
         self._ensure_dirs()
 
     def _ensure_dirs(self) -> None:
@@ -54,6 +57,8 @@ class DiskMetadataCache:
             self._recent_audiodb_albums_dir,
             self._persistent_audiodb_artists_dir,
             self._persistent_audiodb_albums_dir,
+            self._recent_discover_dir,
+            self._persistent_discover_dir,
         ):
             path.mkdir(parents=True, exist_ok=True)
 
@@ -86,6 +91,11 @@ class DiskMetadataCache:
             return (
                 self._recent_audiodb_albums_dir / f"{cache_hash}.json",
                 self._persistent_audiodb_albums_dir / f"{cache_hash}.json",
+            )
+        if entity_type == "discover":
+            return (
+                self._recent_discover_dir / f"{cache_hash}.json",
+                self._persistent_discover_dir / f"{cache_hash}.json",
             )
         raise ValueError(f"Unsupported entity type: {entity_type}")
 
@@ -293,6 +303,20 @@ class DiskMetadataCache:
 
     async def get_audiodb_album(self, identifier: str) -> dict[str, Any] | None:
         return await self._get_entity("audiodb_album", identifier)
+
+    async def set_discover(
+        self,
+        identifier: str,
+        payload: Any,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Persist a built per-user Discover page. Always stored on the persistent side
+        (it must survive restarts) but with an explicit TTL, matching the discover
+        cache's freshness semantics."""
+        await self._set_entity("discover", identifier, payload, is_monitored=True, ttl_seconds=ttl_seconds)
+
+    async def get_discover(self, identifier: str) -> dict[str, Any] | None:
+        return await self._get_entity("discover", identifier)
 
     async def delete_album(self, musicbrainz_id: str) -> None:
         recent_path, persistent_path = self._entity_paths("album", musicbrainz_id)

--- a/backend/services/discover/facade.py
+++ b/backend/services/discover/facade.py
@@ -72,6 +72,8 @@ class DiscoverService:
         follow_service: Any = None,
         cover_repo: Any = None,
         preview_repo: Any = None,
+        disk_cache: Any = None,
+        genre_prefs_store: Any = None,
     ):
         self._integration = IntegrationHelpers(preferences_service)
         self._client_factory = client_factory
@@ -125,6 +127,8 @@ class DiscoverService:
             library_db=library_db,
             follow_service=follow_service,
             cover_repo=cover_repo,
+            disk_cache=disk_cache,
+            genre_prefs_store=genre_prefs_store,
         )
 
         self._radio = radio_service
@@ -147,6 +151,9 @@ class DiscoverService:
 
     async def refresh_discover_data(self, user_id: str) -> None:
         return await self._homepage.refresh_discover_data(user_id)
+
+    async def invalidate_personalization_caches(self, user_id: str) -> None:
+        return await self._homepage.invalidate_personalization_caches(user_id)
 
     async def warm_cache(self, user_id: str) -> None:
         return await self._homepage.warm_cache(user_id)

--- a/backend/services/discover/genre_balance.py
+++ b/backend/services/discover/genre_balance.py
@@ -1,0 +1,312 @@
+"""Genre-balance helpers shared by Discover and the Taste Graph.
+
+A library skewed toward one genre (say 40% K-pop) used to dominate every
+recommendation zone because seeds were picked by raw play/album counts.
+These pure helpers fix that in three ways:
+
+- ``genre_family``       - normalises genre spellings ("k-pop", "kpop",
+                           "korean pop") into one family so caps and prefs
+                           apply to the family, not each spelling.
+- ``balanced_seed_selection`` - picks seeds round-robin across genre
+                           families with sqrt-damped family weights instead
+                           of raw frequency order.
+- ``cap_genre_share``    - enforces a per-zone share cap (~35%) for any one
+                           family, and excludes muted families entirely.
+- ``diverse_genre_selection`` - reorders (genre, count) rows for genre-seeded
+                           builders (daily mixes) with the same damping.
+
+User control arrives as :class:`GenrePrefs` levels per family:
+"reduce" halves a family's weight/allowance, "mute" excludes it.
+Items whose genres are unknown are never penalised - they pass through.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Iterable, Sequence, TypeVar
+
+T = TypeVar("T")
+
+# Default per-zone share cap for a single genre family (~a third of a zone).
+GENRE_SHARE_CAP = 0.35
+
+GENRE_PREF_LEVELS = ("normal", "reduce", "mute")
+
+# Alias map applied AFTER _canon() (lowercase, separators collapsed to single
+# spaces), so one entry covers "k-pop"/"K Pop"/"k_pop". Keep it small and
+# focused: the token rules below catch the systematic "k-"/"j-" prefixes.
+_FAMILY_ALIASES: dict[str, str] = {
+    "kpop": "k-pop",
+    "k pop": "k-pop",
+    "korean pop": "k-pop",
+    "korean idol": "k-pop",
+    "jpop": "j-pop",
+    "j pop": "j-pop",
+    "japanese pop": "j-pop",
+    "hiphop": "hip hop",
+    "hip hop": "hip hop",
+    "rap": "hip hop",
+    "rnb": "r&b",
+    "r&b": "r&b",
+    "r and b": "r&b",
+    "contemporary r&b": "r&b",
+    "electronica": "electronic",
+    "edm": "electronic",
+}
+
+
+def _canon(genre: str) -> str:
+    lowered = genre.strip().lower()
+    for sep in ("-", "_", "/"):
+        lowered = lowered.replace(sep, " ")
+    return " ".join(lowered.split())
+
+
+def genre_family(genre: str | None) -> str:
+    """Canonical family name for a genre string; "" when unknown/blank."""
+    if not isinstance(genre, str) or not genre.strip():
+        return ""
+    canon = _canon(genre)
+    alias = _FAMILY_ALIASES.get(canon)
+    if alias:
+        return alias
+    tokens = canon.split()
+    # "korean ballad", "k rock" style spellings group under the Korean family;
+    # same for Japanese. This is deliberately broad: the point of the family is
+    # the balance cap, not taxonomy.
+    if "korean" in tokens or tokens[0] == "kpop":
+        return "k-pop"
+    if "japanese" in tokens or tokens[0] == "jpop":
+        return "j-pop"
+    if len(tokens) > 1 and tokens[0] == "k":
+        return "k-pop"
+    if len(tokens) > 1 and tokens[0] == "j":
+        return "j-pop"
+    return canon
+
+
+class GenrePrefs:
+    """Per-user genre-family preference levels ("reduce" / "mute").
+
+    Families not present are "normal". Keys are normalised through
+    :func:`genre_family` so any spelling stored still matches.
+    """
+
+    __slots__ = ("_levels",)
+
+    def __init__(self, levels: dict[str, str] | None = None) -> None:
+        self._levels: dict[str, str] = {}
+        for raw_family, level in (levels or {}).items():
+            family = genre_family(raw_family)
+            if family and level in ("reduce", "mute"):
+                self._levels[family] = level
+
+    def is_empty(self) -> bool:
+        return not self._levels
+
+    def level(self, family: str) -> str:
+        return self._levels.get(family, "normal")
+
+    def is_muted(self, family: str) -> bool:
+        return self._levels.get(family) == "mute"
+
+    def multiplier(self, family: str) -> float:
+        level = self._levels.get(family)
+        if level == "mute":
+            return 0.0
+        if level == "reduce":
+            return 0.5
+        return 1.0
+
+    def levels(self) -> dict[str, str]:
+        return dict(self._levels)
+
+
+EMPTY_GENRE_PREFS = GenrePrefs()
+
+
+def primary_family(genres: Iterable[str] | None) -> str:
+    """First known family among an item's genres; "" for unknown."""
+    for g in genres or []:
+        family = genre_family(g)
+        if family:
+            return family
+    return ""
+
+
+def balanced_seed_selection(
+    candidates: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+) -> list[T]:
+    """Pick up to ``limit`` seeds spread across genre families.
+
+    ``candidates`` arrive in preference order (most-played first). Candidates
+    are grouped by primary family; families are ordered by sqrt-damped size
+    times the user's pref multiplier (so a 40%-of-library family no longer
+    swamps the seed set, and "reduce" halves its priority); seeds are then
+    taken round-robin across families. Muted families are excluded. Unknown-
+    genre candidates share one "" bucket, so with no genre data at all this
+    degrades to the original take-the-first-``limit`` behaviour.
+    """
+    if limit <= 0 or not candidates:
+        return []
+
+    buckets: dict[str, list[T]] = {}
+    order: dict[str, int] = {}
+    for index, candidate in enumerate(candidates):
+        family = primary_family(genres_of(candidate))
+        if family and prefs.is_muted(family):
+            continue
+        buckets.setdefault(family, []).append(candidate)
+        order.setdefault(family, index)
+
+    if not buckets:
+        return []
+
+    def family_weight(item: tuple[str, list[T]]) -> tuple[float, int]:
+        family, members = item
+        multiplier = prefs.multiplier(family) if family else 1.0
+        return (-(multiplier * math.sqrt(len(members))), order[family])
+
+    ordered_families = [members for _, members in sorted(buckets.items(), key=family_weight)]
+
+    selected: list[T] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for members in ordered_families:
+            if round_index < len(members):
+                selected.append(members[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def cap_genre_share(
+    items: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    *,
+    cap_ratio: float = GENRE_SHARE_CAP,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    target_size: int | None = None,
+    counts: dict[str, int] | None = None,
+    total_allowed: int | None = None,
+) -> list[T]:
+    """Order-preserving filter enforcing mute + a per-family share cap.
+
+    Any single family keeps at most ``max(1, ceil(cap_ratio * size))`` items
+    where ``size`` is ``target_size`` (or the input length); a reduced family
+    keeps half that. Unknown-genre items always pass. Items skipped for being
+    over-cap simply yield their slot to the next (other-genre) items in the
+    list - the backfill.
+
+    ``counts``/``total_allowed`` allow a caller to thread page-wide family
+    counters through multiple zones so the cap also holds across the whole
+    assembled page, not just inside one zone.
+    """
+    size = target_size if target_size is not None else len(items)
+    if size <= 0:
+        return list(items)
+    base_allowance = max(1, math.ceil(cap_ratio * size))
+
+    local_counts: dict[str, int] = {}
+    kept: list[T] = []
+    for item in items:
+        family = primary_family(genres_of(item))
+        if not family:
+            kept.append(item)
+            continue
+        if prefs.is_muted(family):
+            continue
+        allowance = base_allowance
+        if prefs.level(family) == "reduce":
+            allowance = max(1, base_allowance // 2)
+        if local_counts.get(family, 0) >= allowance:
+            continue
+        if counts is not None and total_allowed is not None:
+            if counts.get(family, 0) >= total_allowed:
+                continue
+            counts[family] = counts.get(family, 0) + 1
+        local_counts[family] = local_counts.get(family, 0) + 1
+        kept.append(item)
+    return kept
+
+
+def diverse_genre_selection(
+    top_genres: Sequence[tuple[str, int]],
+    *,
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    max_per_family: int = 2,
+) -> list[tuple[str, int]]:
+    """Rebalance (genre, count) rows for genre-seeded builders.
+
+    Counts are sqrt-damped and scaled by the user's pref multiplier, muted
+    families drop out, and at most ``max_per_family`` genres of one family
+    survive - so five K-pop spellings can't claim five daily-mix clusters.
+    Families are interleaved (best genre of each family first) so the result
+    leads with breadth.
+    """
+    if limit <= 0:
+        return []
+
+    weighted: list[tuple[float, int, str, int]] = []
+    for index, (genre, count) in enumerate(top_genres):
+        family = genre_family(genre)
+        multiplier = prefs.multiplier(family) if family else 1.0
+        if multiplier <= 0.0:
+            continue
+        weighted.append((multiplier * math.sqrt(max(count, 0) + 1), index, genre, count))
+    weighted.sort(key=lambda row: (-row[0], row[1]))
+
+    per_family: dict[str, list[tuple[str, int]]] = {}
+    family_order: list[str] = []
+    for _, _, genre, count in weighted:
+        family = genre_family(genre) or genre
+        rows = per_family.setdefault(family, [])
+        if family not in family_order:
+            family_order.append(family)
+        if len(rows) < max_per_family:
+            rows.append((genre, count))
+
+    selected: list[tuple[str, int]] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for family in family_order:
+            rows = per_family[family]
+            if round_index < len(rows):
+                selected.append(rows[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def genres_lookup(
+    genres_by_artist: dict[str, list[str]] | None,
+) -> Callable[[Any], list[str]]:
+    """genres_of adapter for HomeArtist/HomeAlbum/TopPickItem-shaped items,
+    resolving through a {artist_mbid_lower: [genres]} map."""
+    mapping = genres_by_artist or {}
+
+    def lookup(item: Any) -> list[str]:
+        mbid = getattr(item, "artist_mbid", None) or getattr(item, "mbid", None)
+        if not mbid:
+            album = getattr(item, "album", None)
+            if album is not None:
+                mbid = getattr(album, "artist_mbid", None)
+        if not mbid:
+            return []
+        return mapping.get(str(mbid).lower(), [])
+
+    return lookup

--- a/backend/services/discover/homepage_service.py
+++ b/backend/services/discover/homepage_service.py
@@ -1,11 +1,12 @@
 import asyncio
 import hashlib
 import logging
+import math
 import random
 from types import SimpleNamespace
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Iterable
 
 from api.v1.schemas.discover import (
     DiscoverResponse,
@@ -38,8 +39,20 @@ from services.home_transformers import HomeDataTransformers
 from services.home.integration_helpers import resolve_source_value
 from services.per_user_client_factory import PerUserClientFactory
 from infrastructure.persistence.user_listening_prefs_store import UserListeningPrefsStore
+from services.discover.genre_balance import (
+    EMPTY_GENRE_PREFS,
+    GENRE_SHARE_CAP,
+    GenrePrefs,
+    balanced_seed_selection,
+    cap_genre_share,
+    diverse_genre_selection,
+    genre_family,
+    genres_lookup,
+    primary_family,
+)
 from services.discover.integration_helpers import IntegrationHelpers
 from services.discover.mbid_resolution_service import MbidResolutionService, discover_build_thorough
+from services.discover.response_codec import decode_discover_response, encode_discover_response
 from services.discover.queue_strategies import build_similar_artist_pools, build_similar_artist_pools_lastfm, discover_by_genres, queue_item_to_home_album, round_robin_dedup_select
 from repositories.listenbrainz_repository import lb_popularity_degraded
 from services.discover.top_picks import TopPickCandidate, score_candidates
@@ -174,6 +187,18 @@ DISCOVER_PICKS_CACHE_TTL = 14400  # 4 hours
 DISCOVER_PICKS_DEGRADED_TTL = 300  # 5 minutes
 UNEXPLORED_GENRES_THRESHOLD = 2
 UNEXPLORED_GENRES_MAX = 8
+# Genre-balance seeding: how many seeds the zones use, and how many candidates we
+# collect before balancing across genre FAMILIES (so a 40% K-pop library doesn't
+# yield 90% K-pop seeds). Pool only widens when a genre index exists to balance with.
+SEED_ARTIST_COUNT = 3
+SEED_CANDIDATE_POOL = 10
+# At most this many daily-mix clusters may come from one genre family
+# ("k-pop" + "korean pop" + "kpop" count as ONE family).
+DAILY_MIX_MAX_CLUSTERS_PER_FAMILY = 2
+# Budget for the cold-path first paint: only library-derived zones (no external charts /
+# similarity) run under it, so a cold cache still returns SOMETHING within ~2s while the
+# full build streams in via the cache in the background.
+QUICK_ZONE_BUDGET_SECONDS = 1.5
 
 
 class DiscoverHomepageService:
@@ -195,6 +220,8 @@ class DiscoverHomepageService:
         library_db: Any = None,
         follow_service: Any = None,
         cover_repo: Any = None,
+        disk_cache: Any = None,
+        genre_prefs_store: Any = None,
     ) -> None:
         self._lb_repo = listenbrainz_repo
         self._jf_repo = jellyfin_repo
@@ -212,6 +239,11 @@ class DiscoverHomepageService:
         self._library_db = library_db
         self._follow_service = follow_service
         self._cover_repo = cover_repo
+        # per-user genre reduce/mute levels for the balance pass (None = defaults)
+        self._genre_prefs_store = genre_prefs_store
+        # persistent (disk) discover cache: survives restarts, reloaded lazily per key
+        self._disk_cache = disk_cache
+        self._disk_checked: set[str] = set()
         self._transformers = HomeDataTransformers(jellyfin_repo)
         self._weekly_exploration = WeeklyExplorationService(listenbrainz_repo, musicbrainz_repo)
         # per-user in-flight warm guard so one user never blocks another
@@ -275,6 +307,10 @@ class DiscoverHomepageService:
                 user_id, lb_enabled, lfm_enabled
             )
             cached = await self._memory_cache.get(cache_key)
+            if not isinstance(cached, DiscoverResponse):
+                # restart-wiped memory: reload yesterday's discover from the persistent
+                # cache instantly; the SWR check below still refreshes it in background
+                cached = await self._load_persisted_response(cache_key)
             if cached is not None and isinstance(cached, DiscoverResponse):
                 # stale-while-revalidate: serve the cached copy immediately, but rebuild
                 # in the background once it's older than the freshness window so the data
@@ -286,7 +322,7 @@ class DiscoverHomepageService:
                 return clone_with_updates(cached, {"refreshing": building})
         # cache miss (first build, restart-wiped cache, or a user whose build is
         # legitimately empty). Back off if a build was attempted within the freshness
-        # window so an empty/failed build doesn't rebuild on every 3s poll and hammer
+        # window so an empty/failed build doesn't rebuild on every poll and hammer
         # upstream APIs; if backed off we report refreshing=false so the UI settles on
         # the empty state instead of polling forever.
         cache_key = self._integration.get_discover_cache_key(
@@ -298,11 +334,90 @@ class DiscoverHomepageService:
         if not building and not attempted_recently:
             self._trigger_warm(user_id)
             building = True
-        return DiscoverResponse(
+        # FAST FIRST PAINT: never block the request on the full cold build. Return the
+        # cheap library-derived zones right away (empty zones are hidden client-side);
+        # the remaining zones land in the cache as the background build completes and
+        # stream in via the frontend's refreshing poll.
+        return await self._build_quick_response(user_id, lb_enabled, lfm_enabled, refreshing=building)
+
+    async def _build_quick_response(
+        self, user_id: str, lb_enabled: bool, lfm_enabled: bool, refreshing: bool,
+    ) -> DiscoverResponse:
+        """Library/local-only zones (anniversaries, new-from-followed, rediscover, genre
+        browse) under a hard ~QUICK_ZONE_BUDGET_SECONDS per zone: no external charts or
+        similarity calls, so a cold cache still paints in well under 2s."""
+        response = DiscoverResponse(
             integration_status=self._integration.get_integration_status(),
             service_prompts=self._build_service_prompts(lb_enabled, lfm_enabled),
-            refreshing=building,
+            refreshing=refreshing,
         )
+        try:
+            jf_enabled = self._integration.is_jellyfin_enabled()
+            library_configured = self._integration.is_library_configured()
+            tasks: dict[str, Any] = {
+                "anniversaries": self._build_anniversaries(),
+                "new_from_followed": self._build_new_from_followed(user_id),
+                "library_mbids": self._mbid.get_library_artist_mbids(library_configured),
+            }
+            if jf_enabled:
+                tasks["jf_most_played"] = self._jf_repo.get_most_played_artists(limit=50)
+            if library_configured:
+                tasks["library_albums"] = self._library_repo.get_library(include_unmonitored=True)
+            keys = list(tasks.keys())
+            raw = await asyncio.gather(
+                *(asyncio.wait_for(c, timeout=QUICK_ZONE_BUDGET_SECONDS) for c in tasks.values()),
+                return_exceptions=True,
+            )
+            results = {k: (None if isinstance(v, BaseException) else v) for k, v in zip(keys, raw)}
+            response.anniversaries = results.get("anniversaries")
+            response.new_from_followed = results.get("new_from_followed")
+            library_mbids = results.get("library_mbids") or set()
+            response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
+            response.genre_list = self._build_genre_list(results, lb_enabled)
+        except Exception as e:  # noqa: BLE001 - the quick paint must never fail the request
+            logger.debug("Quick discover response degraded: %s", e)
+        return response
+
+    async def _persist_response(self, cache_key: str, response: DiscoverResponse) -> None:
+        """Bank the built discover in the persistent metadata cache so a restart reloads
+        yesterday's page instantly instead of showing the build screen."""
+        if self._disk_cache is None:
+            return
+        try:
+            payload = {
+                "built_at": time.time(),
+                "response": encode_discover_response(response),
+            }
+            await self._disk_cache.set_discover(cache_key, payload, ttl_seconds=DISCOVER_CACHE_TTL)
+        except Exception as e:  # noqa: BLE001 - persistence is best-effort
+            logger.warning("Failed to persist discover cache: %s", e)
+
+    async def _load_persisted_response(self, cache_key: str) -> DiscoverResponse | None:
+        """One-shot per key: rehydrate the memory cache (and the SWR clock) from disk
+        after a restart. Returns None when there is nothing usable persisted."""
+        if self._disk_cache is None or cache_key in self._disk_checked:
+            return None
+        self._disk_checked.add(cache_key)
+        try:
+            payload = await self._disk_cache.get_discover(cache_key)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Persisted discover load failed: %s", e)
+            return None
+        if not isinstance(payload, dict):
+            return None
+        response = decode_discover_response(payload.get("response"))
+        if response is None or not self._has_meaningful_content(response):
+            return None
+        built_at = float(payload.get("built_at") or 0.0)
+        remaining = DISCOVER_CACHE_TTL - (time.time() - built_at)
+        if remaining <= 0:
+            return None
+        if self._memory_cache:
+            await self._memory_cache.set(cache_key, response, max(int(remaining), 60))
+        # restore the build time so stale-while-revalidate refreshes it in background
+        self._built_at[cache_key] = built_at
+        logger.info("Discover cache reloaded from disk for key %s", cache_key[:24])
+        return response
 
     async def get_discover_preview(self, user_id: str) -> DiscoverPreview | None:
         if not self._memory_cache:
@@ -379,6 +494,16 @@ class DiscoverHomepageService:
         finally:
             discover_build_thorough.reset(token)
 
+    async def invalidate_personalization_caches(self, user_id: str) -> None:
+        """Drop the per-user sub-caches that bake in genre preferences (daily
+        mixes, top picks) so the next rebuild honors updated prefs immediately
+        instead of after their own TTLs."""
+        if not self._memory_cache:
+            return
+        for source in ("listenbrainz", "lastfm"):
+            await self._memory_cache.delete(self._daily_mix_cache_key(user_id, source))
+            await self._memory_cache.delete(self._top_picks_cache_key(user_id, source))
+
     async def refresh_discover_data(self, user_id: str) -> None:
         _, _, _, _, lb_enabled, lfm_enabled, _ = await self._resolve_user_music(user_id, None)
         if user_id in self._building_keys:
@@ -404,6 +529,7 @@ class DiscoverHomepageService:
             response = await self.build_discover_data(user_id)
             if self._memory_cache and self._has_meaningful_content(response):
                 await self._memory_cache.set(cache_key, response, DISCOVER_CACHE_TTL)
+                await self._persist_response(cache_key, response)
                 self._spawn_cover_prewarm(user_id, response)
             else:
                 logger.warning("Discover build produced no meaningful content, keeping existing cache")
@@ -511,12 +637,14 @@ class DiscoverHomepageService:
         # download buttons) and neutered the don't-suggest-what-you-own exclusions
         library_album_mbids = await self._mbid.get_library_album_mbids(library_configured)
 
+        genre_prefs = await self._load_genre_prefs(user_id)
         seed_artists = await self._get_seed_artists(
             lb_enabled, username, jf_enabled,
             resolved_source=primary,
             lfm_enabled=lfm_enabled,
             lfm_username=lfm_username,
             lb_client=lb_client,
+            genre_prefs=genre_prefs,
         )
 
         tasks: dict[str, Any] = {}
@@ -584,6 +712,9 @@ class DiscoverHomepageService:
 
         seen_artist_mbids: set[str] = set()
 
+        # Synchronous zones first: pure transforms over the phase-1 results. They run
+        # sequentially so the artist dedup between sections (seen_artist_mbids) stays
+        # deterministic; none of them awaits an external service.
         response.because_you_listen_to = self._build_because_sections(
             seed_artists, results, library_mbids, seen_artist_mbids,
             resolved_source=primary,
@@ -591,7 +722,38 @@ class DiscoverHomepageService:
         await self._enrich_because_sections_audiodb(response.because_you_listen_to)
 
         response.fresh_releases = self._build_fresh_releases(results, library_album_mbids)
+        response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
+        response.artists_you_might_like = self._build_artists_you_might_like(
+            seed_artists, results, library_mbids, seen_artist_mbids,
+            resolved_source=primary,
+        )
+        response.genre_list = self._build_genre_list(results, lb_enabled)
 
+        if primary == "lastfm":
+            response.globally_trending = self._build_lastfm_globally_trending(
+                results, library_mbids, seen_artist_mbids
+            )
+        else:
+            response.globally_trending = self._build_globally_trending(
+                results, library_mbids, seen_artist_mbids
+            )
+
+        response.lastfm_weekly_artist_chart = self._build_lastfm_weekly_artist_chart(
+            results, library_mbids, seen_artist_mbids
+        )
+
+        similar_artist_mbids: list[str] = []
+        for i in range(3):
+            similar = results.get(f"similar_{i}") or []
+            for artist in similar:
+                mbid = getattr(artist, 'artist_mbid', None) or getattr(artist, 'mbid', None)
+                if mbid:
+                    similar_artist_mbids.append(mbid)
+
+        # Every remaining zone is independent - run them ALL concurrently, each under its
+        # own per-zone timeout (_execute_tasks), so one slow upstream (a starved
+        # MusicBrainz resolution, a hanging chart call) can't delay unrelated zones.
+        # Upstream fan-out stays bounded by the repos' own rate limiters/queues.
         post_tasks: dict[str, Any] = {
             "missing_essentials": self._build_missing_essentials(results, library_album_mbids),
             "lastfm_weekly_album_chart": self._build_lastfm_weekly_album_chart(
@@ -609,13 +771,22 @@ class DiscoverHomepageService:
             ),
             "anniversaries": self._build_anniversaries(),
             "new_from_followed": self._build_new_from_followed(user_id),
+            "popular_in_your_genres": self._build_popular_in_genres(
+                results, library_mbids, seen_artist_mbids,
+                resolved_source=primary,
+                genre_prefs=genre_prefs,
+            ),
+            "unexplored_genres": self._build_unexplored_genres(
+                response.because_you_listen_to, similar_artist_mbids
+            ),
         }
+        if response.genre_list and response.genre_list.items:
+            post_tasks["genre_artists"] = self._build_genre_artists(response.genre_list)
         if lb_client and username:
             post_tasks["listeners_like_you"] = self._build_listeners_like_you(
                 lb_client, username, user_id,
             )
-        # LB-specific: runs whenever the user's ListenBrainz is linked
-        if lb_client and username:
+            # LB-specific: runs whenever the user's ListenBrainz is linked
             post_tasks["weekly_exploration"] = self._weekly_exploration.build_section(
                 username, lb_repo=lb_client
             )
@@ -628,78 +799,140 @@ class DiscoverHomepageService:
         response.listeners_like_you = post_results.get("listeners_like_you")
         response.anniversaries = post_results.get("anniversaries")
         response.new_from_followed = post_results.get("new_from_followed")
-
-        response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
-
-        response.artists_you_might_like = self._build_artists_you_might_like(
-            seed_artists, results, library_mbids, seen_artist_mbids,
-            resolved_source=primary,
-        )
-
-        response.popular_in_your_genres = await self._build_popular_in_genres(
-            results, library_mbids, seen_artist_mbids,
-            resolved_source=primary,
-        )
-
-        response.genre_list = self._build_genre_list(results, lb_enabled)
-
-        similar_artist_mbids: list[str] = []
-        for i in range(3):
-            similar = results.get(f"similar_{i}") or []
-            for artist in similar:
-                mbid = getattr(artist, 'artist_mbid', None) or getattr(artist, 'mbid', None)
-                if mbid:
-                    similar_artist_mbids.append(mbid)
-
-        response.unexplored_genres = await self._build_unexplored_genres(
-            response.because_you_listen_to, similar_artist_mbids
-        )
-
-        if response.genre_list and response.genre_list.items:
-            genre_names = [
-                g.name for g in response.genre_list.items[:20]
-                if isinstance(g, HomeGenre)
-            ]
-            if genre_names:
-                raw_mbids = await asyncio.gather(
-                    *(self._get_genre_artist(g) for g in genre_names)
-                )
-                used_mbids: set[str] = set()
-                genre_artists: dict[str, str | None] = {}
-                for g, mbid in zip(genre_names, raw_mbids):
-                    if mbid and mbid not in used_mbids:
-                        genre_artists[g] = mbid
-                        used_mbids.add(mbid)
-                    elif mbid and mbid in used_mbids:
-                        alt = await self._get_genre_artist(g, exclude_mbids=used_mbids)
-                        genre_artists[g] = alt
-                        if alt:
-                            used_mbids.add(alt)
-                    else:
-                        genre_artists[g] = None
-                response.genre_artists = genre_artists
-                response.genre_artist_images = await self._resolve_genre_artist_images(
-                    response.genre_artists
-                )
-
-        if primary == "lastfm":
-            response.globally_trending = self._build_lastfm_globally_trending(
-                results, library_mbids, seen_artist_mbids
-            )
-        else:
-            response.globally_trending = self._build_globally_trending(
-                results, library_mbids, seen_artist_mbids
-            )
-
-        response.lastfm_weekly_artist_chart = self._build_lastfm_weekly_artist_chart(
-            results, library_mbids, seen_artist_mbids
-        )
+        response.popular_in_your_genres = post_results.get("popular_in_your_genres")
+        response.unexplored_genres = post_results.get("unexplored_genres")
+        genre_artist_result = post_results.get("genre_artists")
+        if genre_artist_result:
+            response.genre_artists, response.genre_artist_images = genre_artist_result
         response.lastfm_weekly_album_chart = post_results.get("lastfm_weekly_album_chart")
         response.lastfm_recent_scrobbles = post_results.get("lastfm_recent_scrobbles")
 
         response.service_prompts = self._build_service_prompts(lb_enabled, lfm_enabled)
 
+        # Genre-balance pass over the assembled zones: per-zone AND page-wide family
+        # share caps plus the user's reduce/mute levels. Runs after the zone builders
+        # (a pure post-filter) so the parallel orchestration above stays untouched.
+        try:
+            await self._apply_genre_balance(response, genre_prefs)
+        except Exception as e:  # noqa: BLE001 - balancing must never fail the build
+            logger.warning("Genre balance pass failed: %s", e)
+
         return response
+
+    async def _apply_genre_balance(
+        self, response: DiscoverResponse, prefs: GenrePrefs,
+    ) -> None:
+        """Cap any single genre family's share (~GENRE_SHARE_CAP) inside each
+        recommendation zone and across the whole assembled page, and honor the
+        user's reduce/mute levels.
+
+        Classification comes from the library genre index; items whose artist has
+        no known genres always pass through, so external-chart zones are trimmed
+        conservatively rather than emptied. Daily mixes and radio stations are
+        single-genre BY DESIGN - they're balanced at cluster/seed level instead
+        and skipped here."""
+        if self._genre_index is None:
+            return
+
+        other_sections: list[HomeSection] = [
+            section
+            for section in (
+                response.artists_you_might_like,
+                response.popular_in_your_genres,
+                response.globally_trending,
+                response.listeners_like_you,
+                response.fresh_releases,
+                response.missing_essentials,
+            )
+            if section is not None
+        ]
+
+        mbids: set[str] = {
+            b.seed_artist_mbid.lower()
+            for b in response.because_you_listen_to
+            if b.seed_artist_mbid
+        }
+        for section in [b.section for b in response.because_you_listen_to] + other_sections:
+            for item in section.items:
+                mbid = getattr(item, "artist_mbid", None) or getattr(item, "mbid", None)
+                if mbid:
+                    mbids.add(str(mbid).lower())
+        if response.top_picks:
+            for pick in response.top_picks.items:
+                if pick.album.artist_mbid:
+                    mbids.add(pick.album.artist_mbid.lower())
+
+        genres = await self._genres_for_artists(mbids)
+        if not genres:
+            return
+        lookup = genres_lookup(genres)
+
+        # a muted seed family takes its whole "Because You Listen To" rail with it
+        if not prefs.is_empty():
+            response.because_you_listen_to = [
+                b for b in response.because_you_listen_to
+                if not (
+                    b.seed_artist_mbid
+                    and prefs.is_muted(
+                        primary_family(genres.get(b.seed_artist_mbid.lower(), []))
+                    )
+                )
+            ]
+        sections = [b.section for b in response.because_you_listen_to] + other_sections
+
+        # page-wide budget: one family may claim at most the cap share of ALL
+        # capped-zone items combined, on top of each zone's own cap
+        total_items = sum(len(s.items) for s in sections)
+        if response.top_picks:
+            total_items += len(response.top_picks.items)
+        page_counts: dict[str, int] = {}
+        page_allowance = max(1, math.ceil(GENRE_SHARE_CAP * total_items))
+
+        # the hero zone first, so the page budget favors Top Picks
+        if response.top_picks:
+            response.top_picks.items = cap_genre_share(
+                response.top_picks.items, lookup, prefs=prefs,
+                counts=page_counts, total_allowed=page_allowance,
+            )
+        for section in sections:
+            section.items = cap_genre_share(
+                section.items, lookup, prefs=prefs,
+                counts=page_counts, total_allowed=page_allowance,
+            )
+        response.because_you_listen_to = [
+            b for b in response.because_you_listen_to if b.section.items
+        ]
+
+    async def _build_genre_artists(
+        self, genre_list: HomeSection
+    ) -> tuple[dict[str, str | None], dict[str, str | None]] | None:
+        """A representative artist (and image) per browsable genre tile. Split out so it
+        runs as its own zone: its MusicBrainz tag searches (1 req/s) previously ran after
+        everything else and serially stretched the build by tens of seconds."""
+        genre_names = [
+            g.name for g in genre_list.items[:20]
+            if isinstance(g, HomeGenre)
+        ]
+        if not genre_names:
+            return None
+        raw_mbids = await asyncio.gather(
+            *(self._get_genre_artist(g) for g in genre_names)
+        )
+        used_mbids: set[str] = set()
+        genre_artists: dict[str, str | None] = {}
+        for g, mbid in zip(genre_names, raw_mbids):
+            if mbid and mbid not in used_mbids:
+                genre_artists[g] = mbid
+                used_mbids.add(mbid)
+            elif mbid and mbid in used_mbids:
+                alt = await self._get_genre_artist(g, exclude_mbids=used_mbids)
+                genre_artists[g] = alt
+                if alt:
+                    used_mbids.add(alt)
+            else:
+                genre_artists[g] = None
+        images = await self._resolve_genre_artist_images(genre_artists)
+        return genre_artists, images
 
     async def build_playlist_suggestions(
         self,
@@ -805,9 +1038,15 @@ class DiscoverHomepageService:
         lfm_enabled: bool = False,
         lfm_username: str | None = None,
         lb_client: Any = None,
+        genre_prefs: GenrePrefs | None = None,
     ) -> list[ListenBrainzArtist]:
         seeds: list[ListenBrainzArtist] = []
         seen_mbids: set[str] = set()
+        # Collect a wider candidate pool than we need, then balance the final pick
+        # across genre FAMILIES (breadth-based seeding) instead of taking the raw
+        # most-played top - which a genre-skewed library dominates. Without a genre
+        # index there is nothing to balance with, so keep the original tight target.
+        pool_target = SEED_CANDIDATE_POOL if self._genre_index is not None else SEED_ARTIST_COUNT
 
         if resolved_source == "lastfm" and lfm_enabled and lfm_username and self._lfm_repo:
             try:
@@ -815,7 +1054,7 @@ class DiscoverHomepageService:
                     lfm_username, period="3month", limit=10
                 )
                 for a in lfm_artists:
-                    if len(seeds) >= 3:
+                    if len(seeds) >= pool_target:
                         break
                     mbid = a.mbid
                     if mbid and mbid not in seen_mbids:
@@ -832,15 +1071,15 @@ class DiscoverHomepageService:
 
         # LB top-artists rely on the client's own identity, so use the per-user client
         seed_lb_repo = lb_client or self._lb_repo
-        if resolved_source != "lastfm" and len(seeds) < 3 and lb_enabled and username:
+        if resolved_source != "lastfm" and len(seeds) < pool_target and lb_enabled and username:
             # fall back to broader windows so a quiet week/month still yields seeds
             for range_ in ("this_week", "this_month", "this_year", "all_time"):
-                if len(seeds) >= 3:
+                if len(seeds) >= pool_target:
                     break
                 try:
                     artists = await seed_lb_repo.get_user_top_artists(count=10, range_=range_)
                     for a in artists:
-                        if len(seeds) >= 3:
+                        if len(seeds) >= pool_target:
                             break
                         mbid = a.artist_mbids[0] if a.artist_mbids else None
                         if mbid and mbid not in seen_mbids:
@@ -849,17 +1088,17 @@ class DiscoverHomepageService:
                 except Exception as e:  # noqa: BLE001
                     logger.warning(f"Failed to get LB top artists ({range_}): {e}")
 
-        if resolved_source != "lastfm" and len(seeds) < 3 and jf_enabled:
+        if resolved_source != "lastfm" and len(seeds) < pool_target and jf_enabled:
             for fetch_fn in (
                 lambda: self._jf_repo.get_most_played_artists(limit=10),
                 lambda: self._jf_repo.get_favorite_artists(limit=10),
             ):
-                if len(seeds) >= 3:
+                if len(seeds) >= pool_target:
                     break
                 try:
                     jf_items = await fetch_fn()
                     for item in jf_items:
-                        if len(seeds) >= 3:
+                        if len(seeds) >= pool_target:
                             break
                         mbid = None
                         if item.provider_ids:
@@ -875,7 +1114,57 @@ class DiscoverHomepageService:
                     logger.warning(f"Failed to get Jellyfin seed artists: {e}")
                     continue
 
-        return seeds
+        return await self._select_balanced_seeds(seeds, genre_prefs or EMPTY_GENRE_PREFS)
+
+    async def _load_genre_prefs(self, user_id: str) -> GenrePrefs:
+        """The user's genre reduce/mute levels; empty (all-normal) on any failure."""
+        if self._genre_prefs_store is None:
+            return EMPTY_GENRE_PREFS
+        try:
+            return GenrePrefs(await self._genre_prefs_store.get_levels(user_id))
+        except Exception as e:  # noqa: BLE001 - prefs must never break a build
+            logger.debug("Genre prefs load failed: %s", e)
+            return EMPTY_GENRE_PREFS
+
+    async def _genres_for_artists(self, mbids: Iterable[str]) -> dict[str, list[str]]:
+        """{artist_mbid_lower: [genres]} from the library genre index; {} on failure."""
+        mbid_list = [m for m in mbids if m]
+        if self._genre_index is None or not mbid_list:
+            return {}
+        try:
+            return await self._genre_index.get_genres_for_artists(mbid_list)
+        except Exception as e:  # noqa: BLE001 - genre data is best-effort
+            logger.debug("Genre lookup for seed balancing failed: %s", e)
+            return {}
+
+    async def _select_balanced_seeds(
+        self, candidates: list[ListenBrainzArtist], prefs: GenrePrefs,
+    ) -> list[ListenBrainzArtist]:
+        """SEED_ARTIST_COUNT seeds spread round-robin across genre families.
+
+        With no genre data and no prefs this is exactly the old take-the-first-3,
+        so sparse libraries and genre-index-less setups behave as before."""
+        if not candidates:
+            return []
+        genres: dict[str, list[str]] = {}
+        if len(candidates) > SEED_ARTIST_COUNT or not prefs.is_empty():
+            genres = await self._genres_for_artists(
+                [self._seed_mbid(s) or "" for s in candidates]
+            )
+        if not genres and prefs.is_empty():
+            return candidates[:SEED_ARTIST_COUNT]
+
+        def genres_of(seed: Any) -> list[str]:
+            mbid = self._seed_mbid(seed)
+            return genres.get(mbid.lower(), []) if mbid else []
+
+        return balanced_seed_selection(candidates, genres_of, SEED_ARTIST_COUNT, prefs)
+
+    @staticmethod
+    def _seed_mbid(seed: Any) -> str | None:
+        if getattr(seed, "artist_mbids", None):
+            return seed.artist_mbids[0]
+        return getattr(seed, "artist_mbid", None)
 
     async def _enrich_because_sections_audiodb(
         self, sections: list[BecauseYouListenTo]
@@ -972,14 +1261,22 @@ class DiscoverHomepageService:
                 await self._cache_daily_mix_result([], user_id, resolved_source)
                 return []
 
-            genre_names = [g for g, _ in top_genres[:10]]
+            # breadth-based cluster seeding: sqrt-damped counts, at most
+            # DAILY_MIX_MAX_CLUSTERS_PER_FAMILY genres per family ("k-pop" and
+            # "korean pop" are ONE family), muted families dropped, reduce halved
+            genre_prefs = await self._load_genre_prefs(user_id)
+            balanced_genres = diverse_genre_selection(
+                top_genres, limit=10, prefs=genre_prefs,
+                max_per_family=DAILY_MIX_MAX_CLUSTERS_PER_FAMILY,
+            )
+            genre_names = [g for g, _ in balanced_genres]
             artists_by_genre = await self._genre_index.get_artists_for_genres(genre_names)
 
             MIN_ARTISTS_PER_CLUSTER = 3
             MAX_CLUSTERS = 5
             candidate_clusters: list[tuple[str, list[str]]] = []
             seen_artists: set[str] = set()
-            for genre_lower, _count in top_genres:
+            for genre_lower, _count in balanced_genres:
                 artist_mbids = artists_by_genre.get(genre_lower, [])
                 unique = [a for a in artist_mbids if a not in seen_artists]
                 if len(unique) < MIN_ARTISTS_PER_CLUSTER:
@@ -1412,6 +1709,12 @@ class DiscoverHomepageService:
                 name = getattr(g, "genre", None)
                 if name:
                     user_genres.add(name.lower())
+            # muted families don't get to pull the genre-affinity score either
+            genre_prefs = await self._load_genre_prefs(user_id)
+            if not genre_prefs.is_empty():
+                user_genres = {
+                    g for g in user_genres if not genre_prefs.is_muted(genre_family(g))
+                }
             genres_by_artist: dict[str, list[str]] = {}
             if self._genre_index is not None:
                 artist_mbids = [c.artist_mbid for c in candidates if c.artist_mbid]
@@ -1427,6 +1730,14 @@ class DiscoverHomepageService:
                 user_genres=user_genres,
                 genres_by_artist=genres_by_artist,
                 count=count,
+            )
+            # zone genre cap: no single family (where the artist's genres are known)
+            # may dominate Top Picks; muted families are excluded outright
+            picks = cap_genre_share(
+                picks,
+                lambda p: genres_by_artist.get((p.candidate.artist_mbid or "").lower(), []),
+                prefs=genre_prefs,
+                target_size=count,
             )
             if not picks:
                 await self._cache_top_picks_result(None, user_id, primary, ttl=picks_ttl)
@@ -1861,10 +2172,11 @@ class DiscoverHomepageService:
         library_mbids: set[str],
         seen_artist_mbids: set[str],
         resolved_source: str = "listenbrainz",
+        genre_prefs: GenrePrefs = EMPTY_GENRE_PREFS,
     ) -> HomeSection | None:
         if resolved_source == "lastfm" and self._lfm_repo:
             return await self._build_popular_in_genres_lastfm(
-                results, library_mbids, seen_artist_mbids
+                results, library_mbids, seen_artist_mbids, genre_prefs=genre_prefs,
             )
 
         genres = results.get("lb_genres")
@@ -1872,10 +2184,19 @@ class DiscoverHomepageService:
         if not genres:
             return None
         else:
+            # breadth: pick 3 DISTINCT genre families (not three spellings of one),
+            # skipping families the user muted
             genre_names = []
-            for genre in genres[:3]:
+            seen_families: set[str] = set()
+            for genre in genres:
                 name = genre.genre if hasattr(genre, 'genre') else str(genre)
+                family = genre_family(name) or name
+                if family in seen_families or genre_prefs.is_muted(family):
+                    continue
+                seen_families.add(family)
                 genre_names.append(name)
+                if len(genre_names) >= 3:
+                    break
 
         all_artists: list[HomeArtist] = []
         tag_results = await asyncio.gather(
@@ -1915,6 +2236,7 @@ class DiscoverHomepageService:
         results: dict[str, Any],
         library_mbids: set[str],
         seen_artist_mbids: set[str],
+        genre_prefs: GenrePrefs = EMPTY_GENRE_PREFS,
     ) -> HomeSection | None:
         top_artists = results.get("lfm_user_top_artists_for_genres") or []
         if not top_artists or not self._lfm_repo:
@@ -1930,17 +2252,24 @@ class DiscoverHomepageService:
 
         genre_names: list[str] = []
         seen_genres: set[str] = set()
+        seen_families: set[str] = set()
         for info in artist_info_results:
             if isinstance(info, Exception):
                 logger.debug("Failed to get artist info for genre extraction: %s", info)
                 continue
             if info and info.tags:
                 for tag in info.tags[:2]:
-                    if tag.name and tag.name.lower() not in seen_genres:
-                        genre_names.append(tag.name)
-                        seen_genres.add(tag.name.lower())
-                        if len(genre_names) >= 3:
-                            break
+                    if not tag.name or tag.name.lower() in seen_genres:
+                        continue
+                    # one genre per FAMILY, none from muted families
+                    family = genre_family(tag.name) or tag.name.lower()
+                    if family in seen_families or genre_prefs.is_muted(family):
+                        continue
+                    genre_names.append(tag.name)
+                    seen_genres.add(tag.name.lower())
+                    seen_families.add(family)
+                    if len(genre_names) >= 3:
+                        break
             if len(genre_names) >= 3:
                 break
 
@@ -2335,8 +2664,18 @@ class DiscoverHomepageService:
         # bound each upstream call so one slow/hanging service can't stall the whole
         # build (a timeout is caught below and that section is just dropped)
         _task_timeout = _scaled(DISCOVER_TASK_TIMEOUT_SECONDS)
-        coros = [asyncio.wait_for(c, timeout=_task_timeout) for c in tasks.values()]
-        raw_results = await asyncio.gather(*coros, return_exceptions=True)
+        durations: dict[str, float] = {}
+
+        async def _timed(key: str, coro: Any) -> Any:
+            start = time.monotonic()
+            try:
+                return await asyncio.wait_for(coro, timeout=_task_timeout)
+            finally:
+                durations[key] = time.monotonic() - start
+
+        raw_results = await asyncio.gather(
+            *(_timed(k, c) for k, c in tasks.items()), return_exceptions=True
+        )
         results = {}
         self._last_failed_task_keys = set()
         for key, result in zip(keys, raw_results):
@@ -2346,6 +2685,12 @@ class DiscoverHomepageService:
                 self._last_failed_task_keys.add(key)
             else:
                 results[key] = result
+        # where the seconds go, slowest zones first (the whole gather costs max(), not sum())
+        slowest = sorted(durations.items(), key=lambda kv: kv[1], reverse=True)
+        logger.info(
+            "Discover zone timings: %s",
+            ", ".join(f"{k}={v:.1f}s" for k, v in slowest[:10]),
+        )
         return results
 
     @staticmethod

--- a/backend/services/discover/response_codec.py
+++ b/backend/services/discover/response_codec.py
@@ -1,0 +1,179 @@
+"""JSON-safe round-trip for ``DiscoverResponse`` (persistent discover cache).
+
+Encoding is plain ``msgspec.to_builtins``. Decoding needs care because
+``HomeSection.items`` is an UNTAGGED union (``HomeArtist | HomeAlbum | HomeTrack |
+HomeGenre``) which msgspec cannot decode directly - the section's ``type`` field
+("artists"/"albums"/"tracks"/"genres") is the discriminator, so each section's items
+are converted against the concrete type it declares.
+
+Decoding is defensive throughout: a corrupt or schema-drifted payload yields ``None``
+(callers fall back to a normal rebuild) rather than an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import msgspec
+
+from api.v1.schemas.discover import (
+    BecauseYouListenTo,
+    DiscoverIntegrationStatus,
+    DiscoverResponse,
+    TopPicksSection,
+)
+from api.v1.schemas.home import (
+    HomeAlbum,
+    HomeArtist,
+    HomeGenre,
+    HomeSection,
+    HomeTrack,
+    ServicePrompt,
+)
+from api.v1.schemas.weekly_exploration import WeeklyExplorationSection
+
+logger = logging.getLogger(__name__)
+
+_ITEM_TYPES: dict[str, type] = {
+    "artists": HomeArtist,
+    "albums": HomeAlbum,
+    "tracks": HomeTrack,
+    "genres": HomeGenre,
+}
+
+# every DiscoverResponse field typed ``HomeSection | None``
+_SECTION_FIELDS = (
+    "fresh_releases",
+    "missing_essentials",
+    "rediscover",
+    "artists_you_might_like",
+    "popular_in_your_genres",
+    "genre_list",
+    "globally_trending",
+    "lastfm_weekly_artist_chart",
+    "lastfm_weekly_album_chart",
+    "lastfm_recent_scrobbles",
+    "listeners_like_you",
+    "anniversaries",
+    "new_from_followed",
+    "unexplored_genres",
+)
+
+
+def encode_discover_response(response: DiscoverResponse) -> dict[str, Any]:
+    return msgspec.to_builtins(response)
+
+
+def _opt_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _decode_section(raw: Any) -> HomeSection | None:
+    # HomeSection itself carries the untagged union, so it is built by hand; only the
+    # concrete item structs go through msgspec.convert.
+    if not isinstance(raw, dict):
+        return None
+    section_type = str(raw.get("type") or "")
+    section = HomeSection(
+        title=str(raw.get("title") or ""),
+        type=section_type,
+        source=_opt_str(raw.get("source")),
+        fallback_message=_opt_str(raw.get("fallback_message")),
+        connect_service=_opt_str(raw.get("connect_service")),
+        radio_seed_type=_opt_str(raw.get("radio_seed_type")),
+        radio_seed_id=_opt_str(raw.get("radio_seed_id")),
+    )
+    item_type = _ITEM_TYPES.get(section_type)
+    if item_type is None:
+        return section
+    items: list[Any] = []
+    for item_raw in raw.get("items") or []:
+        try:
+            items.append(msgspec.convert(item_raw, type=item_type, strict=False))
+        except (msgspec.ValidationError, TypeError, ValueError):
+            continue
+    section.items = items
+    return section
+
+
+def _decode_because(raw: Any) -> BecauseYouListenTo | None:
+    if not isinstance(raw, dict):
+        return None
+    section = _decode_section(raw.get("section"))
+    if section is None:
+        return None
+    return BecauseYouListenTo(
+        seed_artist=str(raw.get("seed_artist") or ""),
+        seed_artist_mbid=str(raw.get("seed_artist_mbid") or ""),
+        section=section,
+        listen_count=int(raw.get("listen_count") or 0),
+        banner_url=raw.get("banner_url"),
+        wide_thumb_url=raw.get("wide_thumb_url"),
+        fanart_url=raw.get("fanart_url"),
+    )
+
+
+def _convert_opt(raw: Any, target: type) -> Any:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return msgspec.convert(raw, type=target, strict=False)
+    except (msgspec.ValidationError, TypeError, ValueError):
+        return None
+
+
+def _str_map(raw: Any) -> dict[str, str | None]:
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(k): (str(v) if isinstance(v, str) else None)
+        for k, v in raw.items()
+    }
+
+
+def decode_discover_response(payload: Any) -> DiscoverResponse | None:
+    # The DiscoverResponse type as a whole is NOT msgspec-decodable (its sections carry
+    # the untagged items union), so it is reassembled field by field: union-free fields
+    # via msgspec.convert, sections via the type-discriminated decoder above.
+    if not isinstance(payload, dict):
+        return None
+    try:
+        service_status = payload.get("service_status")
+        response = DiscoverResponse(
+            discover_queue_enabled=bool(payload.get("discover_queue_enabled", True)),
+            genre_artists=_str_map(payload.get("genre_artists")),
+            genre_artist_images=_str_map(payload.get("genre_artist_images")),
+            service_status=service_status if isinstance(service_status, dict) else None,
+            refreshing=False,
+        )
+        for field in _SECTION_FIELDS:
+            setattr(response, field, _decode_section(payload.get(field)))
+        response.daily_mixes = [
+            s for s in map(_decode_section, payload.get("daily_mixes") or []) if s is not None
+        ]
+        response.radio_sections = [
+            s for s in map(_decode_section, payload.get("radio_sections") or []) if s is not None
+        ]
+        response.because_you_listen_to = [
+            b for b in map(_decode_because, payload.get("because_you_listen_to") or [])
+            if b is not None
+        ]
+        response.top_picks = _convert_opt(payload.get("top_picks"), TopPicksSection)
+        response.weekly_exploration = _convert_opt(
+            payload.get("weekly_exploration"), WeeklyExplorationSection
+        )
+        response.integration_status = _convert_opt(
+            payload.get("integration_status"), DiscoverIntegrationStatus
+        )
+        response.service_prompts = [
+            p for p in (
+                _convert_opt(raw, ServicePrompt)
+                for raw in payload.get("service_prompts") or []
+            )
+            if p is not None
+        ]
+        return response
+    except Exception as e:  # noqa: BLE001 - a bad payload means "no persisted cache"
+        logger.debug("Failed to decode persisted discover response: %s", e)
+        return None

--- a/backend/tests/services/test_discover_fast_cold_path.py
+++ b/backend/tests/services/test_discover_fast_cold_path.py
@@ -1,0 +1,320 @@
+"""Fast-first-paint, zone isolation and restart persistence for the Discover build.
+
+Covers the slow-Discover fixes:
+- the cold path never blocks on the full build: it returns the cheap library-derived
+  zones within the quick budget, flags ``refreshing`` and completes the rest in a
+  background warm that fills the cache;
+- one hanging upstream zone can't delay unrelated zones (per-zone timeouts);
+- a built page persists to the disk metadata cache and reloads instantly after a
+  simulated restart (new service instance, empty memory cache).
+"""
+
+import asyncio
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.v1.schemas.discover import DiscoverResponse
+from api.v1.schemas.home import HomeAlbum, HomeArtist, HomeGenre, HomeSection
+from infrastructure.cache.memory_cache import InMemoryCache
+from repositories.listenbrainz_models import ListenBrainzArtist
+from services.discover.homepage_service import DiscoverHomepageService
+from services.discover.response_codec import (
+    decode_discover_response,
+    encode_discover_response,
+)
+
+
+def _cache_key(user_id: str) -> str:
+    return f"discover_response:{user_id}:True:False"
+
+
+def _anniversary_albums() -> list[dict]:
+    year = datetime.now(timezone.utc).year - 20
+    return [
+        {"mbid": f"a{i}", "title": f"Old Gold {i}", "artist_name": "A", "artist_mbid": None, "year": year}
+        for i in range(3)
+    ]
+
+
+def _make_service(
+    memory_cache=None,
+    disk_cache=None,
+    lb_repo=None,
+    library_db=None,
+) -> DiscoverHomepageService:
+    lb = lb_repo or AsyncMock()
+    integration = MagicMock()
+    integration.get_discover_cache_key.side_effect = (
+        lambda uid, lb_enabled=False, lfm_enabled=False: _cache_key(uid)
+    )
+    integration.get_integration_status.return_value = None
+    integration.is_jellyfin_enabled.return_value = False
+    integration.is_library_configured.return_value = True
+    integration.get_discover_picks_settings.return_value = (True, 5)
+
+    mbid = MagicMock()
+    mbid.get_library_artist_mbids = AsyncMock(return_value=set())
+    mbid.get_library_album_mbids = AsyncMock(return_value=set())
+    mbid.get_user_listened_release_group_mbids = AsyncMock(return_value=set())
+    mbid.normalize_mbid.side_effect = lambda m: m.lower() if m else None
+
+    library_repo = AsyncMock()
+    library_repo.get_artists_from_library = AsyncMock(return_value=[])
+    library_repo.get_library = AsyncMock(return_value=[])
+
+    factory = MagicMock()
+    factory.resolve_listenbrainz = AsyncMock(return_value=lb)
+    factory.resolve_lastfm = AsyncMock(return_value=None)
+    factory.resolve_listenbrainz_username = AsyncMock(return_value="lbuser")
+    factory.resolve_lastfm_username = AsyncMock(return_value=None)
+
+    prefs_store = MagicMock()
+    prefs_store.get = AsyncMock(
+        return_value=SimpleNamespace(primary_music_source="listenbrainz")
+    )
+
+    return DiscoverHomepageService(
+        listenbrainz_repo=lb,
+        jellyfin_repo=AsyncMock(),
+        library_repo=library_repo,
+        musicbrainz_repo=AsyncMock(),
+        integration=integration,
+        mbid_resolution=mbid,
+        memory_cache=memory_cache,
+        lastfm_repo=None,
+        client_factory=factory,
+        listening_prefs_store=prefs_store,
+        library_db=library_db,
+        disk_cache=disk_cache,
+    )
+
+
+def _full_response() -> DiscoverResponse:
+    return DiscoverResponse(
+        globally_trending=HomeSection(
+            title="Globally Trending",
+            type="artists",
+            items=[HomeArtist(mbid="m1", name="Artist One", listen_count=5)],
+            source="listenbrainz",
+        ),
+        daily_mixes=[
+            HomeSection(
+                title="Daily Mix 1 - Rock",
+                type="albums",
+                items=[HomeAlbum(name="Album", mbid="rg1", artist_name="A")],
+                source="listenbrainz",
+            )
+        ],
+        genre_list=HomeSection(
+            title="Browse by Genre",
+            type="genres",
+            items=[HomeGenre(name="Rock", listen_count=10)],
+            source="listenbrainz",
+        ),
+    )
+
+
+class TestFastColdPath:
+    @pytest.mark.asyncio
+    async def test_cold_request_returns_fast_and_background_build_fills_cache(self):
+        uid = "cold-user-1"
+        cache = InMemoryCache()
+        library_db = MagicMock()
+        library_db.get_albums = AsyncMock(return_value=_anniversary_albums())
+        svc = _make_service(memory_cache=cache, library_db=library_db)
+
+        build_started = asyncio.Event()
+
+        async def slow_build(user_id: str) -> DiscoverResponse:
+            build_started.set()
+            await asyncio.sleep(1.0)  # a slow external-dependent full build
+            return _full_response()
+
+        svc.build_discover_data = slow_build
+
+        start = time.monotonic()
+        resp = await svc.get_discover_data(uid)
+        elapsed = time.monotonic() - start
+
+        # never blocks on the full build; cheap local zones paint immediately
+        assert elapsed < 2.0
+        assert resp.refreshing is True
+        assert resp.anniversaries is not None and resp.anniversaries.items
+        assert resp.globally_trending is None  # not ready yet -> empty zone
+
+        # the triggered background build completes and fills the cache
+        await asyncio.wait_for(build_started.wait(), timeout=2)
+        for _ in range(60):
+            if await cache.get(_cache_key(uid)) is not None:
+                break
+            await asyncio.sleep(0.1)
+        cached = await cache.get(_cache_key(uid))
+        assert isinstance(cached, DiscoverResponse)
+
+        followup = await svc.get_discover_data(uid)
+        assert followup.refreshing is False  # settled
+        assert followup.globally_trending is not None
+        assert followup.globally_trending.items[0].name == "Artist One"
+
+    @pytest.mark.asyncio
+    async def test_empty_quick_zones_still_returns_fast_shell(self):
+        uid = "cold-user-2"
+        svc = _make_service(memory_cache=InMemoryCache())
+        svc.build_discover_data = AsyncMock(return_value=DiscoverResponse())
+
+        resp = await svc.get_discover_data(uid)
+
+        assert resp.refreshing is True
+        assert resp.anniversaries is None
+        assert resp.because_you_listen_to == []
+
+
+class TestZoneIsolation:
+    @pytest.mark.asyncio
+    async def test_one_hanging_zone_does_not_delay_or_kill_others(self, monkeypatch):
+        import services.discover.homepage_service as hs
+
+        monkeypatch.setattr(hs, "DISCOVER_TASK_TIMEOUT_SECONDS", 0.5)
+
+        lb = AsyncMock()
+        lb.get_user_top_artists = AsyncMock(return_value=[])
+        lb.get_sitewide_top_artists = AsyncMock(
+            return_value=[
+                ListenBrainzArtist(
+                    artist_name=f"Trend {i}", listen_count=10 - i, artist_mbids=[f"t{i}"]
+                )
+                for i in range(5)
+            ]
+        )
+
+        async def hang():
+            await asyncio.sleep(30)
+
+        lb.get_user_fresh_releases = AsyncMock(side_effect=hang)
+        lb.get_user_genre_activity = AsyncMock(return_value=[])
+        lb.get_similar_users = AsyncMock(return_value=[])
+        lb.get_recommendation_playlists = AsyncMock(return_value=[])
+        lb.get_sitewide_top_release_groups = AsyncMock(return_value=[])
+
+        svc = _make_service(memory_cache=InMemoryCache(), lb_repo=lb)
+
+        start = time.monotonic()
+        response = await svc.build_discover_data("iso-user")
+        elapsed = time.monotonic() - start
+
+        # the hanging zone was cut at its own budget without stalling the build
+        assert elapsed < 5.0
+        assert response.fresh_releases is None
+        # unrelated zones still built
+        assert response.globally_trending is not None
+        assert len(response.globally_trending.items) == 5
+
+
+class TestPersistentCache:
+    @pytest.mark.asyncio
+    async def test_reload_after_simulated_restart(self, tmp_path):
+        from infrastructure.cache.disk_cache import DiskMetadataCache
+
+        uid = "persist-user-1"
+        disk = DiskMetadataCache(base_path=tmp_path)
+
+        svc1 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc1.build_discover_data = AsyncMock(return_value=_full_response())
+        await svc1.warm_cache(uid)
+
+        persisted = await disk.get_discover(_cache_key(uid))
+        assert isinstance(persisted, dict) and persisted.get("response")
+
+        # "restart": a brand-new service instance with an empty memory cache
+        svc2 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        resp = await svc2.get_discover_data(uid)
+
+        # yesterday's discover is served instantly, fully typed, without a rebuild
+        assert resp.refreshing is False  # fresh enough -> no background churn
+        assert resp.globally_trending is not None
+        assert isinstance(resp.globally_trending.items[0], HomeArtist)
+        assert resp.daily_mixes and isinstance(resp.daily_mixes[0].items[0], HomeAlbum)
+        assert resp.genre_list and isinstance(resp.genre_list.items[0], HomeGenre)
+
+    @pytest.mark.asyncio
+    async def test_stale_persisted_copy_triggers_background_refresh(self, tmp_path, monkeypatch):
+        from infrastructure.cache.disk_cache import DiskMetadataCache
+
+        uid = "persist-user-2"
+        disk = DiskMetadataCache(base_path=tmp_path)
+
+        svc1 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc1.build_discover_data = AsyncMock(return_value=_full_response())
+        await svc1.warm_cache(uid)
+
+        # age the persisted copy past the SWR freshness window (still inside its TTL)
+        payload = await disk.get_discover(_cache_key(uid))
+        payload["built_at"] = time.time() - 3600
+        await disk.set_discover(_cache_key(uid), payload, ttl_seconds=3600)
+
+        svc2 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc2._trigger_warm = MagicMock()
+        resp = await svc2.get_discover_data(uid)
+
+        # stale-but-usable: serve it AND refresh in background
+        assert resp.globally_trending is not None
+        assert resp.refreshing is True
+        svc2._trigger_warm.assert_called_once_with(uid)
+
+
+class TestResponseCodec:
+    def test_round_trip_preserves_sections_and_item_types(self):
+        from api.v1.schemas.discover import (
+            BecauseYouListenTo,
+            TopPickItem,
+            TopPicksSection,
+        )
+
+        original = _full_response()
+        original.because_you_listen_to = [
+            BecauseYouListenTo(
+                seed_artist="Seed",
+                seed_artist_mbid="s1",
+                listen_count=7,
+                section=HomeSection(
+                    title="Because You Listen To Seed",
+                    type="artists",
+                    items=[HomeArtist(mbid="sim1", name="Similar One")],
+                    source="listenbrainz",
+                ),
+            )
+        ]
+        original.top_picks = TopPicksSection(
+            items=[
+                TopPickItem(
+                    album=HomeAlbum(name="Pick", mbid="p1", artist_name="PA"),
+                    match_pct=87,
+                    reasons=["similar to Seed"],
+                )
+            ],
+            source="listenbrainz",
+        )
+        original.genre_artists = {"Rock": "m1"}
+
+        decoded = decode_discover_response(encode_discover_response(original))
+
+        assert decoded is not None
+        assert isinstance(decoded.globally_trending.items[0], HomeArtist)
+        assert decoded.globally_trending.items[0].name == "Artist One"
+        assert isinstance(decoded.daily_mixes[0].items[0], HomeAlbum)
+        assert isinstance(decoded.genre_list.items[0], HomeGenre)
+        because = decoded.because_you_listen_to[0]
+        assert because.seed_artist == "Seed" and because.listen_count == 7
+        assert isinstance(because.section.items[0], HomeArtist)
+        assert decoded.top_picks.items[0].match_pct == 87
+        assert decoded.top_picks.items[0].album.name == "Pick"
+        assert decoded.genre_artists == {"Rock": "m1"}
+
+    def test_corrupt_payload_decodes_to_none(self):
+        assert decode_discover_response(None) is None
+        assert decode_discover_response("junk") is None
+        assert decode_discover_response({"because_you_listen_to": 42}) is None

--- a/backend/tests/services/test_top_picks.py
+++ b/backend/tests/services/test_top_picks.py
@@ -141,6 +141,7 @@ def _svc() -> DiscoverHomepageService:
     svc._memory_cache = None
     svc._mbid_store = None
     svc._genre_index = None
+    svc._genre_prefs_store = None
     svc._library_db = None
     svc._follow_service = None
     svc._integration = MagicMock()

--- a/backend/tests/test_discover_home_peruser.py
+++ b/backend/tests/test_discover_home_peruser.py
@@ -256,6 +256,9 @@ async def test_seed_artists_fall_back_to_broader_ranges():
 
     svc = DiscoverHomepageService.__new__(DiscoverHomepageService)
     svc._lfm_repo = None
+    # no genre index in this test: seed selection keeps the original tight target
+    svc._genre_index = None
+    svc._genre_prefs_store = None
 
     seed = ListenBrainzArtist(artist_name="A", listen_count=5, artist_mbids=["mbid-1"])
 
@@ -360,9 +363,20 @@ def _miss_service(built_at: dict):
     svc._integration = MagicMock()
     svc._integration.get_discover_cache_key.return_value = "discover_response:u1:True:False"
     svc._integration.get_integration_status.return_value = MagicMock()
+    svc._integration.is_jellyfin_enabled.return_value = False
+    svc._integration.is_library_configured.return_value = False
     svc._build_service_prompts = MagicMock(return_value=[])
     svc._trigger_warm = MagicMock()
     svc._built_at = built_at
+    # collaborators the cold-path quick response (library-derived zones) touches
+    svc._disk_cache = None
+    svc._disk_checked = set()
+    svc._mbid = MagicMock()
+    svc._mbid.get_library_artist_mbids = AsyncMock(return_value=set())
+    svc._library_db = None
+    svc._follow_service = None
+    svc._transformers = MagicMock()
+    svc._transformers.extract_genres_from_library.return_value = []
     return svc
 
 

--- a/frontend/src/lib/queries/discover/DiscoverQuery.svelte.ts
+++ b/frontend/src/lib/queries/discover/DiscoverQuery.svelte.ts
@@ -41,13 +41,17 @@ export const getDiscoverQueryOptions = (userId: string | null | undefined) =>
 		queryFn: ({ signal }) => fetchDiscover(userId, signal)
 	});
 
+// While the backend is still building (`refreshing === true`), poll gently so the page
+// fills in zone-by-zone as the background build completes; stop as soon as it settles.
+const DISCOVER_REFRESHING_POLL_MS = 8_000;
+
 export const getDiscoverQuery = () =>
 	createQuery(() => ({
 		staleTime: DISCOVER_REVALIDATE_MS,
 		queryKey: DiscoverQueryKeyFactory.discover(authStore.user?.id),
 		queryFn: ({ signal }) => fetchDiscover(authStore.user?.id, signal),
 		refetchInterval: (query: { state: { data?: DiscoverResponse | undefined } }) =>
-			query.state.data?.refreshing ? 3000 : false
+			query.state.data?.refreshing ? DISCOVER_REFRESHING_POLL_MS : false
 	}));
 
 export const getRadioQuery = (getParams: Getter<{ seedType: string; seedId: string }>) =>


### PR DESCRIPTION
## What

Discover cold start goes from "build screen for tens of seconds" to instant:

- **Fast first paint**: a cache miss no longer blocks the request. `_build_quick_response` returns the cheap library-derived zones (anniversaries, new-from-followed, rediscover, genre browse) under a hard ~1.5s per-zone budget while the full build streams in via the existing `refreshing` poll (poll relaxed 3s -> 8s in `DiscoverQuery.svelte.ts`).
- **Persistent discover cache**: built pages are banked in the `DiskMetadataCache` (new `discover` entity, persistent side with an explicit TTL) and reloaded after a restart - yesterday's page appears instantly and stale-while-revalidate refreshes it in background. `services/discover/response_codec.py` does the msgspec encode/decode.
- **Parallelized zone builds**: the previously-serial post-phase zones (missing essentials, weekly charts, genre-artist resolution, popular-in-genres, unexplored genres...) now run concurrently, each under its own timeout, with per-zone duration logging. The genre-artist MB tag searches (1 req/s, previously serial at the end) become their own zone.
- **Warmer delay 180s -> 10s**: a restart-wiped cache starts repopulating right after boot instead of 3 minutes later.

Also carries `services/discover/genre_balance.py` (same helper module as #162 - identical file, merges cleanly): the rebuilt seed selection uses its breadth-based balancing so a genre-skewed library doesn't produce single-genre seeds. Per-user genre *controls* come in a follow-up PR; here everything runs with default preferences (`genre_prefs_store` is unwired/None).

## Why

Self-hosted boxes restart often. A restart previously meant an empty Discover and a long rebuild; now the page paints in under 2s cold and fully restores after restart.

## How tested

`tests/services/test_discover_fast_cold_path.py` (new), `tests/test_discover_home_peruser.py`, `tests/services/test_top_picks.py` - **43 passed** (Windows, Python 3.13): quick-response budget behavior, disk persist/reload with TTL, SWR clock restoration, zone parallelism, seed fallbacks.
