### PR TITLE
feat(discover): genre balancing with per-genre user controls (reduce/mute)

### DIFF
--- a/backend/api/v1/routes/me_connections.py
+++ b/backend/api/v1/routes/me_connections.py
@@ -26,6 +26,11 @@ from api.v1.schemas.me_connections import (
     ScrobblePreferencesUpdate,
     SpotifyAuthUrlResponse,
 )
+from api.v1.schemas.genre_prefs import (
+    GenrePrefItem,
+    GenrePrefsResponse,
+    GenrePrefsUpdate,
+)
 from api.v1.schemas.section_prefs import (
     SectionPrefItem,
     SectionPrefsResponse,
@@ -39,6 +44,8 @@ from api.v1.schemas.settings import (
 )
 from core.dependencies import (
     get_auth_store,
+    get_cache,
+    get_genre_index,
     get_lastfm_auth_service,
     get_now_playing_service,
     get_per_user_client_factory,
@@ -47,6 +54,7 @@ from core.dependencies import (
     get_settings_service,
     get_sse_publisher,
     get_user_connections_store,
+    get_user_genre_prefs_store,
     get_user_listening_prefs_store,
     get_user_section_prefs_store,
 )
@@ -59,6 +67,7 @@ from core.task_registry import TaskRegistry
 from infrastructure.msgspec_fastapi import MsgSpecBody, MsgSpecRoute
 from infrastructure.persistence.auth_store import AuthStore
 from infrastructure.persistence.user_connections_store import UserConnectionsStore
+from infrastructure.persistence.user_genre_prefs_store import UserGenrePrefsStore
 from infrastructure.persistence.user_listening_prefs_store import UserListeningPrefsStore
 from infrastructure.persistence.user_section_prefs_store import UserSectionPrefsStore
 from middleware import CurrentUserDep
@@ -442,3 +451,91 @@ async def update_section_prefs(
             )
         }
     )
+
+
+_GENRE_PREF_MAX_FAMILIES = 30
+
+
+async def _build_genre_pref_items(
+    user_id: str,
+    genre_prefs: UserGenrePrefsStore,
+    genre_index,
+) -> list[GenrePrefItem]:
+    """The user's library genre FAMILIES (spelling variants merged) with their
+    current balance level. Stored families no longer present in the library are
+    still listed (artist_count 0) so a mute can always be undone."""
+    from services.discover.genre_balance import genre_family
+
+    levels = await genre_prefs.get_levels(user_id)
+    family_counts: dict[str, int] = {}
+    try:
+        top_genres = await genre_index.get_top_genres(limit=60)
+    except Exception:  # noqa: BLE001 - an unscanned library still gets its stored prefs
+        top_genres = []
+    for genre, count in top_genres:
+        family = genre_family(genre)
+        if family:
+            family_counts[family] = family_counts.get(family, 0) + int(count)
+    for family in levels:
+        family_counts.setdefault(family, 0)
+
+    ranked = sorted(family_counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    return [
+        GenrePrefItem(
+            family=family,
+            label=family.title(),
+            artist_count=count,
+            level=levels.get(family, "normal"),  # type: ignore[arg-type]
+        )
+        for family, count in ranked[:_GENRE_PREF_MAX_FAMILIES]
+    ]
+
+
+@router.get("/genre-prefs", response_model=GenrePrefsResponse)
+async def get_genre_prefs(
+    current_user: CurrentUserDep,
+    genre_prefs: UserGenrePrefsStore = Depends(get_user_genre_prefs_store),
+    genre_index=Depends(get_genre_index),
+) -> GenrePrefsResponse:
+    return GenrePrefsResponse(
+        genres=await _build_genre_pref_items(current_user.id, genre_prefs, genre_index)
+    )
+
+
+@router.put("/genre-prefs", response_model=GenrePrefsResponse)
+async def update_genre_prefs(
+    current_user: CurrentUserDep,
+    body: GenrePrefsUpdate = MsgSpecBody(GenrePrefsUpdate),
+    genre_prefs: UserGenrePrefsStore = Depends(get_user_genre_prefs_store),
+    genre_index=Depends(get_genre_index),
+) -> GenrePrefsResponse:
+    from services.discover.genre_balance import genre_family
+
+    levels: dict[str, str] = {}
+    for item in body.genres:
+        family = genre_family(item.family)
+        if not family:
+            raise HTTPException(status_code=422, detail=f"Unknown genre family: {item.family!r}")
+        if item.level in ("reduce", "mute"):
+            levels[family] = item.level
+    await genre_prefs.set_levels(current_user.id, levels)
+    await _invalidate_recommendation_caches(current_user.id)
+    return GenrePrefsResponse(
+        genres=await _build_genre_pref_items(current_user.id, genre_prefs, genre_index)
+    )
+
+
+async def _invalidate_recommendation_caches(user_id: str) -> None:
+    """Changed genre levels must reach the (heavily cached) recommendation
+    surfaces: drop the per-user taste graph + daily mix + top picks entries and
+    kick a background Discover rebuild. All best-effort - the pref save wins."""
+    from core.dependencies import get_discover_service
+    from infrastructure.cache.cache_keys import TASTE_GRAPH_PREFIX
+
+    try:
+        await get_cache().delete(f"{TASTE_GRAPH_PREFIX}{user_id}")
+        discover = get_discover_service()
+        await discover.invalidate_personalization_caches(user_id)
+        await discover.refresh_discover_data(user_id)
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Genre-pref cache invalidation failed: %s", e)

--- a/backend/api/v1/routes/taste_graph.py
+++ b/backend/api/v1/routes/taste_graph.py
@@ -1,0 +1,21 @@
+from fastapi import APIRouter, Depends
+
+from api.v1.schemas.taste_graph import TasteGraphResponse
+from core.dependencies import get_taste_graph_service
+from core.dependencies.type_aliases import CurrentUserDep
+from infrastructure.msgspec_fastapi import MsgSpecRoute
+from services.taste_graph_service import TasteGraphService
+
+router = APIRouter(route_class=MsgSpecRoute, prefix="/discover", tags=["discover"])
+
+
+@router.get("/taste-graph", response_model=TasteGraphResponse)
+async def get_taste_graph(
+    current_user: CurrentUserDep,
+    service: TasteGraphService = Depends(get_taste_graph_service),
+) -> TasteGraphResponse:
+    """Recommendations built ONLY from this user's own signals (library, follows,
+    play history) expanded through canonical MusicBrainz metadata — never charts,
+    global popularity, or other users' listens. An empty library returns a
+    graceful cold-start response."""
+    return await service.get_taste_graph(current_user.id)

--- a/backend/api/v1/schemas/genre_prefs.py
+++ b/backend/api/v1/schemas/genre_prefs.py
@@ -1,0 +1,25 @@
+from typing import Literal
+
+from infrastructure.msgspec_fastapi import AppStruct
+
+GenrePrefLevel = Literal["normal", "reduce", "mute"]
+
+
+class GenrePrefItem(AppStruct):
+    family: str
+    label: str
+    artist_count: int = 0
+    level: GenrePrefLevel = "normal"
+
+
+class GenrePrefsResponse(AppStruct):
+    genres: list[GenrePrefItem] = []
+
+
+class GenrePrefUpdateItem(AppStruct):
+    family: str
+    level: GenrePrefLevel
+
+
+class GenrePrefsUpdate(AppStruct):
+    genres: list[GenrePrefUpdateItem] = []

--- a/backend/api/v1/schemas/taste_graph.py
+++ b/backend/api/v1/schemas/taste_graph.py
@@ -1,0 +1,38 @@
+"""Taste Graph — recommendations derived ONLY from this user's own signals
+(library, follows, play history) expanded through canonical MusicBrainz
+metadata. No external charts, no global popularity, no other users' data."""
+
+from typing import Literal
+
+from infrastructure.msgspec_fastapi import AppStruct
+
+
+class TasteGraphReason(AppStruct):
+    type: Literal["collaborator", "member", "label", "scene"]
+    label: str
+    via_mbid: str | None = None
+    via_name: str | None = None
+
+
+class TasteGraphSeed(AppStruct):
+    artist_mbid: str
+    name: str
+    weight: float
+
+
+class TasteGraphItem(AppStruct):
+    kind: Literal["artist", "album"]
+    mbid: str
+    name: str
+    score: float
+    reasons: list[TasteGraphReason] = []
+    artist_mbid: str | None = None
+    artist_name: str | None = None
+    in_library: bool = False
+
+
+class TasteGraphResponse(AppStruct):
+    cold_start: bool = False
+    generated_at: str = ""
+    seeds: list[TasteGraphSeed] = []
+    items: list[TasteGraphItem] = []

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -124,6 +124,7 @@ from .service_providers import (  # noqa: F401
     get_scrobble_service,
     get_discover_service,
     get_discover_queue_manager,
+    get_taste_graph_service,
     get_discovery_batch_service,
     get_jellyfin_playback_service,
     get_local_files_service,

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -50,6 +50,7 @@ from .repo_providers import (  # noqa: F401
     get_user_connections_store,
     get_user_listening_prefs_store,
     get_user_section_prefs_store,
+    get_user_genre_prefs_store,
     get_preview_repository,
     get_discovery_batch_store,
     get_play_history_store,

--- a/backend/core/dependencies/repo_providers.py
+++ b/backend/core/dependencies/repo_providers.py
@@ -403,6 +403,17 @@ def get_user_section_prefs_store() -> "UserSectionPrefsStore":
 
 
 @singleton
+def get_user_genre_prefs_store() -> "UserGenrePrefsStore":
+    from infrastructure.persistence.user_genre_prefs_store import UserGenrePrefsStore
+    from .cache_providers import get_persistence_write_lock
+
+    settings = get_settings()
+    return UserGenrePrefsStore(
+        db_path=settings.library_db_path, write_lock=get_persistence_write_lock()
+    )
+
+
+@singleton
 def get_play_history_store() -> "PlayHistoryStore":
     from infrastructure.persistence.play_history_store import PlayHistoryStore
     from .cache_providers import get_persistence_write_lock

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -844,6 +844,20 @@ def get_scrobble_service() -> "ScrobbleService":
 
 
 @singleton
+def get_taste_graph_service() -> "TasteGraphService":
+    from services.taste_graph_service import TasteGraphService
+
+    return TasteGraphService(
+        library_db=get_library_db(),
+        follow_store=get_follow_store(),
+        play_history_store=get_play_history_store(),
+        mb_repo=get_musicbrainz_repository(),
+        cache=get_cache(),
+        genre_index=get_genre_index(),
+    )
+
+
+@singleton
 def get_discover_service() -> "DiscoverService":
     from services.discover_service import DiscoverService
     from services.discover.radio_service import DiscoverRadioService

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -44,6 +44,7 @@ from .repo_providers import (
     get_request_history_store,
     get_user_connections_store,
     get_user_listening_prefs_store,
+    get_user_genre_prefs_store,
     get_play_history_store,
     get_follow_store,
     get_github_repository,
@@ -854,6 +855,7 @@ def get_taste_graph_service() -> "TasteGraphService":
         mb_repo=get_musicbrainz_repository(),
         cache=get_cache(),
         genre_index=get_genre_index(),
+        genre_prefs_store=get_user_genre_prefs_store(),
     )
 
 
@@ -919,6 +921,7 @@ def get_discover_service() -> "DiscoverService":
         cover_repo=get_coverart_repository(),
         preview_repo=get_preview_repository(),
         disk_cache=get_disk_cache(),
+        genre_prefs_store=get_user_genre_prefs_store(),
     )
 
 

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -904,6 +904,7 @@ def get_discover_service() -> "DiscoverService":
         follow_service=get_follow_service(),
         cover_repo=get_coverart_repository(),
         preview_repo=get_preview_repository(),
+        disk_cache=get_disk_cache(),
     )
 
 

--- a/backend/core/tasks.py
+++ b/backend/core/tasks.py
@@ -495,7 +495,8 @@ def start_artist_discovery_cache_warming_task(
 # and banks them to mbid_store so the following normal-budget build finds them cached. One
 # loop, ONE user at a time (the single global MB 1/s queue makes concurrency pointless), and
 # it yields whenever a user is actively browsing.
-DISCOVER_WARMER_STARTUP_DELAY = 180       # let boot + first on-demand traffic settle
+DISCOVER_WARMER_STARTUP_DELAY = 10        # start warming right after boot: a restart-wiped
+                                          # cache must repopulate before users notice, not 3min later
 DISCOVER_WARMER_INTERVAL = 90             # floor between per-user warm ticks
 DISCOVER_WARMER_ENUM_TTL = 600            # re-enumerate eligible users at most this often
 DISCOVER_WARMER_REFRESH_INTERVAL = 6 * 3600   # re-warm a converged user this often

--- a/backend/infrastructure/cache/cache_keys.py
+++ b/backend/infrastructure/cache/cache_keys.py
@@ -15,6 +15,10 @@ MB_RECORDING_TO_RG_PREFIX = "mb:recording_to_rg:"
 MB_ARTIST_RELS_PREFIX = "mb:artist_rels:"
 MB_ARTISTS_BY_TAG_PREFIX = "mb_artists_by_tag:"
 MB_RG_BY_TAG_PREFIX = "mb_rg_by_tag:"
+MB_ARTIST_EXPANSION_PREFIX = "mb:artist_expansion:"
+MB_LABEL_RELEASES_PREFIX = "mb:label_releases:"
+
+TASTE_GRAPH_PREFIX = "taste_graph:"
 
 LB_PREFIX = "lb_"
 
@@ -96,6 +100,8 @@ def musicbrainz_prefixes() -> list[str]:
         MB_ARTIST_RELS_PREFIX,
         MB_ARTISTS_BY_TAG_PREFIX,
         MB_RG_BY_TAG_PREFIX,
+        MB_ARTIST_EXPANSION_PREFIX,
+        MB_LABEL_RELEASES_PREFIX,
     ]
 
 

--- a/backend/infrastructure/cache/disk_cache.py
+++ b/backend/infrastructure/cache/disk_cache.py
@@ -41,6 +41,9 @@ class DiskMetadataCache:
         self._recent_audiodb_albums_dir = self.base_path / "recent" / "audiodb_albums"
         self._persistent_audiodb_artists_dir = self.base_path / "persistent" / "audiodb_artists"
         self._persistent_audiodb_albums_dir = self.base_path / "persistent" / "audiodb_albums"
+        # per-user Discover pages: persistent so a restart reloads them instantly
+        self._recent_discover_dir = self.base_path / "recent" / "discover"
+        self._persistent_discover_dir = self.base_path / "persistent" / "discover"
         self._ensure_dirs()
 
     def _ensure_dirs(self) -> None:
@@ -54,6 +57,8 @@ class DiskMetadataCache:
             self._recent_audiodb_albums_dir,
             self._persistent_audiodb_artists_dir,
             self._persistent_audiodb_albums_dir,
+            self._recent_discover_dir,
+            self._persistent_discover_dir,
         ):
             path.mkdir(parents=True, exist_ok=True)
 
@@ -86,6 +91,11 @@ class DiskMetadataCache:
             return (
                 self._recent_audiodb_albums_dir / f"{cache_hash}.json",
                 self._persistent_audiodb_albums_dir / f"{cache_hash}.json",
+            )
+        if entity_type == "discover":
+            return (
+                self._recent_discover_dir / f"{cache_hash}.json",
+                self._persistent_discover_dir / f"{cache_hash}.json",
             )
         raise ValueError(f"Unsupported entity type: {entity_type}")
 
@@ -293,6 +303,20 @@ class DiskMetadataCache:
 
     async def get_audiodb_album(self, identifier: str) -> dict[str, Any] | None:
         return await self._get_entity("audiodb_album", identifier)
+
+    async def set_discover(
+        self,
+        identifier: str,
+        payload: Any,
+        ttl_seconds: int | None = None,
+    ) -> None:
+        """Persist a built per-user Discover page. Always stored on the persistent side
+        (it must survive restarts) but with an explicit TTL, matching the discover
+        cache's freshness semantics."""
+        await self._set_entity("discover", identifier, payload, is_monitored=True, ttl_seconds=ttl_seconds)
+
+    async def get_discover(self, identifier: str) -> dict[str, Any] | None:
+        return await self._get_entity("discover", identifier)
 
     async def delete_album(self, musicbrainz_id: str) -> None:
         recent_path, persistent_path = self._entity_paths("album", musicbrainz_id)

--- a/backend/infrastructure/persistence/user_genre_prefs_store.py
+++ b/backend/infrastructure/persistence/user_genre_prefs_store.py
@@ -1,0 +1,69 @@
+"""Per-user genre-balance preferences for recommendations.
+
+Default-normal semantics: only "reduce"/"mute" levels are stored, so every
+genre family is at full weight unless the user dials it down. Families are
+stored in normalised form (see ``services.discover.genre_balance.genre_family``)
+by the API layer; this store is a dumb (user, family) -> level table.
+"""
+
+import sqlite3
+from datetime import datetime, timezone
+
+from infrastructure.persistence._database import PersistenceBase
+
+_VALID_LEVELS = ("reduce", "mute")
+
+
+class UserGenrePrefsStore(PersistenceBase):
+    def _ensure_tables(self) -> None:
+        conn = self._connect()
+        try:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS user_genre_prefs (
+                  user_id      TEXT NOT NULL,
+                  genre_family TEXT NOT NULL,
+                  level        TEXT NOT NULL,
+                  updated_at   TEXT NOT NULL,
+                  PRIMARY KEY (user_id, genre_family)
+                )
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    async def get_levels(self, user_id: str) -> dict[str, str]:
+        """{genre_family: level} for this user's non-normal families."""
+
+        def operation(conn: sqlite3.Connection) -> dict[str, str]:
+            rows = conn.execute(
+                "SELECT genre_family, level FROM user_genre_prefs WHERE user_id = ?",
+                (user_id,),
+            ).fetchall()
+            return {
+                row["genre_family"]: row["level"]
+                for row in rows
+                if row["level"] in _VALID_LEVELS
+            }
+
+        return await self._read(operation)
+
+    async def set_levels(self, user_id: str, levels: dict[str, str]) -> None:
+        """Replace the user's non-normal levels in one transaction."""
+        now = datetime.now(timezone.utc).isoformat()
+        rows = [
+            (user_id, family, level, now)
+            for family, level in sorted(levels.items())
+            if family and level in _VALID_LEVELS
+        ]
+
+        def operation(conn: sqlite3.Connection) -> None:
+            conn.execute("DELETE FROM user_genre_prefs WHERE user_id = ?", (user_id,))
+            conn.executemany(
+                "INSERT INTO user_genre_prefs (user_id, genre_family, level, updated_at) "
+                "VALUES (?, ?, ?, ?)",
+                rows,
+            )
+
+        await self._write(operation)

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from api.v1.routes import (
 from api.v1.routes import (
     discovery_batches as discovery_batches_routes
 )
+from api.v1.routes import taste_graph as taste_graph_routes
 from api.v1.routes import library_scan as library_scan_routes
 from api.v1.routes import cache as cache_routes
 from api.v1.routes import cache_status as cache_status_routes
@@ -729,6 +730,9 @@ v1_router.include_router(wrapped.router)
 # literal /discover/batches paths registered before the discover router (which owns
 # the broader /discover prefix) so they can never be shadowed
 v1_router.include_router(discovery_batches_routes.router)
+# literal /discover/taste-graph path, registered alongside the other literal
+# /discover/* routers before the main discover router
+v1_router.include_router(taste_graph_routes.router)
 v1_router.include_router(discover.router)
 v1_router.include_router(youtube_routes.router)
 v1_router.include_router(cache_routes.router)

--- a/backend/repositories/musicbrainz_artist.py
+++ b/backend/repositories/musicbrainz_artist.py
@@ -12,6 +12,7 @@ from infrastructure.cache.memory_cache import CacheInterface
 from infrastructure.cache.cache_keys import (
     mb_artist_search_key, mb_artist_detail_key,
     MB_ARTISTS_BY_TAG_PREFIX, MB_ARTIST_RELS_PREFIX,
+    MB_ARTIST_EXPANSION_PREFIX, MB_LABEL_RELEASES_PREFIX,
 )
 from infrastructure.queue.priority_queue import RequestPriority
 from infrastructure.resilience.retry import CircuitOpenError
@@ -256,6 +257,60 @@ class MusicBrainzArtistMixin:
                 await self.get_release_group_by_id(rg_id, priority=RequestPriority.BACKGROUND_SYNC)
             except (CircuitOpenError, ExternalServiceError, httpx.HTTPError):
                 pass
+
+    async def get_artist_expansion(self, mbid: str) -> dict | None:
+        """Artist relationships (band members, collaborations, tributes), label
+        relations, and tags — the taste-graph expansion payload. One MB call per
+        artist per 24h (cached + deduplicated); BACKGROUND_SYNC priority so it can
+        never starve user-initiated lookups."""
+        cache_key = f"{MB_ARTIST_EXPANSION_PREFIX}{mbid}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        return await mb_deduplicator.dedupe(
+            cache_key, lambda: self._fetch_artist_expansion(mbid, cache_key)
+        )
+
+    async def _fetch_artist_expansion(self, mbid: str, cache_key: str) -> dict | None:
+        try:
+            result = await mb_api_get(
+                f"/artist/{mbid}",
+                params={"inc": "artist-rels+label-rels+tags"},
+                priority=RequestPriority.BACKGROUND_SYNC,
+            )
+            if not result:
+                return None
+            await self._cache.set(cache_key, result, ttl_seconds=86400)
+            return result
+        except Exception as e:  # noqa: BLE001 - one seed failing must not sink the graph
+            logger.error(f"Failed to fetch artist expansion {mbid}: {e}")
+            _record_mb_degradation(f"artist expansion failed: {e}")
+            return None
+
+    async def get_label_releases(self, label_mbid: str, limit: int = 25) -> list[dict[str, Any]]:
+        """Releases on a label (with release-groups + artist credits), for
+        label-mate discovery. Cached 24h; BACKGROUND_SYNC priority."""
+        cache_key = f"{MB_LABEL_RELEASES_PREFIX}{label_mbid}:{limit}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+        try:
+            result = await mb_api_get(
+                "/release",
+                params={
+                    "label": label_mbid,
+                    "inc": "release-groups+artist-credits",
+                    "limit": min(100, limit),
+                },
+                priority=RequestPriority.BACKGROUND_SYNC,
+            )
+            releases = result.get("releases", []) if isinstance(result, dict) else []
+            await self._cache.set(cache_key, releases, ttl_seconds=86400)
+            return releases
+        except Exception as e:  # noqa: BLE001 - one label failing must not sink the graph
+            logger.error(f"Failed to fetch label releases {label_mbid}: {e}")
+            _record_mb_degradation(f"label releases failed: {e}")
+            return []
 
     async def get_artist_release_groups(
         self,

--- a/backend/services/discover/facade.py
+++ b/backend/services/discover/facade.py
@@ -72,6 +72,8 @@ class DiscoverService:
         follow_service: Any = None,
         cover_repo: Any = None,
         preview_repo: Any = None,
+        disk_cache: Any = None,
+        genre_prefs_store: Any = None,
     ):
         self._integration = IntegrationHelpers(preferences_service)
         self._client_factory = client_factory
@@ -125,6 +127,8 @@ class DiscoverService:
             library_db=library_db,
             follow_service=follow_service,
             cover_repo=cover_repo,
+            disk_cache=disk_cache,
+            genre_prefs_store=genre_prefs_store,
         )
 
         self._radio = radio_service
@@ -147,6 +151,9 @@ class DiscoverService:
 
     async def refresh_discover_data(self, user_id: str) -> None:
         return await self._homepage.refresh_discover_data(user_id)
+
+    async def invalidate_personalization_caches(self, user_id: str) -> None:
+        return await self._homepage.invalidate_personalization_caches(user_id)
 
     async def warm_cache(self, user_id: str) -> None:
         return await self._homepage.warm_cache(user_id)

--- a/backend/services/discover/genre_balance.py
+++ b/backend/services/discover/genre_balance.py
@@ -1,0 +1,312 @@
+"""Genre-balance helpers shared by Discover and the Taste Graph.
+
+A library skewed toward one genre (say 40% K-pop) used to dominate every
+recommendation zone because seeds were picked by raw play/album counts.
+These pure helpers fix that in three ways:
+
+- ``genre_family``       - normalises genre spellings ("k-pop", "kpop",
+                           "korean pop") into one family so caps and prefs
+                           apply to the family, not each spelling.
+- ``balanced_seed_selection`` - picks seeds round-robin across genre
+                           families with sqrt-damped family weights instead
+                           of raw frequency order.
+- ``cap_genre_share``    - enforces a per-zone share cap (~35%) for any one
+                           family, and excludes muted families entirely.
+- ``diverse_genre_selection`` - reorders (genre, count) rows for genre-seeded
+                           builders (daily mixes) with the same damping.
+
+User control arrives as :class:`GenrePrefs` levels per family:
+"reduce" halves a family's weight/allowance, "mute" excludes it.
+Items whose genres are unknown are never penalised - they pass through.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Iterable, Sequence, TypeVar
+
+T = TypeVar("T")
+
+# Default per-zone share cap for a single genre family (~a third of a zone).
+GENRE_SHARE_CAP = 0.35
+
+GENRE_PREF_LEVELS = ("normal", "reduce", "mute")
+
+# Alias map applied AFTER _canon() (lowercase, separators collapsed to single
+# spaces), so one entry covers "k-pop"/"K Pop"/"k_pop". Keep it small and
+# focused: the token rules below catch the systematic "k-"/"j-" prefixes.
+_FAMILY_ALIASES: dict[str, str] = {
+    "kpop": "k-pop",
+    "k pop": "k-pop",
+    "korean pop": "k-pop",
+    "korean idol": "k-pop",
+    "jpop": "j-pop",
+    "j pop": "j-pop",
+    "japanese pop": "j-pop",
+    "hiphop": "hip hop",
+    "hip hop": "hip hop",
+    "rap": "hip hop",
+    "rnb": "r&b",
+    "r&b": "r&b",
+    "r and b": "r&b",
+    "contemporary r&b": "r&b",
+    "electronica": "electronic",
+    "edm": "electronic",
+}
+
+
+def _canon(genre: str) -> str:
+    lowered = genre.strip().lower()
+    for sep in ("-", "_", "/"):
+        lowered = lowered.replace(sep, " ")
+    return " ".join(lowered.split())
+
+
+def genre_family(genre: str | None) -> str:
+    """Canonical family name for a genre string; "" when unknown/blank."""
+    if not isinstance(genre, str) or not genre.strip():
+        return ""
+    canon = _canon(genre)
+    alias = _FAMILY_ALIASES.get(canon)
+    if alias:
+        return alias
+    tokens = canon.split()
+    # "korean ballad", "k rock" style spellings group under the Korean family;
+    # same for Japanese. This is deliberately broad: the point of the family is
+    # the balance cap, not taxonomy.
+    if "korean" in tokens or tokens[0] == "kpop":
+        return "k-pop"
+    if "japanese" in tokens or tokens[0] == "jpop":
+        return "j-pop"
+    if len(tokens) > 1 and tokens[0] == "k":
+        return "k-pop"
+    if len(tokens) > 1 and tokens[0] == "j":
+        return "j-pop"
+    return canon
+
+
+class GenrePrefs:
+    """Per-user genre-family preference levels ("reduce" / "mute").
+
+    Families not present are "normal". Keys are normalised through
+    :func:`genre_family` so any spelling stored still matches.
+    """
+
+    __slots__ = ("_levels",)
+
+    def __init__(self, levels: dict[str, str] | None = None) -> None:
+        self._levels: dict[str, str] = {}
+        for raw_family, level in (levels or {}).items():
+            family = genre_family(raw_family)
+            if family and level in ("reduce", "mute"):
+                self._levels[family] = level
+
+    def is_empty(self) -> bool:
+        return not self._levels
+
+    def level(self, family: str) -> str:
+        return self._levels.get(family, "normal")
+
+    def is_muted(self, family: str) -> bool:
+        return self._levels.get(family) == "mute"
+
+    def multiplier(self, family: str) -> float:
+        level = self._levels.get(family)
+        if level == "mute":
+            return 0.0
+        if level == "reduce":
+            return 0.5
+        return 1.0
+
+    def levels(self) -> dict[str, str]:
+        return dict(self._levels)
+
+
+EMPTY_GENRE_PREFS = GenrePrefs()
+
+
+def primary_family(genres: Iterable[str] | None) -> str:
+    """First known family among an item's genres; "" for unknown."""
+    for g in genres or []:
+        family = genre_family(g)
+        if family:
+            return family
+    return ""
+
+
+def balanced_seed_selection(
+    candidates: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+) -> list[T]:
+    """Pick up to ``limit`` seeds spread across genre families.
+
+    ``candidates`` arrive in preference order (most-played first). Candidates
+    are grouped by primary family; families are ordered by sqrt-damped size
+    times the user's pref multiplier (so a 40%-of-library family no longer
+    swamps the seed set, and "reduce" halves its priority); seeds are then
+    taken round-robin across families. Muted families are excluded. Unknown-
+    genre candidates share one "" bucket, so with no genre data at all this
+    degrades to the original take-the-first-``limit`` behaviour.
+    """
+    if limit <= 0 or not candidates:
+        return []
+
+    buckets: dict[str, list[T]] = {}
+    order: dict[str, int] = {}
+    for index, candidate in enumerate(candidates):
+        family = primary_family(genres_of(candidate))
+        if family and prefs.is_muted(family):
+            continue
+        buckets.setdefault(family, []).append(candidate)
+        order.setdefault(family, index)
+
+    if not buckets:
+        return []
+
+    def family_weight(item: tuple[str, list[T]]) -> tuple[float, int]:
+        family, members = item
+        multiplier = prefs.multiplier(family) if family else 1.0
+        return (-(multiplier * math.sqrt(len(members))), order[family])
+
+    ordered_families = [members for _, members in sorted(buckets.items(), key=family_weight)]
+
+    selected: list[T] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for members in ordered_families:
+            if round_index < len(members):
+                selected.append(members[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def cap_genre_share(
+    items: Sequence[T],
+    genres_of: Callable[[T], Iterable[str] | None],
+    *,
+    cap_ratio: float = GENRE_SHARE_CAP,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    target_size: int | None = None,
+    counts: dict[str, int] | None = None,
+    total_allowed: int | None = None,
+) -> list[T]:
+    """Order-preserving filter enforcing mute + a per-family share cap.
+
+    Any single family keeps at most ``max(1, ceil(cap_ratio * size))`` items
+    where ``size`` is ``target_size`` (or the input length); a reduced family
+    keeps half that. Unknown-genre items always pass. Items skipped for being
+    over-cap simply yield their slot to the next (other-genre) items in the
+    list - the backfill.
+
+    ``counts``/``total_allowed`` allow a caller to thread page-wide family
+    counters through multiple zones so the cap also holds across the whole
+    assembled page, not just inside one zone.
+    """
+    size = target_size if target_size is not None else len(items)
+    if size <= 0:
+        return list(items)
+    base_allowance = max(1, math.ceil(cap_ratio * size))
+
+    local_counts: dict[str, int] = {}
+    kept: list[T] = []
+    for item in items:
+        family = primary_family(genres_of(item))
+        if not family:
+            kept.append(item)
+            continue
+        if prefs.is_muted(family):
+            continue
+        allowance = base_allowance
+        if prefs.level(family) == "reduce":
+            allowance = max(1, base_allowance // 2)
+        if local_counts.get(family, 0) >= allowance:
+            continue
+        if counts is not None and total_allowed is not None:
+            if counts.get(family, 0) >= total_allowed:
+                continue
+            counts[family] = counts.get(family, 0) + 1
+        local_counts[family] = local_counts.get(family, 0) + 1
+        kept.append(item)
+    return kept
+
+
+def diverse_genre_selection(
+    top_genres: Sequence[tuple[str, int]],
+    *,
+    limit: int,
+    prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    max_per_family: int = 2,
+) -> list[tuple[str, int]]:
+    """Rebalance (genre, count) rows for genre-seeded builders.
+
+    Counts are sqrt-damped and scaled by the user's pref multiplier, muted
+    families drop out, and at most ``max_per_family`` genres of one family
+    survive - so five K-pop spellings can't claim five daily-mix clusters.
+    Families are interleaved (best genre of each family first) so the result
+    leads with breadth.
+    """
+    if limit <= 0:
+        return []
+
+    weighted: list[tuple[float, int, str, int]] = []
+    for index, (genre, count) in enumerate(top_genres):
+        family = genre_family(genre)
+        multiplier = prefs.multiplier(family) if family else 1.0
+        if multiplier <= 0.0:
+            continue
+        weighted.append((multiplier * math.sqrt(max(count, 0) + 1), index, genre, count))
+    weighted.sort(key=lambda row: (-row[0], row[1]))
+
+    per_family: dict[str, list[tuple[str, int]]] = {}
+    family_order: list[str] = []
+    for _, _, genre, count in weighted:
+        family = genre_family(genre) or genre
+        rows = per_family.setdefault(family, [])
+        if family not in family_order:
+            family_order.append(family)
+        if len(rows) < max_per_family:
+            rows.append((genre, count))
+
+    selected: list[tuple[str, int]] = []
+    round_index = 0
+    while len(selected) < limit:
+        took_any = False
+        for family in family_order:
+            rows = per_family[family]
+            if round_index < len(rows):
+                selected.append(rows[round_index])
+                took_any = True
+                if len(selected) >= limit:
+                    break
+        if not took_any:
+            break
+        round_index += 1
+    return selected
+
+
+def genres_lookup(
+    genres_by_artist: dict[str, list[str]] | None,
+) -> Callable[[Any], list[str]]:
+    """genres_of adapter for HomeArtist/HomeAlbum/TopPickItem-shaped items,
+    resolving through a {artist_mbid_lower: [genres]} map."""
+    mapping = genres_by_artist or {}
+
+    def lookup(item: Any) -> list[str]:
+        mbid = getattr(item, "artist_mbid", None) or getattr(item, "mbid", None)
+        if not mbid:
+            album = getattr(item, "album", None)
+            if album is not None:
+                mbid = getattr(album, "artist_mbid", None)
+        if not mbid:
+            return []
+        return mapping.get(str(mbid).lower(), [])
+
+    return lookup

--- a/backend/services/discover/homepage_service.py
+++ b/backend/services/discover/homepage_service.py
@@ -1,11 +1,12 @@
 import asyncio
 import hashlib
 import logging
+import math
 import random
 from types import SimpleNamespace
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Iterable
 
 from api.v1.schemas.discover import (
     DiscoverResponse,
@@ -38,8 +39,20 @@ from services.home_transformers import HomeDataTransformers
 from services.home.integration_helpers import resolve_source_value
 from services.per_user_client_factory import PerUserClientFactory
 from infrastructure.persistence.user_listening_prefs_store import UserListeningPrefsStore
+from services.discover.genre_balance import (
+    EMPTY_GENRE_PREFS,
+    GENRE_SHARE_CAP,
+    GenrePrefs,
+    balanced_seed_selection,
+    cap_genre_share,
+    diverse_genre_selection,
+    genre_family,
+    genres_lookup,
+    primary_family,
+)
 from services.discover.integration_helpers import IntegrationHelpers
 from services.discover.mbid_resolution_service import MbidResolutionService, discover_build_thorough
+from services.discover.response_codec import decode_discover_response, encode_discover_response
 from services.discover.queue_strategies import build_similar_artist_pools, build_similar_artist_pools_lastfm, discover_by_genres, queue_item_to_home_album, round_robin_dedup_select
 from repositories.listenbrainz_repository import lb_popularity_degraded
 from services.discover.top_picks import TopPickCandidate, score_candidates
@@ -174,6 +187,18 @@ DISCOVER_PICKS_CACHE_TTL = 14400  # 4 hours
 DISCOVER_PICKS_DEGRADED_TTL = 300  # 5 minutes
 UNEXPLORED_GENRES_THRESHOLD = 2
 UNEXPLORED_GENRES_MAX = 8
+# Genre-balance seeding: how many seeds the zones use, and how many candidates we
+# collect before balancing across genre FAMILIES (so a 40% K-pop library doesn't
+# yield 90% K-pop seeds). Pool only widens when a genre index exists to balance with.
+SEED_ARTIST_COUNT = 3
+SEED_CANDIDATE_POOL = 10
+# At most this many daily-mix clusters may come from one genre family
+# ("k-pop" + "korean pop" + "kpop" count as ONE family).
+DAILY_MIX_MAX_CLUSTERS_PER_FAMILY = 2
+# Budget for the cold-path first paint: only library-derived zones (no external charts /
+# similarity) run under it, so a cold cache still returns SOMETHING within ~2s while the
+# full build streams in via the cache in the background.
+QUICK_ZONE_BUDGET_SECONDS = 1.5
 
 
 class DiscoverHomepageService:
@@ -195,6 +220,8 @@ class DiscoverHomepageService:
         library_db: Any = None,
         follow_service: Any = None,
         cover_repo: Any = None,
+        disk_cache: Any = None,
+        genre_prefs_store: Any = None,
     ) -> None:
         self._lb_repo = listenbrainz_repo
         self._jf_repo = jellyfin_repo
@@ -212,6 +239,11 @@ class DiscoverHomepageService:
         self._library_db = library_db
         self._follow_service = follow_service
         self._cover_repo = cover_repo
+        # per-user genre reduce/mute levels for the balance pass (None = defaults)
+        self._genre_prefs_store = genre_prefs_store
+        # persistent (disk) discover cache: survives restarts, reloaded lazily per key
+        self._disk_cache = disk_cache
+        self._disk_checked: set[str] = set()
         self._transformers = HomeDataTransformers(jellyfin_repo)
         self._weekly_exploration = WeeklyExplorationService(listenbrainz_repo, musicbrainz_repo)
         # per-user in-flight warm guard so one user never blocks another
@@ -275,6 +307,10 @@ class DiscoverHomepageService:
                 user_id, lb_enabled, lfm_enabled
             )
             cached = await self._memory_cache.get(cache_key)
+            if not isinstance(cached, DiscoverResponse):
+                # restart-wiped memory: reload yesterday's discover from the persistent
+                # cache instantly; the SWR check below still refreshes it in background
+                cached = await self._load_persisted_response(cache_key)
             if cached is not None and isinstance(cached, DiscoverResponse):
                 # stale-while-revalidate: serve the cached copy immediately, but rebuild
                 # in the background once it's older than the freshness window so the data
@@ -286,7 +322,7 @@ class DiscoverHomepageService:
                 return clone_with_updates(cached, {"refreshing": building})
         # cache miss (first build, restart-wiped cache, or a user whose build is
         # legitimately empty). Back off if a build was attempted within the freshness
-        # window so an empty/failed build doesn't rebuild on every 3s poll and hammer
+        # window so an empty/failed build doesn't rebuild on every poll and hammer
         # upstream APIs; if backed off we report refreshing=false so the UI settles on
         # the empty state instead of polling forever.
         cache_key = self._integration.get_discover_cache_key(
@@ -298,11 +334,90 @@ class DiscoverHomepageService:
         if not building and not attempted_recently:
             self._trigger_warm(user_id)
             building = True
-        return DiscoverResponse(
+        # FAST FIRST PAINT: never block the request on the full cold build. Return the
+        # cheap library-derived zones right away (empty zones are hidden client-side);
+        # the remaining zones land in the cache as the background build completes and
+        # stream in via the frontend's refreshing poll.
+        return await self._build_quick_response(user_id, lb_enabled, lfm_enabled, refreshing=building)
+
+    async def _build_quick_response(
+        self, user_id: str, lb_enabled: bool, lfm_enabled: bool, refreshing: bool,
+    ) -> DiscoverResponse:
+        """Library/local-only zones (anniversaries, new-from-followed, rediscover, genre
+        browse) under a hard ~QUICK_ZONE_BUDGET_SECONDS per zone: no external charts or
+        similarity calls, so a cold cache still paints in well under 2s."""
+        response = DiscoverResponse(
             integration_status=self._integration.get_integration_status(),
             service_prompts=self._build_service_prompts(lb_enabled, lfm_enabled),
-            refreshing=building,
+            refreshing=refreshing,
         )
+        try:
+            jf_enabled = self._integration.is_jellyfin_enabled()
+            library_configured = self._integration.is_library_configured()
+            tasks: dict[str, Any] = {
+                "anniversaries": self._build_anniversaries(),
+                "new_from_followed": self._build_new_from_followed(user_id),
+                "library_mbids": self._mbid.get_library_artist_mbids(library_configured),
+            }
+            if jf_enabled:
+                tasks["jf_most_played"] = self._jf_repo.get_most_played_artists(limit=50)
+            if library_configured:
+                tasks["library_albums"] = self._library_repo.get_library(include_unmonitored=True)
+            keys = list(tasks.keys())
+            raw = await asyncio.gather(
+                *(asyncio.wait_for(c, timeout=QUICK_ZONE_BUDGET_SECONDS) for c in tasks.values()),
+                return_exceptions=True,
+            )
+            results = {k: (None if isinstance(v, BaseException) else v) for k, v in zip(keys, raw)}
+            response.anniversaries = results.get("anniversaries")
+            response.new_from_followed = results.get("new_from_followed")
+            library_mbids = results.get("library_mbids") or set()
+            response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
+            response.genre_list = self._build_genre_list(results, lb_enabled)
+        except Exception as e:  # noqa: BLE001 - the quick paint must never fail the request
+            logger.debug("Quick discover response degraded: %s", e)
+        return response
+
+    async def _persist_response(self, cache_key: str, response: DiscoverResponse) -> None:
+        """Bank the built discover in the persistent metadata cache so a restart reloads
+        yesterday's page instantly instead of showing the build screen."""
+        if self._disk_cache is None:
+            return
+        try:
+            payload = {
+                "built_at": time.time(),
+                "response": encode_discover_response(response),
+            }
+            await self._disk_cache.set_discover(cache_key, payload, ttl_seconds=DISCOVER_CACHE_TTL)
+        except Exception as e:  # noqa: BLE001 - persistence is best-effort
+            logger.warning("Failed to persist discover cache: %s", e)
+
+    async def _load_persisted_response(self, cache_key: str) -> DiscoverResponse | None:
+        """One-shot per key: rehydrate the memory cache (and the SWR clock) from disk
+        after a restart. Returns None when there is nothing usable persisted."""
+        if self._disk_cache is None or cache_key in self._disk_checked:
+            return None
+        self._disk_checked.add(cache_key)
+        try:
+            payload = await self._disk_cache.get_discover(cache_key)
+        except Exception as e:  # noqa: BLE001
+            logger.debug("Persisted discover load failed: %s", e)
+            return None
+        if not isinstance(payload, dict):
+            return None
+        response = decode_discover_response(payload.get("response"))
+        if response is None or not self._has_meaningful_content(response):
+            return None
+        built_at = float(payload.get("built_at") or 0.0)
+        remaining = DISCOVER_CACHE_TTL - (time.time() - built_at)
+        if remaining <= 0:
+            return None
+        if self._memory_cache:
+            await self._memory_cache.set(cache_key, response, max(int(remaining), 60))
+        # restore the build time so stale-while-revalidate refreshes it in background
+        self._built_at[cache_key] = built_at
+        logger.info("Discover cache reloaded from disk for key %s", cache_key[:24])
+        return response
 
     async def get_discover_preview(self, user_id: str) -> DiscoverPreview | None:
         if not self._memory_cache:
@@ -379,6 +494,16 @@ class DiscoverHomepageService:
         finally:
             discover_build_thorough.reset(token)
 
+    async def invalidate_personalization_caches(self, user_id: str) -> None:
+        """Drop the per-user sub-caches that bake in genre preferences (daily
+        mixes, top picks) so the next rebuild honors updated prefs immediately
+        instead of after their own TTLs."""
+        if not self._memory_cache:
+            return
+        for source in ("listenbrainz", "lastfm"):
+            await self._memory_cache.delete(self._daily_mix_cache_key(user_id, source))
+            await self._memory_cache.delete(self._top_picks_cache_key(user_id, source))
+
     async def refresh_discover_data(self, user_id: str) -> None:
         _, _, _, _, lb_enabled, lfm_enabled, _ = await self._resolve_user_music(user_id, None)
         if user_id in self._building_keys:
@@ -404,6 +529,7 @@ class DiscoverHomepageService:
             response = await self.build_discover_data(user_id)
             if self._memory_cache and self._has_meaningful_content(response):
                 await self._memory_cache.set(cache_key, response, DISCOVER_CACHE_TTL)
+                await self._persist_response(cache_key, response)
                 self._spawn_cover_prewarm(user_id, response)
             else:
                 logger.warning("Discover build produced no meaningful content, keeping existing cache")
@@ -511,12 +637,14 @@ class DiscoverHomepageService:
         # download buttons) and neutered the don't-suggest-what-you-own exclusions
         library_album_mbids = await self._mbid.get_library_album_mbids(library_configured)
 
+        genre_prefs = await self._load_genre_prefs(user_id)
         seed_artists = await self._get_seed_artists(
             lb_enabled, username, jf_enabled,
             resolved_source=primary,
             lfm_enabled=lfm_enabled,
             lfm_username=lfm_username,
             lb_client=lb_client,
+            genre_prefs=genre_prefs,
         )
 
         tasks: dict[str, Any] = {}
@@ -584,6 +712,9 @@ class DiscoverHomepageService:
 
         seen_artist_mbids: set[str] = set()
 
+        # Synchronous zones first: pure transforms over the phase-1 results. They run
+        # sequentially so the artist dedup between sections (seen_artist_mbids) stays
+        # deterministic; none of them awaits an external service.
         response.because_you_listen_to = self._build_because_sections(
             seed_artists, results, library_mbids, seen_artist_mbids,
             resolved_source=primary,
@@ -591,7 +722,38 @@ class DiscoverHomepageService:
         await self._enrich_because_sections_audiodb(response.because_you_listen_to)
 
         response.fresh_releases = self._build_fresh_releases(results, library_album_mbids)
+        response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
+        response.artists_you_might_like = self._build_artists_you_might_like(
+            seed_artists, results, library_mbids, seen_artist_mbids,
+            resolved_source=primary,
+        )
+        response.genre_list = self._build_genre_list(results, lb_enabled)
 
+        if primary == "lastfm":
+            response.globally_trending = self._build_lastfm_globally_trending(
+                results, library_mbids, seen_artist_mbids
+            )
+        else:
+            response.globally_trending = self._build_globally_trending(
+                results, library_mbids, seen_artist_mbids
+            )
+
+        response.lastfm_weekly_artist_chart = self._build_lastfm_weekly_artist_chart(
+            results, library_mbids, seen_artist_mbids
+        )
+
+        similar_artist_mbids: list[str] = []
+        for i in range(3):
+            similar = results.get(f"similar_{i}") or []
+            for artist in similar:
+                mbid = getattr(artist, 'artist_mbid', None) or getattr(artist, 'mbid', None)
+                if mbid:
+                    similar_artist_mbids.append(mbid)
+
+        # Every remaining zone is independent - run them ALL concurrently, each under its
+        # own per-zone timeout (_execute_tasks), so one slow upstream (a starved
+        # MusicBrainz resolution, a hanging chart call) can't delay unrelated zones.
+        # Upstream fan-out stays bounded by the repos' own rate limiters/queues.
         post_tasks: dict[str, Any] = {
             "missing_essentials": self._build_missing_essentials(results, library_album_mbids),
             "lastfm_weekly_album_chart": self._build_lastfm_weekly_album_chart(
@@ -609,13 +771,22 @@ class DiscoverHomepageService:
             ),
             "anniversaries": self._build_anniversaries(),
             "new_from_followed": self._build_new_from_followed(user_id),
+            "popular_in_your_genres": self._build_popular_in_genres(
+                results, library_mbids, seen_artist_mbids,
+                resolved_source=primary,
+                genre_prefs=genre_prefs,
+            ),
+            "unexplored_genres": self._build_unexplored_genres(
+                response.because_you_listen_to, similar_artist_mbids
+            ),
         }
+        if response.genre_list and response.genre_list.items:
+            post_tasks["genre_artists"] = self._build_genre_artists(response.genre_list)
         if lb_client and username:
             post_tasks["listeners_like_you"] = self._build_listeners_like_you(
                 lb_client, username, user_id,
             )
-        # LB-specific: runs whenever the user's ListenBrainz is linked
-        if lb_client and username:
+            # LB-specific: runs whenever the user's ListenBrainz is linked
             post_tasks["weekly_exploration"] = self._weekly_exploration.build_section(
                 username, lb_repo=lb_client
             )
@@ -628,78 +799,140 @@ class DiscoverHomepageService:
         response.listeners_like_you = post_results.get("listeners_like_you")
         response.anniversaries = post_results.get("anniversaries")
         response.new_from_followed = post_results.get("new_from_followed")
-
-        response.rediscover = self._build_rediscover(results, library_mbids, jf_enabled)
-
-        response.artists_you_might_like = self._build_artists_you_might_like(
-            seed_artists, results, library_mbids, seen_artist_mbids,
-            resolved_source=primary,
-        )
-
-        response.popular_in_your_genres = await self._build_popular_in_genres(
-            results, library_mbids, seen_artist_mbids,
-            resolved_source=primary,
-        )
-
-        response.genre_list = self._build_genre_list(results, lb_enabled)
-
-        similar_artist_mbids: list[str] = []
-        for i in range(3):
-            similar = results.get(f"similar_{i}") or []
-            for artist in similar:
-                mbid = getattr(artist, 'artist_mbid', None) or getattr(artist, 'mbid', None)
-                if mbid:
-                    similar_artist_mbids.append(mbid)
-
-        response.unexplored_genres = await self._build_unexplored_genres(
-            response.because_you_listen_to, similar_artist_mbids
-        )
-
-        if response.genre_list and response.genre_list.items:
-            genre_names = [
-                g.name for g in response.genre_list.items[:20]
-                if isinstance(g, HomeGenre)
-            ]
-            if genre_names:
-                raw_mbids = await asyncio.gather(
-                    *(self._get_genre_artist(g) for g in genre_names)
-                )
-                used_mbids: set[str] = set()
-                genre_artists: dict[str, str | None] = {}
-                for g, mbid in zip(genre_names, raw_mbids):
-                    if mbid and mbid not in used_mbids:
-                        genre_artists[g] = mbid
-                        used_mbids.add(mbid)
-                    elif mbid and mbid in used_mbids:
-                        alt = await self._get_genre_artist(g, exclude_mbids=used_mbids)
-                        genre_artists[g] = alt
-                        if alt:
-                            used_mbids.add(alt)
-                    else:
-                        genre_artists[g] = None
-                response.genre_artists = genre_artists
-                response.genre_artist_images = await self._resolve_genre_artist_images(
-                    response.genre_artists
-                )
-
-        if primary == "lastfm":
-            response.globally_trending = self._build_lastfm_globally_trending(
-                results, library_mbids, seen_artist_mbids
-            )
-        else:
-            response.globally_trending = self._build_globally_trending(
-                results, library_mbids, seen_artist_mbids
-            )
-
-        response.lastfm_weekly_artist_chart = self._build_lastfm_weekly_artist_chart(
-            results, library_mbids, seen_artist_mbids
-        )
+        response.popular_in_your_genres = post_results.get("popular_in_your_genres")
+        response.unexplored_genres = post_results.get("unexplored_genres")
+        genre_artist_result = post_results.get("genre_artists")
+        if genre_artist_result:
+            response.genre_artists, response.genre_artist_images = genre_artist_result
         response.lastfm_weekly_album_chart = post_results.get("lastfm_weekly_album_chart")
         response.lastfm_recent_scrobbles = post_results.get("lastfm_recent_scrobbles")
 
         response.service_prompts = self._build_service_prompts(lb_enabled, lfm_enabled)
 
+        # Genre-balance pass over the assembled zones: per-zone AND page-wide family
+        # share caps plus the user's reduce/mute levels. Runs after the zone builders
+        # (a pure post-filter) so the parallel orchestration above stays untouched.
+        try:
+            await self._apply_genre_balance(response, genre_prefs)
+        except Exception as e:  # noqa: BLE001 - balancing must never fail the build
+            logger.warning("Genre balance pass failed: %s", e)
+
         return response
+
+    async def _apply_genre_balance(
+        self, response: DiscoverResponse, prefs: GenrePrefs,
+    ) -> None:
+        """Cap any single genre family's share (~GENRE_SHARE_CAP) inside each
+        recommendation zone and across the whole assembled page, and honor the
+        user's reduce/mute levels.
+
+        Classification comes from the library genre index; items whose artist has
+        no known genres always pass through, so external-chart zones are trimmed
+        conservatively rather than emptied. Daily mixes and radio stations are
+        single-genre BY DESIGN - they're balanced at cluster/seed level instead
+        and skipped here."""
+        if self._genre_index is None:
+            return
+
+        other_sections: list[HomeSection] = [
+            section
+            for section in (
+                response.artists_you_might_like,
+                response.popular_in_your_genres,
+                response.globally_trending,
+                response.listeners_like_you,
+                response.fresh_releases,
+                response.missing_essentials,
+            )
+            if section is not None
+        ]
+
+        mbids: set[str] = {
+            b.seed_artist_mbid.lower()
+            for b in response.because_you_listen_to
+            if b.seed_artist_mbid
+        }
+        for section in [b.section for b in response.because_you_listen_to] + other_sections:
+            for item in section.items:
+                mbid = getattr(item, "artist_mbid", None) or getattr(item, "mbid", None)
+                if mbid:
+                    mbids.add(str(mbid).lower())
+        if response.top_picks:
+            for pick in response.top_picks.items:
+                if pick.album.artist_mbid:
+                    mbids.add(pick.album.artist_mbid.lower())
+
+        genres = await self._genres_for_artists(mbids)
+        if not genres:
+            return
+        lookup = genres_lookup(genres)
+
+        # a muted seed family takes its whole "Because You Listen To" rail with it
+        if not prefs.is_empty():
+            response.because_you_listen_to = [
+                b for b in response.because_you_listen_to
+                if not (
+                    b.seed_artist_mbid
+                    and prefs.is_muted(
+                        primary_family(genres.get(b.seed_artist_mbid.lower(), []))
+                    )
+                )
+            ]
+        sections = [b.section for b in response.because_you_listen_to] + other_sections
+
+        # page-wide budget: one family may claim at most the cap share of ALL
+        # capped-zone items combined, on top of each zone's own cap
+        total_items = sum(len(s.items) for s in sections)
+        if response.top_picks:
+            total_items += len(response.top_picks.items)
+        page_counts: dict[str, int] = {}
+        page_allowance = max(1, math.ceil(GENRE_SHARE_CAP * total_items))
+
+        # the hero zone first, so the page budget favors Top Picks
+        if response.top_picks:
+            response.top_picks.items = cap_genre_share(
+                response.top_picks.items, lookup, prefs=prefs,
+                counts=page_counts, total_allowed=page_allowance,
+            )
+        for section in sections:
+            section.items = cap_genre_share(
+                section.items, lookup, prefs=prefs,
+                counts=page_counts, total_allowed=page_allowance,
+            )
+        response.because_you_listen_to = [
+            b for b in response.because_you_listen_to if b.section.items
+        ]
+
+    async def _build_genre_artists(
+        self, genre_list: HomeSection
+    ) -> tuple[dict[str, str | None], dict[str, str | None]] | None:
+        """A representative artist (and image) per browsable genre tile. Split out so it
+        runs as its own zone: its MusicBrainz tag searches (1 req/s) previously ran after
+        everything else and serially stretched the build by tens of seconds."""
+        genre_names = [
+            g.name for g in genre_list.items[:20]
+            if isinstance(g, HomeGenre)
+        ]
+        if not genre_names:
+            return None
+        raw_mbids = await asyncio.gather(
+            *(self._get_genre_artist(g) for g in genre_names)
+        )
+        used_mbids: set[str] = set()
+        genre_artists: dict[str, str | None] = {}
+        for g, mbid in zip(genre_names, raw_mbids):
+            if mbid and mbid not in used_mbids:
+                genre_artists[g] = mbid
+                used_mbids.add(mbid)
+            elif mbid and mbid in used_mbids:
+                alt = await self._get_genre_artist(g, exclude_mbids=used_mbids)
+                genre_artists[g] = alt
+                if alt:
+                    used_mbids.add(alt)
+            else:
+                genre_artists[g] = None
+        images = await self._resolve_genre_artist_images(genre_artists)
+        return genre_artists, images
 
     async def build_playlist_suggestions(
         self,
@@ -805,9 +1038,15 @@ class DiscoverHomepageService:
         lfm_enabled: bool = False,
         lfm_username: str | None = None,
         lb_client: Any = None,
+        genre_prefs: GenrePrefs | None = None,
     ) -> list[ListenBrainzArtist]:
         seeds: list[ListenBrainzArtist] = []
         seen_mbids: set[str] = set()
+        # Collect a wider candidate pool than we need, then balance the final pick
+        # across genre FAMILIES (breadth-based seeding) instead of taking the raw
+        # most-played top - which a genre-skewed library dominates. Without a genre
+        # index there is nothing to balance with, so keep the original tight target.
+        pool_target = SEED_CANDIDATE_POOL if self._genre_index is not None else SEED_ARTIST_COUNT
 
         if resolved_source == "lastfm" and lfm_enabled and lfm_username and self._lfm_repo:
             try:
@@ -815,7 +1054,7 @@ class DiscoverHomepageService:
                     lfm_username, period="3month", limit=10
                 )
                 for a in lfm_artists:
-                    if len(seeds) >= 3:
+                    if len(seeds) >= pool_target:
                         break
                     mbid = a.mbid
                     if mbid and mbid not in seen_mbids:
@@ -832,15 +1071,15 @@ class DiscoverHomepageService:
 
         # LB top-artists rely on the client's own identity, so use the per-user client
         seed_lb_repo = lb_client or self._lb_repo
-        if resolved_source != "lastfm" and len(seeds) < 3 and lb_enabled and username:
+        if resolved_source != "lastfm" and len(seeds) < pool_target and lb_enabled and username:
             # fall back to broader windows so a quiet week/month still yields seeds
             for range_ in ("this_week", "this_month", "this_year", "all_time"):
-                if len(seeds) >= 3:
+                if len(seeds) >= pool_target:
                     break
                 try:
                     artists = await seed_lb_repo.get_user_top_artists(count=10, range_=range_)
                     for a in artists:
-                        if len(seeds) >= 3:
+                        if len(seeds) >= pool_target:
                             break
                         mbid = a.artist_mbids[0] if a.artist_mbids else None
                         if mbid and mbid not in seen_mbids:
@@ -849,17 +1088,17 @@ class DiscoverHomepageService:
                 except Exception as e:  # noqa: BLE001
                     logger.warning(f"Failed to get LB top artists ({range_}): {e}")
 
-        if resolved_source != "lastfm" and len(seeds) < 3 and jf_enabled:
+        if resolved_source != "lastfm" and len(seeds) < pool_target and jf_enabled:
             for fetch_fn in (
                 lambda: self._jf_repo.get_most_played_artists(limit=10),
                 lambda: self._jf_repo.get_favorite_artists(limit=10),
             ):
-                if len(seeds) >= 3:
+                if len(seeds) >= pool_target:
                     break
                 try:
                     jf_items = await fetch_fn()
                     for item in jf_items:
-                        if len(seeds) >= 3:
+                        if len(seeds) >= pool_target:
                             break
                         mbid = None
                         if item.provider_ids:
@@ -875,7 +1114,57 @@ class DiscoverHomepageService:
                     logger.warning(f"Failed to get Jellyfin seed artists: {e}")
                     continue
 
-        return seeds
+        return await self._select_balanced_seeds(seeds, genre_prefs or EMPTY_GENRE_PREFS)
+
+    async def _load_genre_prefs(self, user_id: str) -> GenrePrefs:
+        """The user's genre reduce/mute levels; empty (all-normal) on any failure."""
+        if self._genre_prefs_store is None:
+            return EMPTY_GENRE_PREFS
+        try:
+            return GenrePrefs(await self._genre_prefs_store.get_levels(user_id))
+        except Exception as e:  # noqa: BLE001 - prefs must never break a build
+            logger.debug("Genre prefs load failed: %s", e)
+            return EMPTY_GENRE_PREFS
+
+    async def _genres_for_artists(self, mbids: Iterable[str]) -> dict[str, list[str]]:
+        """{artist_mbid_lower: [genres]} from the library genre index; {} on failure."""
+        mbid_list = [m for m in mbids if m]
+        if self._genre_index is None or not mbid_list:
+            return {}
+        try:
+            return await self._genre_index.get_genres_for_artists(mbid_list)
+        except Exception as e:  # noqa: BLE001 - genre data is best-effort
+            logger.debug("Genre lookup for seed balancing failed: %s", e)
+            return {}
+
+    async def _select_balanced_seeds(
+        self, candidates: list[ListenBrainzArtist], prefs: GenrePrefs,
+    ) -> list[ListenBrainzArtist]:
+        """SEED_ARTIST_COUNT seeds spread round-robin across genre families.
+
+        With no genre data and no prefs this is exactly the old take-the-first-3,
+        so sparse libraries and genre-index-less setups behave as before."""
+        if not candidates:
+            return []
+        genres: dict[str, list[str]] = {}
+        if len(candidates) > SEED_ARTIST_COUNT or not prefs.is_empty():
+            genres = await self._genres_for_artists(
+                [self._seed_mbid(s) or "" for s in candidates]
+            )
+        if not genres and prefs.is_empty():
+            return candidates[:SEED_ARTIST_COUNT]
+
+        def genres_of(seed: Any) -> list[str]:
+            mbid = self._seed_mbid(seed)
+            return genres.get(mbid.lower(), []) if mbid else []
+
+        return balanced_seed_selection(candidates, genres_of, SEED_ARTIST_COUNT, prefs)
+
+    @staticmethod
+    def _seed_mbid(seed: Any) -> str | None:
+        if getattr(seed, "artist_mbids", None):
+            return seed.artist_mbids[0]
+        return getattr(seed, "artist_mbid", None)
 
     async def _enrich_because_sections_audiodb(
         self, sections: list[BecauseYouListenTo]
@@ -972,14 +1261,22 @@ class DiscoverHomepageService:
                 await self._cache_daily_mix_result([], user_id, resolved_source)
                 return []
 
-            genre_names = [g for g, _ in top_genres[:10]]
+            # breadth-based cluster seeding: sqrt-damped counts, at most
+            # DAILY_MIX_MAX_CLUSTERS_PER_FAMILY genres per family ("k-pop" and
+            # "korean pop" are ONE family), muted families dropped, reduce halved
+            genre_prefs = await self._load_genre_prefs(user_id)
+            balanced_genres = diverse_genre_selection(
+                top_genres, limit=10, prefs=genre_prefs,
+                max_per_family=DAILY_MIX_MAX_CLUSTERS_PER_FAMILY,
+            )
+            genre_names = [g for g, _ in balanced_genres]
             artists_by_genre = await self._genre_index.get_artists_for_genres(genre_names)
 
             MIN_ARTISTS_PER_CLUSTER = 3
             MAX_CLUSTERS = 5
             candidate_clusters: list[tuple[str, list[str]]] = []
             seen_artists: set[str] = set()
-            for genre_lower, _count in top_genres:
+            for genre_lower, _count in balanced_genres:
                 artist_mbids = artists_by_genre.get(genre_lower, [])
                 unique = [a for a in artist_mbids if a not in seen_artists]
                 if len(unique) < MIN_ARTISTS_PER_CLUSTER:
@@ -1412,6 +1709,12 @@ class DiscoverHomepageService:
                 name = getattr(g, "genre", None)
                 if name:
                     user_genres.add(name.lower())
+            # muted families don't get to pull the genre-affinity score either
+            genre_prefs = await self._load_genre_prefs(user_id)
+            if not genre_prefs.is_empty():
+                user_genres = {
+                    g for g in user_genres if not genre_prefs.is_muted(genre_family(g))
+                }
             genres_by_artist: dict[str, list[str]] = {}
             if self._genre_index is not None:
                 artist_mbids = [c.artist_mbid for c in candidates if c.artist_mbid]
@@ -1427,6 +1730,14 @@ class DiscoverHomepageService:
                 user_genres=user_genres,
                 genres_by_artist=genres_by_artist,
                 count=count,
+            )
+            # zone genre cap: no single family (where the artist's genres are known)
+            # may dominate Top Picks; muted families are excluded outright
+            picks = cap_genre_share(
+                picks,
+                lambda p: genres_by_artist.get((p.candidate.artist_mbid or "").lower(), []),
+                prefs=genre_prefs,
+                target_size=count,
             )
             if not picks:
                 await self._cache_top_picks_result(None, user_id, primary, ttl=picks_ttl)
@@ -1861,10 +2172,11 @@ class DiscoverHomepageService:
         library_mbids: set[str],
         seen_artist_mbids: set[str],
         resolved_source: str = "listenbrainz",
+        genre_prefs: GenrePrefs = EMPTY_GENRE_PREFS,
     ) -> HomeSection | None:
         if resolved_source == "lastfm" and self._lfm_repo:
             return await self._build_popular_in_genres_lastfm(
-                results, library_mbids, seen_artist_mbids
+                results, library_mbids, seen_artist_mbids, genre_prefs=genre_prefs,
             )
 
         genres = results.get("lb_genres")
@@ -1872,10 +2184,19 @@ class DiscoverHomepageService:
         if not genres:
             return None
         else:
+            # breadth: pick 3 DISTINCT genre families (not three spellings of one),
+            # skipping families the user muted
             genre_names = []
-            for genre in genres[:3]:
+            seen_families: set[str] = set()
+            for genre in genres:
                 name = genre.genre if hasattr(genre, 'genre') else str(genre)
+                family = genre_family(name) or name
+                if family in seen_families or genre_prefs.is_muted(family):
+                    continue
+                seen_families.add(family)
                 genre_names.append(name)
+                if len(genre_names) >= 3:
+                    break
 
         all_artists: list[HomeArtist] = []
         tag_results = await asyncio.gather(
@@ -1915,6 +2236,7 @@ class DiscoverHomepageService:
         results: dict[str, Any],
         library_mbids: set[str],
         seen_artist_mbids: set[str],
+        genre_prefs: GenrePrefs = EMPTY_GENRE_PREFS,
     ) -> HomeSection | None:
         top_artists = results.get("lfm_user_top_artists_for_genres") or []
         if not top_artists or not self._lfm_repo:
@@ -1930,17 +2252,24 @@ class DiscoverHomepageService:
 
         genre_names: list[str] = []
         seen_genres: set[str] = set()
+        seen_families: set[str] = set()
         for info in artist_info_results:
             if isinstance(info, Exception):
                 logger.debug("Failed to get artist info for genre extraction: %s", info)
                 continue
             if info and info.tags:
                 for tag in info.tags[:2]:
-                    if tag.name and tag.name.lower() not in seen_genres:
-                        genre_names.append(tag.name)
-                        seen_genres.add(tag.name.lower())
-                        if len(genre_names) >= 3:
-                            break
+                    if not tag.name or tag.name.lower() in seen_genres:
+                        continue
+                    # one genre per FAMILY, none from muted families
+                    family = genre_family(tag.name) or tag.name.lower()
+                    if family in seen_families or genre_prefs.is_muted(family):
+                        continue
+                    genre_names.append(tag.name)
+                    seen_genres.add(tag.name.lower())
+                    seen_families.add(family)
+                    if len(genre_names) >= 3:
+                        break
             if len(genre_names) >= 3:
                 break
 
@@ -2335,8 +2664,18 @@ class DiscoverHomepageService:
         # bound each upstream call so one slow/hanging service can't stall the whole
         # build (a timeout is caught below and that section is just dropped)
         _task_timeout = _scaled(DISCOVER_TASK_TIMEOUT_SECONDS)
-        coros = [asyncio.wait_for(c, timeout=_task_timeout) for c in tasks.values()]
-        raw_results = await asyncio.gather(*coros, return_exceptions=True)
+        durations: dict[str, float] = {}
+
+        async def _timed(key: str, coro: Any) -> Any:
+            start = time.monotonic()
+            try:
+                return await asyncio.wait_for(coro, timeout=_task_timeout)
+            finally:
+                durations[key] = time.monotonic() - start
+
+        raw_results = await asyncio.gather(
+            *(_timed(k, c) for k, c in tasks.items()), return_exceptions=True
+        )
         results = {}
         self._last_failed_task_keys = set()
         for key, result in zip(keys, raw_results):
@@ -2346,6 +2685,12 @@ class DiscoverHomepageService:
                 self._last_failed_task_keys.add(key)
             else:
                 results[key] = result
+        # where the seconds go, slowest zones first (the whole gather costs max(), not sum())
+        slowest = sorted(durations.items(), key=lambda kv: kv[1], reverse=True)
+        logger.info(
+            "Discover zone timings: %s",
+            ", ".join(f"{k}={v:.1f}s" for k, v in slowest[:10]),
+        )
         return results
 
     @staticmethod

--- a/backend/services/discover/response_codec.py
+++ b/backend/services/discover/response_codec.py
@@ -1,0 +1,179 @@
+"""JSON-safe round-trip for ``DiscoverResponse`` (persistent discover cache).
+
+Encoding is plain ``msgspec.to_builtins``. Decoding needs care because
+``HomeSection.items`` is an UNTAGGED union (``HomeArtist | HomeAlbum | HomeTrack |
+HomeGenre``) which msgspec cannot decode directly - the section's ``type`` field
+("artists"/"albums"/"tracks"/"genres") is the discriminator, so each section's items
+are converted against the concrete type it declares.
+
+Decoding is defensive throughout: a corrupt or schema-drifted payload yields ``None``
+(callers fall back to a normal rebuild) rather than an exception.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import msgspec
+
+from api.v1.schemas.discover import (
+    BecauseYouListenTo,
+    DiscoverIntegrationStatus,
+    DiscoverResponse,
+    TopPicksSection,
+)
+from api.v1.schemas.home import (
+    HomeAlbum,
+    HomeArtist,
+    HomeGenre,
+    HomeSection,
+    HomeTrack,
+    ServicePrompt,
+)
+from api.v1.schemas.weekly_exploration import WeeklyExplorationSection
+
+logger = logging.getLogger(__name__)
+
+_ITEM_TYPES: dict[str, type] = {
+    "artists": HomeArtist,
+    "albums": HomeAlbum,
+    "tracks": HomeTrack,
+    "genres": HomeGenre,
+}
+
+# every DiscoverResponse field typed ``HomeSection | None``
+_SECTION_FIELDS = (
+    "fresh_releases",
+    "missing_essentials",
+    "rediscover",
+    "artists_you_might_like",
+    "popular_in_your_genres",
+    "genre_list",
+    "globally_trending",
+    "lastfm_weekly_artist_chart",
+    "lastfm_weekly_album_chart",
+    "lastfm_recent_scrobbles",
+    "listeners_like_you",
+    "anniversaries",
+    "new_from_followed",
+    "unexplored_genres",
+)
+
+
+def encode_discover_response(response: DiscoverResponse) -> dict[str, Any]:
+    return msgspec.to_builtins(response)
+
+
+def _opt_str(value: Any) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _decode_section(raw: Any) -> HomeSection | None:
+    # HomeSection itself carries the untagged union, so it is built by hand; only the
+    # concrete item structs go through msgspec.convert.
+    if not isinstance(raw, dict):
+        return None
+    section_type = str(raw.get("type") or "")
+    section = HomeSection(
+        title=str(raw.get("title") or ""),
+        type=section_type,
+        source=_opt_str(raw.get("source")),
+        fallback_message=_opt_str(raw.get("fallback_message")),
+        connect_service=_opt_str(raw.get("connect_service")),
+        radio_seed_type=_opt_str(raw.get("radio_seed_type")),
+        radio_seed_id=_opt_str(raw.get("radio_seed_id")),
+    )
+    item_type = _ITEM_TYPES.get(section_type)
+    if item_type is None:
+        return section
+    items: list[Any] = []
+    for item_raw in raw.get("items") or []:
+        try:
+            items.append(msgspec.convert(item_raw, type=item_type, strict=False))
+        except (msgspec.ValidationError, TypeError, ValueError):
+            continue
+    section.items = items
+    return section
+
+
+def _decode_because(raw: Any) -> BecauseYouListenTo | None:
+    if not isinstance(raw, dict):
+        return None
+    section = _decode_section(raw.get("section"))
+    if section is None:
+        return None
+    return BecauseYouListenTo(
+        seed_artist=str(raw.get("seed_artist") or ""),
+        seed_artist_mbid=str(raw.get("seed_artist_mbid") or ""),
+        section=section,
+        listen_count=int(raw.get("listen_count") or 0),
+        banner_url=raw.get("banner_url"),
+        wide_thumb_url=raw.get("wide_thumb_url"),
+        fanart_url=raw.get("fanart_url"),
+    )
+
+
+def _convert_opt(raw: Any, target: type) -> Any:
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return msgspec.convert(raw, type=target, strict=False)
+    except (msgspec.ValidationError, TypeError, ValueError):
+        return None
+
+
+def _str_map(raw: Any) -> dict[str, str | None]:
+    if not isinstance(raw, dict):
+        return {}
+    return {
+        str(k): (str(v) if isinstance(v, str) else None)
+        for k, v in raw.items()
+    }
+
+
+def decode_discover_response(payload: Any) -> DiscoverResponse | None:
+    # The DiscoverResponse type as a whole is NOT msgspec-decodable (its sections carry
+    # the untagged items union), so it is reassembled field by field: union-free fields
+    # via msgspec.convert, sections via the type-discriminated decoder above.
+    if not isinstance(payload, dict):
+        return None
+    try:
+        service_status = payload.get("service_status")
+        response = DiscoverResponse(
+            discover_queue_enabled=bool(payload.get("discover_queue_enabled", True)),
+            genre_artists=_str_map(payload.get("genre_artists")),
+            genre_artist_images=_str_map(payload.get("genre_artist_images")),
+            service_status=service_status if isinstance(service_status, dict) else None,
+            refreshing=False,
+        )
+        for field in _SECTION_FIELDS:
+            setattr(response, field, _decode_section(payload.get(field)))
+        response.daily_mixes = [
+            s for s in map(_decode_section, payload.get("daily_mixes") or []) if s is not None
+        ]
+        response.radio_sections = [
+            s for s in map(_decode_section, payload.get("radio_sections") or []) if s is not None
+        ]
+        response.because_you_listen_to = [
+            b for b in map(_decode_because, payload.get("because_you_listen_to") or [])
+            if b is not None
+        ]
+        response.top_picks = _convert_opt(payload.get("top_picks"), TopPicksSection)
+        response.weekly_exploration = _convert_opt(
+            payload.get("weekly_exploration"), WeeklyExplorationSection
+        )
+        response.integration_status = _convert_opt(
+            payload.get("integration_status"), DiscoverIntegrationStatus
+        )
+        response.service_prompts = [
+            p for p in (
+                _convert_opt(raw, ServicePrompt)
+                for raw in payload.get("service_prompts") or []
+            )
+            if p is not None
+        ]
+        return response
+    except Exception as e:  # noqa: BLE001 - a bad payload means "no persisted cache"
+        logger.debug("Failed to decode persisted discover response: %s", e)
+        return None

--- a/backend/services/taste_graph_service.py
+++ b/backend/services/taste_graph_service.py
@@ -1,0 +1,541 @@
+"""Taste Graph — self-contained discovery from the user's OWN signals only.
+
+Seeds are weighted from this user's library (artists + album counts), followed
+artists, and recent play history (followed > recently played > library
+presence). The top seeds are expanded through canonical MusicBrainz metadata
+only: artist relationships (band members, collaborations, tributes), shared
+labels, and shared tags. HARD RULE (by design): no ListenBrainz/Last.fm charts,
+no sitewide/global popularity, no other users' listens anywhere in this path.
+
+MB call budget per build: <= _MAX_SEEDS expansion lookups + _MAX_LABELS label
+browses + _MAX_TAGS tag searches (~14 worst case), every one 24h-cached inside
+the MusicBrainz repository, and the assembled graph itself is cached per user
+for 24h — so steady state is zero MB calls.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+from datetime import datetime, timezone
+
+from api.v1.schemas.taste_graph import (
+    TasteGraphItem,
+    TasteGraphReason,
+    TasteGraphResponse,
+    TasteGraphSeed,
+)
+from infrastructure.cache.cache_keys import TASTE_GRAPH_PREFIX
+from services.discover.genre_balance import (
+    EMPTY_GENRE_PREFS,
+    GenrePrefs,
+    balanced_seed_selection,
+    genre_family,
+)
+
+logger = logging.getLogger(__name__)
+
+_MAX_SEEDS = 10
+_MAX_LABELS = 2
+_MAX_TAGS = 2
+_MAX_ITEMS = 30
+_MAX_PER_SEED = 3  # diversity: max candidates attributed to one seed
+_GENRE_CAP_RATIO = 0.4  # diversity: max 40% of items sharing one genre
+_GRAPH_TTL_SECONDS = 86400
+# on a completely cold MB cache the expansion is rate-limited (~1 req/s); bound the
+# request so the endpoint stays responsive and the next request reuses the MB-layer
+# cache entries that did land.
+_BUILD_BUDGET_SECONDS = 60
+
+_RECENT_PLAYS_LIMIT = 200
+
+# signal weights: followed > recently played > library presence
+_FOLLOW_WEIGHT = 3.0
+_RECENT_PLAY_WEIGHT = 0.2  # per play, capped
+_RECENT_PLAY_MAX = 2.0
+_LIBRARY_BASE_WEIGHT = 1.0
+_LIBRARY_ALBUM_WEIGHT = 0.25  # per owned album, capped at 8
+
+# relationship strength: member/collab > label-mate > shared tag
+_MEMBER_STRENGTH = 1.0
+_COLLAB_STRENGTH = 0.9
+_LABEL_STRENGTH = 0.7
+_SCENE_STRENGTH = 0.5
+
+_MEMBER_REL_TYPES = {"member of band", "founder", "subgroup"}
+_COLLAB_REL_TYPES = {
+    "collaboration",
+    "is person",
+    "tribute",
+    "supporting musician",
+    "instrumental supporting musician",
+    "vocal supporting musician",
+    "voice actor",
+}
+_ARTIST_LABEL_REL_TYPES = {"recording contract", "label founder", "publishing"}
+
+# never recommend these placeholder artists
+_FILTERED_CANDIDATE_NAMES = {"various artists", "[unknown]", "/v/"}
+
+
+class _Seed:
+    __slots__ = ("mbid", "name", "weight", "norm_weight", "top_tag")
+
+    def __init__(self, mbid: str, name: str, weight: float):
+        self.mbid = mbid
+        self.name = name
+        self.weight = weight
+        self.norm_weight = 1.0
+        self.top_tag: str = ""
+
+
+class _Candidate:
+    __slots__ = ("kind", "mbid", "name", "artist_mbid", "artist_name", "score", "reasons", "genre")
+
+    def __init__(self, kind, mbid, name, artist_mbid, artist_name, score, reason, genre):
+        self.kind = kind
+        self.mbid = mbid
+        self.name = name
+        self.artist_mbid = artist_mbid
+        self.artist_name = artist_name
+        self.score = score
+        self.reasons: list[TasteGraphReason] = [reason]
+        self.genre = genre
+
+
+class TasteGraphService:
+    def __init__(
+        self,
+        library_db,
+        follow_store,
+        play_history_store,
+        mb_repo,
+        cache,
+        genre_index=None,
+        genre_prefs_store=None,
+    ) -> None:
+        self._library_db = library_db
+        self._follow_store = follow_store
+        self._play_history = play_history_store
+        self._mb_repo = mb_repo
+        self._cache = cache
+        # optional: library genre index for breadth-based seed balancing, and the
+        # user's genre reduce/mute levels; both degrade to the old behaviour when absent
+        self._genre_index = genre_index
+        self._genre_prefs_store = genre_prefs_store
+
+    async def get_taste_graph(self, user_id: str) -> TasteGraphResponse:
+        cache_key = f"{TASTE_GRAPH_PREFIX}{user_id}"
+        cached = await self._cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        response = await self._build(user_id)
+        # a timed-out/failed expansion returns seeds with no items — don't pin
+        # that for 24h, let the next request retry on the warmed MB cache
+        if response.cold_start or response.items:
+            await self._cache.set(cache_key, response, ttl_seconds=_GRAPH_TTL_SECONDS)
+        return response
+
+    async def _build(self, user_id: str) -> TasteGraphResponse:
+        generated_at = datetime.now(timezone.utc).isoformat()
+        prefs = await self._load_genre_prefs(user_id)
+        seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names = (
+            await self._collect_seeds(user_id, prefs)
+        )
+        if not seeds:
+            return TasteGraphResponse(
+                cold_start=True, generated_at=generated_at, seeds=[], items=[]
+            )
+
+        try:
+            items = await asyncio.wait_for(
+                self._expand(
+                    seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names, prefs
+                ),
+                timeout=_BUILD_BUDGET_SECONDS,
+            )
+        except asyncio.TimeoutError:
+            logger.warning("Taste graph expansion exceeded its budget for user %s", user_id[:8])
+            items = []
+        except Exception:  # noqa: BLE001 - the endpoint must degrade, not 500
+            logger.error("Taste graph expansion failed for user %s", user_id[:8], exc_info=True)
+            items = []
+
+        return TasteGraphResponse(
+            cold_start=False,
+            generated_at=generated_at,
+            seeds=[
+                TasteGraphSeed(artist_mbid=s.mbid, name=s.name, weight=round(s.norm_weight, 4))
+                for s in seeds
+            ],
+            items=items,
+        )
+
+    # ------------------------------------------------------------------ seeds
+
+    async def _load_genre_prefs(self, user_id: str) -> GenrePrefs:
+        if self._genre_prefs_store is None:
+            return EMPTY_GENRE_PREFS
+        try:
+            return GenrePrefs(await self._genre_prefs_store.get_levels(user_id))
+        except Exception:  # noqa: BLE001 - prefs must never break the graph
+            return EMPTY_GENRE_PREFS
+
+    async def _collect_seeds(
+        self, user_id: str, prefs: GenrePrefs = EMPTY_GENRE_PREFS
+    ) -> tuple[list[_Seed], set[str], set[str], set[str]]:
+        artists, albums_for_matching, album_mbids, followed, recent = await asyncio.gather(
+            self._library_db.get_artists(),
+            self._library_db.get_all_albums_for_matching(),
+            self._library_db.get_all_album_mbids(),
+            self._follow_store.list_followed_artists(user_id),
+            self._play_history.recent(user_id, limit=_RECENT_PLAYS_LIMIT),
+        )
+
+        owned_artist_mbids = {
+            str(a.get("mbid", "")).lower() for a in artists if a.get("mbid")
+        }
+        owned_artist_names = {
+            str(a.get("name", "")).lower() for a in artists if a.get("name")
+        }
+        owned_album_mbids = {m.lower() for m in album_mbids}
+
+        album_counts: dict[str, int] = {}
+        for _title, _artist_name, _album_mbid, artist_mbid in albums_for_matching:
+            key = artist_mbid.lower()
+            if key:
+                album_counts[key] = album_counts.get(key, 0) + 1
+
+        name_to_mbid = {
+            str(a.get("name", "")).lower(): str(a.get("mbid", ""))
+            for a in artists
+            if a.get("name") and a.get("mbid")
+        }
+        play_counts: dict[str, int] = {}
+        for record in recent:
+            mbid = name_to_mbid.get((record.artist_name or "").lower())
+            if mbid:
+                play_counts[mbid.lower()] = play_counts.get(mbid.lower(), 0) + 1
+
+        weights: dict[str, float] = {}
+        names: dict[str, str] = {}
+
+        for a in artists:
+            mbid = str(a.get("mbid", "")).lower()
+            if not mbid:
+                continue
+            names[mbid] = str(a.get("name", "")) or mbid
+            weights[mbid] = _LIBRARY_BASE_WEIGHT + _LIBRARY_ALBUM_WEIGHT * min(
+                album_counts.get(mbid, 0), 8
+            )
+
+        for mbid, plays in play_counts.items():
+            weights[mbid] = weights.get(mbid, 0.0) + min(
+                plays * _RECENT_PLAY_WEIGHT, _RECENT_PLAY_MAX
+            )
+
+        for f in followed:
+            mbid = f.artist_mbid.lower()
+            names.setdefault(mbid, f.artist_name)
+            weights[mbid] = weights.get(mbid, 0.0) + _FOLLOW_WEIGHT
+
+        if not weights:
+            return [], owned_artist_mbids, owned_album_mbids, owned_artist_names
+
+        candidates = sorted(weights.items(), key=lambda kv: kv[1], reverse=True)
+        top = await self._balance_seed_candidates(candidates, prefs)
+        if not top:
+            return [], owned_artist_mbids, owned_album_mbids, owned_artist_names
+        max_weight = max(w for _, w in top) or 1.0
+        seeds = [_Seed(mbid, names.get(mbid, mbid), weight) for mbid, weight in top]
+        for s in seeds:
+            s.norm_weight = s.weight / max_weight
+        return seeds, owned_artist_mbids, owned_album_mbids, owned_artist_names
+
+    async def _balance_seed_candidates(
+        self, candidates: list[tuple[str, float]], prefs: GenrePrefs
+    ) -> list[tuple[str, float]]:
+        """Breadth-based seeding: instead of the raw top-N by weight (which a
+        genre-skewed library dominates), spread the _MAX_SEEDS picks round-robin
+        across genre FAMILIES, sqrt-damped, from a 3x-deep candidate pool. The
+        user's prefs apply first: muted families are dropped, reduced families'
+        weights halved. Without a genre index this stays the plain top-N."""
+        pool = candidates[: _MAX_SEEDS * 3]
+        genres: dict[str, list[str]] = {}
+        if self._genre_index is not None and pool:
+            try:
+                genres = await self._genre_index.get_genres_for_artists(
+                    [mbid for mbid, _ in pool]
+                )
+            except Exception:  # noqa: BLE001 - genre data is best-effort
+                genres = {}
+
+        if not prefs.is_empty():
+            adjusted: list[tuple[str, float]] = []
+            for mbid, weight in pool:
+                families = {genre_family(g) for g in genres.get(mbid, [])} - {""}
+                if families and all(prefs.is_muted(f) for f in families):
+                    continue
+                live = [prefs.multiplier(f) for f in families if not prefs.is_muted(f)]
+                adjusted.append((mbid, weight * (min(live) if live else 1.0)))
+            adjusted.sort(key=lambda kv: kv[1], reverse=True)
+            pool = adjusted
+
+        if not genres:
+            return pool[:_MAX_SEEDS]
+        selected = balanced_seed_selection(
+            pool, lambda kv: genres.get(kv[0], []), _MAX_SEEDS, prefs
+        )
+        # keep the seed list weight-ordered so norm_weight scoring stays intuitive
+        selected.sort(key=lambda kv: kv[1], reverse=True)
+        return selected
+
+    # -------------------------------------------------------------- expansion
+
+    async def _expand(
+        self,
+        seeds: list[_Seed],
+        owned_artist_mbids: set[str],
+        owned_album_mbids: set[str],
+        owned_artist_names: set[str],
+        prefs: GenrePrefs = EMPTY_GENRE_PREFS,
+    ) -> list[TasteGraphItem]:
+        expansions = await asyncio.gather(
+            *(self._mb_repo.get_artist_expansion(s.mbid) for s in seeds),
+            return_exceptions=True,
+        )
+
+        candidates: dict[str, _Candidate] = {}
+        per_seed_count: dict[str, int] = {}
+        # label_mbid -> (label_name, best seed)
+        labels: dict[str, tuple[str, _Seed]] = {}
+        # tag -> best seed
+        tags: dict[str, tuple[float, _Seed]] = {}
+
+        seed_mbids = {s.mbid.lower() for s in seeds}
+
+        for seed, expansion in zip(seeds, expansions):
+            if not isinstance(expansion, dict):
+                continue
+            seed_tags = sorted(
+                expansion.get("tags") or [],
+                key=lambda t: int(t.get("count", 0) or 0),
+                reverse=True,
+            )
+            seed.top_tag = str(seed_tags[0].get("name", "")).lower() if seed_tags else ""
+            for tag in seed_tags[:3]:
+                name = str(tag.get("name", "")).lower()
+                if not name:
+                    continue
+                score = seed.norm_weight * (1 + int(tag.get("count", 0) or 0))
+                if name not in tags or score > tags[name][0]:
+                    tags[name] = (score, seed)
+
+            for rel in expansion.get("relations") or []:
+                rel_type = str(rel.get("type", "")).lower()
+                target = rel.get("artist")
+                if isinstance(target, dict) and target.get("id"):
+                    self._consider_related_artist(
+                        seed, rel_type, target, candidates, per_seed_count,
+                        owned_artist_mbids, seed_mbids,
+                    )
+                    continue
+                label = rel.get("label")
+                if (
+                    isinstance(label, dict)
+                    and label.get("id")
+                    and rel_type in _ARTIST_LABEL_REL_TYPES
+                ):
+                    label_id = str(label["id"])
+                    if label_id not in labels or seed.norm_weight > labels[label_id][1].norm_weight:
+                        labels[label_id] = (str(label.get("name", "")), seed)
+
+        top_labels = sorted(
+            labels.items(), key=lambda kv: kv[1][1].norm_weight, reverse=True
+        )[:_MAX_LABELS]
+        top_tags = sorted(tags.items(), key=lambda kv: kv[1][0], reverse=True)[:_MAX_TAGS]
+
+        label_results, tag_results = await asyncio.gather(
+            asyncio.gather(
+                *(self._mb_repo.get_label_releases(label_id) for label_id, _ in top_labels),
+                return_exceptions=True,
+            ),
+            asyncio.gather(
+                *(self._mb_repo.search_release_groups_by_tag(tag, limit=15) for tag, _ in top_tags),
+                return_exceptions=True,
+            ),
+        )
+
+        for (label_id, (label_name, seed)), releases in zip(top_labels, label_results):
+            if not isinstance(releases, list):
+                continue
+            self._consider_label_releases(
+                seed, label_id, label_name, releases, candidates, per_seed_count,
+                owned_artist_mbids, owned_album_mbids, seed_mbids,
+            )
+
+        for (tag, (_score, seed)), results in zip(top_tags, tag_results):
+            if not isinstance(results, list):
+                continue
+            self._consider_scene_release_groups(
+                seed, tag, results, candidates, per_seed_count,
+                owned_album_mbids, owned_artist_names,
+            )
+
+        return self._select_items(candidates, prefs)
+
+    def _consider_related_artist(
+        self, seed, rel_type, target, candidates, per_seed_count,
+        owned_artist_mbids, seed_mbids,
+    ) -> None:
+        if rel_type in _MEMBER_REL_TYPES:
+            reason_type, strength = "member", _MEMBER_STRENGTH
+            reason_label = f"Band-member connection with {seed.name}"
+        elif rel_type in _COLLAB_REL_TYPES:
+            reason_type, strength = "collaborator", _COLLAB_STRENGTH
+            reason_label = f"Collaborated with {seed.name}"
+        else:
+            return
+
+        mbid = str(target["id"]).lower()
+        name = str(target.get("name", ""))
+        if (
+            mbid in owned_artist_mbids  # novelty: not already in the library
+            or mbid in seed_mbids
+            or name.lower() in _FILTERED_CANDIDATE_NAMES
+        ):
+            return
+        reason = TasteGraphReason(
+            type=reason_type, label=reason_label, via_mbid=seed.mbid, via_name=seed.name
+        )
+        self._add_candidate(
+            candidates, per_seed_count, seed,
+            _Candidate(
+                kind="artist", mbid=mbid, name=name, artist_mbid=None, artist_name=None,
+                score=seed.norm_weight * strength, reason=reason, genre=seed.top_tag,
+            ),
+        )
+
+    def _consider_label_releases(
+        self, seed, label_id, label_name, releases, candidates, per_seed_count,
+        owned_artist_mbids, owned_album_mbids, seed_mbids,
+    ) -> None:
+        for rank, release in enumerate(releases):
+            if not isinstance(release, dict):
+                continue
+            rg = release.get("release-group") or {}
+            rg_mbid = str(rg.get("id", "")).lower()
+            credits = release.get("artist-credit") or []
+            first = credits[0] if credits and isinstance(credits[0], dict) else {}
+            credit_artist = first.get("artist") or {}
+            artist_mbid = str(credit_artist.get("id", "")).lower()
+            artist_name = str(first.get("name") or credit_artist.get("name") or "")
+            if (
+                not rg_mbid
+                or rg_mbid in owned_album_mbids  # novelty
+                or not artist_mbid
+                or artist_mbid in owned_artist_mbids
+                or artist_mbid in seed_mbids
+                or artist_name.lower() in _FILTERED_CANDIDATE_NAMES
+            ):
+                continue
+            reason = TasteGraphReason(
+                type="label",
+                label=f"On {label_name or 'the same label'} with {seed.name}",
+                via_mbid=label_id,
+                via_name=label_name or None,
+            )
+            decay = 1.0 / (1.0 + 0.1 * rank)
+            self._add_candidate(
+                candidates, per_seed_count, seed,
+                _Candidate(
+                    kind="album", mbid=rg_mbid, name=str(rg.get("title") or release.get("title", "")),
+                    artist_mbid=artist_mbid, artist_name=artist_name,
+                    score=seed.norm_weight * _LABEL_STRENGTH * decay,
+                    reason=reason, genre=seed.top_tag,
+                ),
+            )
+
+    def _consider_scene_release_groups(
+        self, seed, tag, results, candidates, per_seed_count,
+        owned_album_mbids, owned_artist_names,
+    ) -> None:
+        for rank, result in enumerate(results):
+            rg_mbid = (result.musicbrainz_id or "").lower()
+            artist_name = result.artist or ""
+            if (
+                not rg_mbid
+                or rg_mbid in owned_album_mbids  # novelty
+                or artist_name.lower() in owned_artist_names
+                or artist_name.lower() in _FILTERED_CANDIDATE_NAMES
+            ):
+                continue
+            reason = TasteGraphReason(
+                type="scene",
+                label=f"From the {tag} scene, like {seed.name}",
+                via_mbid=seed.mbid,
+                via_name=tag,
+            )
+            decay = 1.0 / (1.0 + 0.15 * rank)
+            self._add_candidate(
+                candidates, per_seed_count, seed,
+                _Candidate(
+                    kind="album", mbid=rg_mbid, name=result.title,
+                    artist_mbid=None, artist_name=artist_name or None,
+                    score=seed.norm_weight * _SCENE_STRENGTH * decay,
+                    reason=reason, genre=tag,
+                ),
+            )
+
+    @staticmethod
+    def _add_candidate(candidates, per_seed_count, seed, candidate: _Candidate) -> None:
+        existing = candidates.get(candidate.mbid)
+        if existing is not None:
+            # corroborated by multiple connections: merge the reason, small bonus
+            if len(existing.reasons) < 3 and all(
+                r.label != candidate.reasons[0].label for r in existing.reasons
+            ):
+                existing.reasons.append(candidate.reasons[0])
+                existing.score = max(existing.score, candidate.score) + 0.05
+            return
+        if per_seed_count.get(seed.mbid, 0) >= _MAX_PER_SEED:
+            return  # diversity: this seed already placed its quota
+        per_seed_count[seed.mbid] = per_seed_count.get(seed.mbid, 0) + 1
+        candidates[candidate.mbid] = candidate
+
+    @staticmethod
+    def _select_items(
+        candidates: dict[str, _Candidate], prefs: GenrePrefs = EMPTY_GENRE_PREFS
+    ) -> list[TasteGraphItem]:
+        genre_cap = max(1, math.ceil(_MAX_ITEMS * _GENRE_CAP_RATIO))
+        genre_counts: dict[str, int] = {}
+        items: list[TasteGraphItem] = []
+        for c in sorted(candidates.values(), key=lambda c: c.score, reverse=True):
+            if len(items) >= _MAX_ITEMS:
+                break
+            if c.genre:
+                # the cap counts genre FAMILIES ("k-pop"/"korean pop"/"kpop" are one),
+                # and the user's mute/reduce levels apply: muted families are excluded,
+                # reduced families get half the cap
+                family = genre_family(c.genre) or c.genre
+                if prefs.is_muted(family):
+                    continue
+                cap = genre_cap
+                if prefs.level(family) == "reduce":
+                    cap = max(1, genre_cap // 2)
+                if genre_counts.get(family, 0) >= cap:
+                    continue  # diversity: max 40% of items from one genre family
+                genre_counts[family] = genre_counts.get(family, 0) + 1
+            items.append(TasteGraphItem(
+                kind=c.kind,
+                mbid=c.mbid,
+                name=c.name,
+                artist_mbid=c.artist_mbid or None,
+                artist_name=c.artist_name or None,
+                score=round(c.score, 4),
+                reasons=c.reasons,
+                in_library=False,  # candidates are novelty-filtered against the library
+            ))
+        return items

--- a/backend/tests/routes/test_genre_prefs_routes.py
+++ b/backend/tests/routes/test_genre_prefs_routes.py
@@ -1,0 +1,102 @@
+import threading
+
+import pytest
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+
+import api.v1.routes.me_connections as me_connections
+from api.v1.routes.me_connections import router
+from core.dependencies import (
+    get_genre_index,
+    get_user_genre_prefs_store,
+)
+from infrastructure.persistence.user_genre_prefs_store import UserGenrePrefsStore
+from tests.helpers import build_test_client, override_user_auth
+
+_UID = "test-user-id"
+
+
+@pytest.fixture
+def store(tmp_path):
+    return UserGenrePrefsStore(db_path=tmp_path / "library.db", write_lock=threading.Lock())
+
+
+@pytest.fixture
+def genre_index():
+    index = AsyncMock()
+    # three spellings of the K-pop family plus two distinct families
+    index.get_top_genres = AsyncMock(
+        return_value=[("k-pop", 30), ("kpop", 8), ("korean pop", 4), ("rock", 12), ("jazz", 3)]
+    )
+    return index
+
+
+@pytest.fixture
+def client(store, genre_index, monkeypatch):
+    # cache invalidation reaches into app singletons; not under test here
+    monkeypatch.setattr(
+        me_connections, "_invalidate_recommendation_caches", AsyncMock()
+    )
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_user_genre_prefs_store] = lambda: store
+    app.dependency_overrides[get_genre_index] = lambda: genre_index
+    override_user_auth(app, user_id=_UID)
+    return build_test_client(app)
+
+
+class TestGetGenrePrefs:
+    def test_families_merge_spellings_and_sum_counts(self, client):
+        resp = client.get("/me/genre-prefs")
+        assert resp.status_code == 200
+        genres = {g["family"]: g for g in resp.json()["genres"]}
+        # "k-pop" + "kpop" + "korean pop" merge into one family
+        assert set(genres) == {"k-pop", "rock", "jazz"}
+        assert genres["k-pop"]["artist_count"] == 42
+        assert all(g["level"] == "normal" for g in genres.values())
+
+
+class TestPutGenrePrefs:
+    def test_reduce_and_mute_round_trip(self, client):
+        resp = client.put(
+            "/me/genre-prefs",
+            json={
+                "genres": [
+                    # any spelling normalises to the family key
+                    {"family": "kpop", "level": "mute"},
+                    {"family": "rock", "level": "reduce"},
+                    {"family": "jazz", "level": "normal"},
+                ]
+            },
+        )
+        assert resp.status_code == 200
+        genres = {g["family"]: g["level"] for g in resp.json()["genres"]}
+        assert genres["k-pop"] == "mute"
+        assert genres["rock"] == "reduce"
+        assert genres["jazz"] == "normal"
+
+        # back to normal clears the stored rows
+        resp = client.put(
+            "/me/genre-prefs",
+            json={"genres": [{"family": "k-pop", "level": "normal"}]},
+        )
+        genres = {g["family"]: g["level"] for g in resp.json()["genres"]}
+        assert all(level == "normal" for level in genres.values())
+
+    def test_invalid_level_rejected(self, client):
+        resp = client.put(
+            "/me/genre-prefs",
+            json={"genres": [{"family": "rock", "level": "banish"}]},
+        )
+        assert resp.status_code == 422
+
+    def test_stored_family_missing_from_library_still_listed(self, client):
+        client.put(
+            "/me/genre-prefs",
+            json={"genres": [{"family": "vaporwave", "level": "mute"}]},
+        )
+        resp = client.get("/me/genre-prefs")
+        genres = {g["family"]: g for g in resp.json()["genres"]}
+        assert genres["vaporwave"]["level"] == "mute"
+        assert genres["vaporwave"]["artist_count"] == 0

--- a/backend/tests/routes/test_taste_graph_routes.py
+++ b/backend/tests/routes/test_taste_graph_routes.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from api.v1.routes.taste_graph import router
+from api.v1.schemas.taste_graph import (
+    TasteGraphItem,
+    TasteGraphReason,
+    TasteGraphResponse,
+    TasteGraphSeed,
+)
+from core.dependencies import get_taste_graph_service
+from tests.helpers import override_user_auth
+
+_UID = "test-user-id"
+
+
+def _make_response() -> TasteGraphResponse:
+    return TasteGraphResponse(
+        cold_start=False,
+        generated_at="2026-07-10T00:00:00+00:00",
+        seeds=[TasteGraphSeed(artist_mbid="seed-1", name="Seed Artist", weight=1.0)],
+        items=[
+            TasteGraphItem(
+                kind="artist",
+                mbid="candidate-1",
+                name="Candidate Artist",
+                score=0.9,
+                reasons=[
+                    TasteGraphReason(
+                        type="member",
+                        label="Band-member connection with Seed Artist",
+                        via_mbid="seed-1",
+                        via_name="Seed Artist",
+                    )
+                ],
+                in_library=False,
+            ),
+            TasteGraphItem(
+                kind="album",
+                mbid="rg-1",
+                name="Candidate Album",
+                artist_mbid="candidate-2",
+                artist_name="Label Mate",
+                score=0.7,
+                reasons=[
+                    TasteGraphReason(
+                        type="label",
+                        label="On Test Label with Seed Artist",
+                        via_mbid="label-1",
+                        via_name="Test Label",
+                    )
+                ],
+                in_library=False,
+            ),
+        ],
+    )
+
+
+@pytest.fixture
+def mock_service():
+    mock = AsyncMock()
+    mock.get_taste_graph = AsyncMock(return_value=_make_response())
+    return mock
+
+
+@pytest.fixture
+def client(mock_service):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_taste_graph_service] = lambda: mock_service
+    override_user_auth(app, user_id=_UID)
+    return TestClient(app)
+
+
+class TestTasteGraphRoute:
+    def test_builds_for_current_user(self, client, mock_service):
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        mock_service.get_taste_graph.assert_awaited_once_with(_UID)
+
+    def test_response_shape(self, client):
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cold_start"] is False
+        assert data["generated_at"]
+        assert data["seeds"][0] == {
+            "artist_mbid": "seed-1",
+            "name": "Seed Artist",
+            "weight": 1.0,
+        }
+        artist_item = data["items"][0]
+        assert artist_item["kind"] == "artist"
+        assert artist_item["mbid"] == "candidate-1"
+        assert artist_item["in_library"] is False
+        assert artist_item["reasons"][0]["type"] == "member"
+        album_item = data["items"][1]
+        assert album_item["kind"] == "album"
+        assert album_item["artist_mbid"] == "candidate-2"
+        assert album_item["reasons"][0]["type"] == "label"
+        assert album_item["reasons"][0]["via_name"] == "Test Label"
+
+    def test_cold_start_shape(self, client, mock_service):
+        mock_service.get_taste_graph = AsyncMock(
+            return_value=TasteGraphResponse(
+                cold_start=True, generated_at="2026-07-10T00:00:00+00:00",
+            )
+        )
+        resp = client.get("/discover/taste-graph")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cold_start"] is True
+        assert data["seeds"] == []
+        assert data["items"] == []

--- a/backend/tests/services/test_discover_fast_cold_path.py
+++ b/backend/tests/services/test_discover_fast_cold_path.py
@@ -1,0 +1,320 @@
+"""Fast-first-paint, zone isolation and restart persistence for the Discover build.
+
+Covers the slow-Discover fixes:
+- the cold path never blocks on the full build: it returns the cheap library-derived
+  zones within the quick budget, flags ``refreshing`` and completes the rest in a
+  background warm that fills the cache;
+- one hanging upstream zone can't delay unrelated zones (per-zone timeouts);
+- a built page persists to the disk metadata cache and reloads instantly after a
+  simulated restart (new service instance, empty memory cache).
+"""
+
+import asyncio
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.v1.schemas.discover import DiscoverResponse
+from api.v1.schemas.home import HomeAlbum, HomeArtist, HomeGenre, HomeSection
+from infrastructure.cache.memory_cache import InMemoryCache
+from repositories.listenbrainz_models import ListenBrainzArtist
+from services.discover.homepage_service import DiscoverHomepageService
+from services.discover.response_codec import (
+    decode_discover_response,
+    encode_discover_response,
+)
+
+
+def _cache_key(user_id: str) -> str:
+    return f"discover_response:{user_id}:True:False"
+
+
+def _anniversary_albums() -> list[dict]:
+    year = datetime.now(timezone.utc).year - 20
+    return [
+        {"mbid": f"a{i}", "title": f"Old Gold {i}", "artist_name": "A", "artist_mbid": None, "year": year}
+        for i in range(3)
+    ]
+
+
+def _make_service(
+    memory_cache=None,
+    disk_cache=None,
+    lb_repo=None,
+    library_db=None,
+) -> DiscoverHomepageService:
+    lb = lb_repo or AsyncMock()
+    integration = MagicMock()
+    integration.get_discover_cache_key.side_effect = (
+        lambda uid, lb_enabled=False, lfm_enabled=False: _cache_key(uid)
+    )
+    integration.get_integration_status.return_value = None
+    integration.is_jellyfin_enabled.return_value = False
+    integration.is_library_configured.return_value = True
+    integration.get_discover_picks_settings.return_value = (True, 5)
+
+    mbid = MagicMock()
+    mbid.get_library_artist_mbids = AsyncMock(return_value=set())
+    mbid.get_library_album_mbids = AsyncMock(return_value=set())
+    mbid.get_user_listened_release_group_mbids = AsyncMock(return_value=set())
+    mbid.normalize_mbid.side_effect = lambda m: m.lower() if m else None
+
+    library_repo = AsyncMock()
+    library_repo.get_artists_from_library = AsyncMock(return_value=[])
+    library_repo.get_library = AsyncMock(return_value=[])
+
+    factory = MagicMock()
+    factory.resolve_listenbrainz = AsyncMock(return_value=lb)
+    factory.resolve_lastfm = AsyncMock(return_value=None)
+    factory.resolve_listenbrainz_username = AsyncMock(return_value="lbuser")
+    factory.resolve_lastfm_username = AsyncMock(return_value=None)
+
+    prefs_store = MagicMock()
+    prefs_store.get = AsyncMock(
+        return_value=SimpleNamespace(primary_music_source="listenbrainz")
+    )
+
+    return DiscoverHomepageService(
+        listenbrainz_repo=lb,
+        jellyfin_repo=AsyncMock(),
+        library_repo=library_repo,
+        musicbrainz_repo=AsyncMock(),
+        integration=integration,
+        mbid_resolution=mbid,
+        memory_cache=memory_cache,
+        lastfm_repo=None,
+        client_factory=factory,
+        listening_prefs_store=prefs_store,
+        library_db=library_db,
+        disk_cache=disk_cache,
+    )
+
+
+def _full_response() -> DiscoverResponse:
+    return DiscoverResponse(
+        globally_trending=HomeSection(
+            title="Globally Trending",
+            type="artists",
+            items=[HomeArtist(mbid="m1", name="Artist One", listen_count=5)],
+            source="listenbrainz",
+        ),
+        daily_mixes=[
+            HomeSection(
+                title="Daily Mix 1 - Rock",
+                type="albums",
+                items=[HomeAlbum(name="Album", mbid="rg1", artist_name="A")],
+                source="listenbrainz",
+            )
+        ],
+        genre_list=HomeSection(
+            title="Browse by Genre",
+            type="genres",
+            items=[HomeGenre(name="Rock", listen_count=10)],
+            source="listenbrainz",
+        ),
+    )
+
+
+class TestFastColdPath:
+    @pytest.mark.asyncio
+    async def test_cold_request_returns_fast_and_background_build_fills_cache(self):
+        uid = "cold-user-1"
+        cache = InMemoryCache()
+        library_db = MagicMock()
+        library_db.get_albums = AsyncMock(return_value=_anniversary_albums())
+        svc = _make_service(memory_cache=cache, library_db=library_db)
+
+        build_started = asyncio.Event()
+
+        async def slow_build(user_id: str) -> DiscoverResponse:
+            build_started.set()
+            await asyncio.sleep(1.0)  # a slow external-dependent full build
+            return _full_response()
+
+        svc.build_discover_data = slow_build
+
+        start = time.monotonic()
+        resp = await svc.get_discover_data(uid)
+        elapsed = time.monotonic() - start
+
+        # never blocks on the full build; cheap local zones paint immediately
+        assert elapsed < 2.0
+        assert resp.refreshing is True
+        assert resp.anniversaries is not None and resp.anniversaries.items
+        assert resp.globally_trending is None  # not ready yet -> empty zone
+
+        # the triggered background build completes and fills the cache
+        await asyncio.wait_for(build_started.wait(), timeout=2)
+        for _ in range(60):
+            if await cache.get(_cache_key(uid)) is not None:
+                break
+            await asyncio.sleep(0.1)
+        cached = await cache.get(_cache_key(uid))
+        assert isinstance(cached, DiscoverResponse)
+
+        followup = await svc.get_discover_data(uid)
+        assert followup.refreshing is False  # settled
+        assert followup.globally_trending is not None
+        assert followup.globally_trending.items[0].name == "Artist One"
+
+    @pytest.mark.asyncio
+    async def test_empty_quick_zones_still_returns_fast_shell(self):
+        uid = "cold-user-2"
+        svc = _make_service(memory_cache=InMemoryCache())
+        svc.build_discover_data = AsyncMock(return_value=DiscoverResponse())
+
+        resp = await svc.get_discover_data(uid)
+
+        assert resp.refreshing is True
+        assert resp.anniversaries is None
+        assert resp.because_you_listen_to == []
+
+
+class TestZoneIsolation:
+    @pytest.mark.asyncio
+    async def test_one_hanging_zone_does_not_delay_or_kill_others(self, monkeypatch):
+        import services.discover.homepage_service as hs
+
+        monkeypatch.setattr(hs, "DISCOVER_TASK_TIMEOUT_SECONDS", 0.5)
+
+        lb = AsyncMock()
+        lb.get_user_top_artists = AsyncMock(return_value=[])
+        lb.get_sitewide_top_artists = AsyncMock(
+            return_value=[
+                ListenBrainzArtist(
+                    artist_name=f"Trend {i}", listen_count=10 - i, artist_mbids=[f"t{i}"]
+                )
+                for i in range(5)
+            ]
+        )
+
+        async def hang():
+            await asyncio.sleep(30)
+
+        lb.get_user_fresh_releases = AsyncMock(side_effect=hang)
+        lb.get_user_genre_activity = AsyncMock(return_value=[])
+        lb.get_similar_users = AsyncMock(return_value=[])
+        lb.get_recommendation_playlists = AsyncMock(return_value=[])
+        lb.get_sitewide_top_release_groups = AsyncMock(return_value=[])
+
+        svc = _make_service(memory_cache=InMemoryCache(), lb_repo=lb)
+
+        start = time.monotonic()
+        response = await svc.build_discover_data("iso-user")
+        elapsed = time.monotonic() - start
+
+        # the hanging zone was cut at its own budget without stalling the build
+        assert elapsed < 5.0
+        assert response.fresh_releases is None
+        # unrelated zones still built
+        assert response.globally_trending is not None
+        assert len(response.globally_trending.items) == 5
+
+
+class TestPersistentCache:
+    @pytest.mark.asyncio
+    async def test_reload_after_simulated_restart(self, tmp_path):
+        from infrastructure.cache.disk_cache import DiskMetadataCache
+
+        uid = "persist-user-1"
+        disk = DiskMetadataCache(base_path=tmp_path)
+
+        svc1 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc1.build_discover_data = AsyncMock(return_value=_full_response())
+        await svc1.warm_cache(uid)
+
+        persisted = await disk.get_discover(_cache_key(uid))
+        assert isinstance(persisted, dict) and persisted.get("response")
+
+        # "restart": a brand-new service instance with an empty memory cache
+        svc2 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        resp = await svc2.get_discover_data(uid)
+
+        # yesterday's discover is served instantly, fully typed, without a rebuild
+        assert resp.refreshing is False  # fresh enough -> no background churn
+        assert resp.globally_trending is not None
+        assert isinstance(resp.globally_trending.items[0], HomeArtist)
+        assert resp.daily_mixes and isinstance(resp.daily_mixes[0].items[0], HomeAlbum)
+        assert resp.genre_list and isinstance(resp.genre_list.items[0], HomeGenre)
+
+    @pytest.mark.asyncio
+    async def test_stale_persisted_copy_triggers_background_refresh(self, tmp_path, monkeypatch):
+        from infrastructure.cache.disk_cache import DiskMetadataCache
+
+        uid = "persist-user-2"
+        disk = DiskMetadataCache(base_path=tmp_path)
+
+        svc1 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc1.build_discover_data = AsyncMock(return_value=_full_response())
+        await svc1.warm_cache(uid)
+
+        # age the persisted copy past the SWR freshness window (still inside its TTL)
+        payload = await disk.get_discover(_cache_key(uid))
+        payload["built_at"] = time.time() - 3600
+        await disk.set_discover(_cache_key(uid), payload, ttl_seconds=3600)
+
+        svc2 = _make_service(memory_cache=InMemoryCache(), disk_cache=disk)
+        svc2._trigger_warm = MagicMock()
+        resp = await svc2.get_discover_data(uid)
+
+        # stale-but-usable: serve it AND refresh in background
+        assert resp.globally_trending is not None
+        assert resp.refreshing is True
+        svc2._trigger_warm.assert_called_once_with(uid)
+
+
+class TestResponseCodec:
+    def test_round_trip_preserves_sections_and_item_types(self):
+        from api.v1.schemas.discover import (
+            BecauseYouListenTo,
+            TopPickItem,
+            TopPicksSection,
+        )
+
+        original = _full_response()
+        original.because_you_listen_to = [
+            BecauseYouListenTo(
+                seed_artist="Seed",
+                seed_artist_mbid="s1",
+                listen_count=7,
+                section=HomeSection(
+                    title="Because You Listen To Seed",
+                    type="artists",
+                    items=[HomeArtist(mbid="sim1", name="Similar One")],
+                    source="listenbrainz",
+                ),
+            )
+        ]
+        original.top_picks = TopPicksSection(
+            items=[
+                TopPickItem(
+                    album=HomeAlbum(name="Pick", mbid="p1", artist_name="PA"),
+                    match_pct=87,
+                    reasons=["similar to Seed"],
+                )
+            ],
+            source="listenbrainz",
+        )
+        original.genre_artists = {"Rock": "m1"}
+
+        decoded = decode_discover_response(encode_discover_response(original))
+
+        assert decoded is not None
+        assert isinstance(decoded.globally_trending.items[0], HomeArtist)
+        assert decoded.globally_trending.items[0].name == "Artist One"
+        assert isinstance(decoded.daily_mixes[0].items[0], HomeAlbum)
+        assert isinstance(decoded.genre_list.items[0], HomeGenre)
+        because = decoded.because_you_listen_to[0]
+        assert because.seed_artist == "Seed" and because.listen_count == 7
+        assert isinstance(because.section.items[0], HomeArtist)
+        assert decoded.top_picks.items[0].match_pct == 87
+        assert decoded.top_picks.items[0].album.name == "Pick"
+        assert decoded.genre_artists == {"Rock": "m1"}
+
+    def test_corrupt_payload_decodes_to_none(self):
+        assert decode_discover_response(None) is None
+        assert decode_discover_response("junk") is None
+        assert decode_discover_response({"because_you_listen_to": 42}) is None

--- a/backend/tests/services/test_genre_balance.py
+++ b/backend/tests/services/test_genre_balance.py
@@ -1,0 +1,380 @@
+"""Genre balance: breadth-based seeding, per-zone/page genre-family share caps,
+and user reduce/mute preferences across Discover and the Taste Graph."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from api.v1.schemas.discover import DiscoverResponse
+from api.v1.schemas.home import HomeArtist, HomeSection
+from infrastructure.cache.memory_cache import InMemoryCache
+from repositories.listenbrainz_models import ListenBrainzArtist
+from services.discover.genre_balance import (
+    GenrePrefs,
+    balanced_seed_selection,
+    cap_genre_share,
+    diverse_genre_selection,
+    genre_family,
+)
+from services.discover.homepage_service import DiscoverHomepageService
+from services.taste_graph_service import TasteGraphService
+
+
+# ------------------------------------------------------------------ families
+
+
+class TestGenreFamily:
+    def test_kpop_spellings_are_one_family(self) -> None:
+        assert genre_family("k-pop") == "k-pop"
+        assert genre_family("kpop") == "k-pop"
+        assert genre_family("K Pop") == "k-pop"
+        assert genre_family("korean pop") == "k-pop"
+        assert genre_family("Korean Ballad") == "k-pop"
+
+    def test_distinct_genres_stay_distinct(self) -> None:
+        assert genre_family("rock") == "rock"
+        assert genre_family("jazz") == "jazz"
+        assert genre_family("rock") != genre_family("k-pop")
+
+    def test_unknown_or_blank_is_empty(self) -> None:
+        assert genre_family(None) == ""
+        assert genre_family("   ") == ""
+
+    def test_prefs_normalize_family_spellings(self) -> None:
+        prefs = GenrePrefs({"kpop": "mute", "hip-hop": "reduce"})
+        assert prefs.is_muted("k-pop")
+        assert prefs.multiplier(genre_family("korean pop")) == 0.0
+        assert prefs.multiplier(genre_family("hip hop")) == 0.5
+
+
+# ------------------------------------------------------------- seed balancing
+
+
+def _skewed_candidates() -> tuple[list[str], dict[str, list[str]]]:
+    """10 candidates in play-count order: 7 K-pop-family, 2 rock, 1 jazz."""
+    mbids = [f"a{i}" for i in range(10)]
+    kpop_spellings = ["k-pop", "kpop", "korean pop", "k-pop", "kpop", "korean pop", "k-pop"]
+    genres = {f"a{i}": [kpop_spellings[i]] for i in range(7)}
+    genres["a7"] = ["rock"]
+    genres["a8"] = ["rock"]
+    genres["a9"] = ["jazz"]
+    return mbids, genres
+
+
+class TestBalancedSeedSelection:
+    def test_skewed_library_yields_one_seed_per_family(self) -> None:
+        mbids, genres = _skewed_candidates()
+        picked = balanced_seed_selection(mbids, lambda m: genres[m], 3)
+        families = [genre_family(genres[m][0]) for m in picked]
+        # breadth: a 70% K-pop pool still seeds three DISTINCT families
+        assert sorted(families) == ["jazz", "k-pop", "rock"]
+
+    def test_mute_excludes_the_family(self) -> None:
+        mbids, genres = _skewed_candidates()
+        prefs = GenrePrefs({"k-pop": "mute"})
+        picked = balanced_seed_selection(mbids, lambda m: genres[m], 3, prefs)
+        assert picked and all(genre_family(genres[m][0]) != "k-pop" for m in picked)
+
+    def test_reduce_halves_the_family_weight(self) -> None:
+        # 9 kpop vs 4 rock: raw damped weights sqrt(9)=3 > sqrt(4)=2, but reduce
+        # halves kpop to 1.5 so rock leads the round-robin
+        candidates = [f"k{i}" for i in range(9)] + [f"r{i}" for i in range(4)]
+        genres = {m: ["k-pop"] if m.startswith("k") else ["rock"] for m in candidates}
+        prefs = GenrePrefs({"k-pop": "reduce"})
+        picked = balanced_seed_selection(candidates, lambda m: genres[m], 2, prefs)
+        assert genres[picked[0]] == ["rock"]
+
+    def test_no_genre_data_degrades_to_first_n(self) -> None:
+        picked = balanced_seed_selection(["a", "b", "c", "d"], lambda m: [], 3)
+        assert picked == ["a", "b", "c"]
+
+
+# ------------------------------------------------------------------ zone caps
+
+
+class TestCapGenreShare:
+    def test_zone_cap_holds_for_dominant_family(self) -> None:
+        items = [("k", i) for i in range(12)] + [("r", i) for i in range(3)]
+        genres_of = lambda item: ["korean pop"] if item[0] == "k" else ["rock"]  # noqa: E731
+        kept = cap_genre_share(items, genres_of)
+        kpop_kept = [i for i in kept if i[0] == "k"]
+        # cap = ceil(0.35 * 15) = 6
+        assert len(kpop_kept) <= 6
+        # backfill: every other-genre item survives
+        assert [i for i in kept if i[0] == "r"] == [("r", 0), ("r", 1), ("r", 2)]
+
+    def test_mute_excludes_all_spellings_of_a_family(self) -> None:
+        items = [("a", ["kpop"]), ("b", ["korean pop"]), ("c", ["k-pop"]), ("d", ["rock"])]
+        kept = cap_genre_share(items, lambda i: i[1], prefs=GenrePrefs({"k-pop": "mute"}))
+        assert kept == [("d", ["rock"])]
+
+    def test_unknown_genre_items_pass_through(self) -> None:
+        items = list(range(10))
+        assert cap_genre_share(items, lambda i: []) == items
+
+    def test_page_wide_budget_is_shared_across_zones(self) -> None:
+        counts: dict[str, int] = {}
+        zone = [("k", i) for i in range(6)]
+        genres_of = lambda item: ["k-pop"]  # noqa: E731
+        # target_size 20 -> per-zone cap of 7 doesn't bite; the page budget does
+        first = cap_genre_share(
+            zone, genres_of, target_size=20, counts=counts, total_allowed=8
+        )
+        second = cap_genre_share(
+            zone, genres_of, target_size=20, counts=counts, total_allowed=8
+        )
+        # 6 from the first zone, only 2 left in the page budget for the second
+        assert len(first) == 6
+        assert len(second) == 2
+
+
+class TestDiverseGenreSelection:
+    def test_family_capped_and_muted_dropped(self) -> None:
+        top = [("k-pop", 30), ("kpop", 20), ("korean pop", 15), ("rock", 8), ("jazz", 5)]
+        rows = diverse_genre_selection(top, limit=10, max_per_family=2)
+        kpop_rows = [g for g, _ in rows if genre_family(g) == "k-pop"]
+        assert len(kpop_rows) == 2
+        assert {"rock", "jazz"} <= {g for g, _ in rows}
+
+        muted = diverse_genre_selection(
+            top, limit=10, prefs=GenrePrefs({"k-pop": "mute"}), max_per_family=2
+        )
+        assert all(genre_family(g) != "k-pop" for g, _ in muted)
+
+
+# --------------------------------------------------- homepage service seeding
+
+
+def _make_homepage_service(
+    genre_index: AsyncMock | None = None,
+    genre_prefs_store: AsyncMock | None = None,
+    lb_repo: AsyncMock | None = None,
+) -> DiscoverHomepageService:
+    return DiscoverHomepageService(
+        listenbrainz_repo=lb_repo or AsyncMock(),
+        jellyfin_repo=AsyncMock(),
+        library_repo=AsyncMock(),
+        musicbrainz_repo=AsyncMock(),
+        integration=MagicMock(),
+        mbid_resolution=MagicMock(),
+        memory_cache=None,
+        genre_index=genre_index,
+        genre_prefs_store=genre_prefs_store,
+    )
+
+
+def _lb_artist(mbid: str, plays: int) -> ListenBrainzArtist:
+    return ListenBrainzArtist(
+        artist_name=f"Artist {mbid}", listen_count=plays, artist_mbids=[mbid]
+    )
+
+
+class TestSeedArtistsAreGenreBalanced:
+    @pytest.mark.asyncio
+    async def test_skewed_top_artists_seed_three_distinct_families(self) -> None:
+        mbids, genres = _skewed_candidates()
+        lb_repo = AsyncMock()
+        # play-count order: the 7 K-pop artists dominate the raw top
+        lb_repo.get_user_top_artists = AsyncMock(
+            return_value=[_lb_artist(m, 100 - i) for i, m in enumerate(mbids)]
+        )
+        genre_index = AsyncMock()
+        genre_index.get_genres_for_artists = AsyncMock(return_value=genres)
+        service = _make_homepage_service(genre_index=genre_index, lb_repo=lb_repo)
+
+        seeds = await service._get_seed_artists(True, "user", False)
+        assert len(seeds) == 3
+        families = {genre_family(genres[s.artist_mbids[0]][0]) for s in seeds}
+        assert families == {"k-pop", "rock", "jazz"}
+
+    @pytest.mark.asyncio
+    async def test_mute_excludes_family_from_seeds(self) -> None:
+        mbids, genres = _skewed_candidates()
+        lb_repo = AsyncMock()
+        lb_repo.get_user_top_artists = AsyncMock(
+            return_value=[_lb_artist(m, 100 - i) for i, m in enumerate(mbids)]
+        )
+        genre_index = AsyncMock()
+        genre_index.get_genres_for_artists = AsyncMock(return_value=genres)
+        service = _make_homepage_service(genre_index=genre_index, lb_repo=lb_repo)
+
+        seeds = await service._get_seed_artists(
+            True, "user", False, genre_prefs=GenrePrefs({"k-pop": "mute"})
+        )
+        assert seeds
+        for seed in seeds:
+            assert genre_family(genres[seed.artist_mbids[0]][0]) != "k-pop"
+
+    @pytest.mark.asyncio
+    async def test_without_genre_index_keeps_original_top_three(self) -> None:
+        lb_repo = AsyncMock()
+        lb_repo.get_user_top_artists = AsyncMock(
+            return_value=[_lb_artist(f"a{i}", 100 - i) for i in range(10)]
+        )
+        service = _make_homepage_service(genre_index=None, lb_repo=lb_repo)
+        seeds = await service._get_seed_artists(True, "user", False)
+        assert [s.artist_mbids[0] for s in seeds] == ["a0", "a1", "a2"]
+
+
+class TestZoneGenreCapInResponse:
+    @staticmethod
+    def _response_with_section(n_kpop: int, n_rock: int) -> tuple[DiscoverResponse, dict]:
+        items = [HomeArtist(mbid=f"k{i}", name=f"K{i}") for i in range(n_kpop)]
+        items += [HomeArtist(mbid=f"r{i}", name=f"R{i}") for i in range(n_rock)]
+        genres = {f"k{i}": ["korean pop"] for i in range(n_kpop)}
+        genres.update({f"r{i}": ["rock"] for i in range(n_rock)})
+        response = DiscoverResponse(
+            artists_you_might_like=HomeSection(
+                title="Artists You Might Like", type="artists", items=items,
+            )
+        )
+        return response, genres
+
+    @pytest.mark.asyncio
+    async def test_zone_share_cap_holds(self) -> None:
+        response, genres = self._response_with_section(12, 3)
+        genre_index = AsyncMock()
+        genre_index.get_genres_for_artists = AsyncMock(return_value=genres)
+        service = _make_homepage_service(genre_index=genre_index)
+
+        await service._apply_genre_balance(response, GenrePrefs())
+        kept = response.artists_you_might_like.items
+        kpop = [i for i in kept if i.mbid.startswith("k")]
+        assert len(kpop) <= 6  # ceil(0.35 * 15)
+        assert len([i for i in kept if i.mbid.startswith("r")]) == 3
+
+    @pytest.mark.asyncio
+    async def test_mute_removes_family_from_zone(self) -> None:
+        response, genres = self._response_with_section(12, 3)
+        genre_index = AsyncMock()
+        genre_index.get_genres_for_artists = AsyncMock(return_value=genres)
+        service = _make_homepage_service(genre_index=genre_index)
+
+        await service._apply_genre_balance(response, GenrePrefs({"k-pop": "mute"}))
+        kept = response.artists_you_might_like.items
+        assert kept and all(i.mbid.startswith("r") for i in kept)
+
+
+class TestDailyMixClusterBalance:
+    @staticmethod
+    def _genre_index(top_genres: list[tuple[str, int]]) -> AsyncMock:
+        genre_index = AsyncMock()
+        genre_index.get_top_genres = AsyncMock(return_value=top_genres)
+        counter = 0
+        artists: dict[str, list[str]] = {}
+        for genre, _ in top_genres:
+            artists[genre] = [f"artist-{counter + j}" for j in range(4)]
+            counter += 4
+        genre_index.get_artists_for_genres = AsyncMock(return_value=artists)
+        genre_index.get_albums_by_genre = AsyncMock(return_value=[])
+        return genre_index
+
+    _TOP = [
+        ("k-pop", 30), ("kpop", 20), ("korean pop", 15), ("rock", 8), ("jazz", 5),
+    ]
+
+    @pytest.mark.asyncio
+    @patch("services.discover.homepage_service.build_similar_artist_pools")
+    async def test_one_family_gets_at_most_two_clusters(self, mock_pools: AsyncMock) -> None:
+        mock_pools.return_value = []
+        genre_index = self._genre_index(self._TOP)
+        service = _make_homepage_service(genre_index=genre_index)
+        # no memory cache -> no daily-mix cache read/write; library albums empty ->
+        # sections need pool items, so give every cluster one album
+        from api.v1.schemas.discover import DiscoverQueueItemLight
+        mock_pools.return_value = [[
+            DiscoverQueueItemLight(
+                release_group_mbid="rg-1", album_name="A", artist_name="B",
+                artist_mbid="m-1", recommendation_reason="r",
+            )
+        ]]
+
+        sections = await service._build_daily_mix_sections("u1", "listenbrainz", set())
+        families = [
+            genre_family(section.title.split(" - ", 1)[1].lower()) for section in sections
+        ]
+        assert families.count("k-pop") <= 2
+        assert "rock" in families and "jazz" in families
+
+    @pytest.mark.asyncio
+    @patch("services.discover.homepage_service.build_similar_artist_pools")
+    async def test_muted_family_gets_no_cluster(self, mock_pools: AsyncMock) -> None:
+        from api.v1.schemas.discover import DiscoverQueueItemLight
+        mock_pools.return_value = [[
+            DiscoverQueueItemLight(
+                release_group_mbid="rg-1", album_name="A", artist_name="B",
+                artist_mbid="m-1", recommendation_reason="r",
+            )
+        ]]
+        prefs_store = AsyncMock()
+        prefs_store.get_levels = AsyncMock(return_value={"k-pop": "mute"})
+        genre_index = self._genre_index(self._TOP)
+        service = _make_homepage_service(
+            genre_index=genre_index, genre_prefs_store=prefs_store
+        )
+
+        sections = await service._build_daily_mix_sections("u1", "listenbrainz", set())
+        assert sections
+        for section in sections:
+            genre_label = section.title.split(" - ", 1)[1].lower()
+            assert genre_family(genre_label) != "k-pop"
+
+
+# ------------------------------------------------------------------ taste graph
+
+
+def _taste_graph_service(
+    artists: list[dict],
+    genres: dict[str, list[str]],
+    levels: dict[str, str] | None = None,
+) -> TasteGraphService:
+    library_db = AsyncMock()
+    library_db.get_artists = AsyncMock(return_value=artists)
+    library_db.get_all_albums_for_matching = AsyncMock(return_value=[])
+    library_db.get_all_album_mbids = AsyncMock(return_value=set())
+    follow_store = AsyncMock()
+    follow_store.list_followed_artists = AsyncMock(return_value=[])
+    play_history = AsyncMock()
+    play_history.recent = AsyncMock(return_value=[])
+    mb_repo = AsyncMock()
+    mb_repo.get_artist_expansion = AsyncMock(return_value={})
+    genre_index = AsyncMock()
+    genre_index.get_genres_for_artists = AsyncMock(return_value=genres)
+    prefs_store = AsyncMock()
+    prefs_store.get_levels = AsyncMock(return_value=levels or {})
+    return TasteGraphService(
+        library_db=library_db,
+        follow_store=follow_store,
+        play_history_store=play_history,
+        mb_repo=mb_repo,
+        cache=InMemoryCache(max_entries=100),
+        genre_index=genre_index,
+        genre_prefs_store=prefs_store,
+    )
+
+
+class TestTasteGraphSeedBalance:
+    @staticmethod
+    def _skewed_library() -> tuple[list[dict], dict[str, list[str]]]:
+        artists = [{"mbid": f"k{i}", "name": f"KArtist {i}"} for i in range(12)]
+        artists += [{"mbid": "r1", "name": "Rock One"}, {"mbid": "r2", "name": "Rock Two"}]
+        genres = {f"k{i}": ["kpop"] for i in range(12)}
+        genres["r1"] = ["rock"]
+        genres["r2"] = ["rock"]
+        return artists, genres
+
+    @pytest.mark.asyncio
+    async def test_minority_families_reach_the_seed_set(self) -> None:
+        artists, genres = self._skewed_library()
+        service = _taste_graph_service(artists, genres)
+        result = await service.get_taste_graph("u1")
+        seed_mbids = {s.artist_mbid for s in result.seeds}
+        # raw top-10-by-weight would be K-pop only; balanced seeding pulls rock in
+        assert {"r1", "r2"} <= seed_mbids
+
+    @pytest.mark.asyncio
+    async def test_muted_family_never_seeds(self) -> None:
+        artists, genres = self._skewed_library()
+        service = _taste_graph_service(artists, genres, levels={"k-pop": "mute"})
+        result = await service.get_taste_graph("u1")
+        seed_mbids = {s.artist_mbid for s in result.seeds}
+        assert seed_mbids == {"r1", "r2"}

--- a/backend/tests/services/test_taste_graph_service.py
+++ b/backend/tests/services/test_taste_graph_service.py
@@ -1,0 +1,230 @@
+"""TasteGraphService — seeds weighted from the user's own signals only,
+expanded through MusicBrainz relations/labels/tags, with novelty + diversity."""
+
+import pytest
+from unittest.mock import AsyncMock
+
+from infrastructure.cache.memory_cache import InMemoryCache
+from infrastructure.persistence.follow_store import FollowedArtist
+from infrastructure.persistence.play_history_store import PlayHistoryRecord
+from models.search import SearchResult
+from services.taste_graph_service import TasteGraphService
+
+_SEED_A = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_SEED_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_FOLLOWED = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+
+def _followed(mbid: str, name: str) -> FollowedArtist:
+    return FollowedArtist(
+        artist_mbid=mbid,
+        artist_name=name,
+        auto_download=False,
+        auto_download_state="none",
+        followed_at=1000.0,
+    )
+
+
+def _play(artist_name: str, i: int) -> PlayHistoryRecord:
+    return PlayHistoryRecord(
+        id=f"play-{artist_name}-{i}",
+        user_id="u1",
+        track_name=f"Track {i}",
+        artist_name=artist_name,
+        played_at=f"2026-07-0{(i % 9) + 1}T00:00:00Z",
+    )
+
+
+def _library_db(artists=(), albums_for_matching=(), album_mbids=()):
+    db = AsyncMock()
+    db.get_artists = AsyncMock(return_value=list(artists))
+    db.get_all_albums_for_matching = AsyncMock(return_value=list(albums_for_matching))
+    db.get_all_album_mbids = AsyncMock(return_value=set(album_mbids))
+    return db
+
+
+def _mb_repo(expansions=None, label_releases=None, tag_results=None):
+    repo = AsyncMock()
+    repo.get_artist_expansion = AsyncMock(
+        side_effect=lambda mbid: (expansions or {}).get(mbid)
+    )
+    repo.get_label_releases = AsyncMock(
+        side_effect=lambda label_mbid, limit=25: (label_releases or {}).get(label_mbid, [])
+    )
+    repo.search_release_groups_by_tag = AsyncMock(
+        side_effect=lambda tag, limit=15: (tag_results or {}).get(tag, [])
+    )
+    return repo
+
+
+def _service(library_db=None, followed=(), plays=(), mb_repo=None):
+    follow_store = AsyncMock()
+    follow_store.list_followed_artists = AsyncMock(return_value=list(followed))
+    play_history = AsyncMock()
+    play_history.recent = AsyncMock(return_value=list(plays))
+    return TasteGraphService(
+        library_db=library_db or _library_db(),
+        follow_store=follow_store,
+        play_history_store=play_history,
+        mb_repo=mb_repo or _mb_repo(),
+        cache=InMemoryCache(max_entries=100),
+    )
+
+
+class TestColdStart:
+    @pytest.mark.asyncio
+    async def test_empty_everything_is_graceful_cold_start(self):
+        service = _service()
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is True
+        assert result.seeds == []
+        assert result.items == []
+        assert result.generated_at
+
+
+class TestSeedWeighting:
+    @pytest.mark.asyncio
+    async def test_followed_outweighs_played_outweighs_library(self):
+        library_db = _library_db(
+            artists=[
+                {"mbid": _SEED_A, "name": "Library Only"},
+                {"mbid": _SEED_B, "name": "Library Played"},
+            ],
+        )
+        service = _service(
+            library_db=library_db,
+            followed=[_followed(_FOLLOWED, "Followed Artist")],
+            plays=[_play("Library Played", i) for i in range(5)],
+        )
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is False
+        ordered = [s.artist_mbid for s in result.seeds]
+        assert ordered == [_FOLLOWED, _SEED_B, _SEED_A]
+        assert result.seeds[0].weight == 1.0  # normalized to the top seed
+
+
+class TestExpansion:
+    @pytest.mark.asyncio
+    async def test_member_collab_label_scene_candidates(self):
+        expansions = {
+            _SEED_A: {
+                "tags": [{"name": "shoegaze", "count": 5}],
+                "relations": [
+                    {
+                        "type": "member of band",
+                        "artist": {"id": "member-1", "name": "New Member"},
+                    },
+                    {
+                        "type": "collaboration",
+                        "artist": {"id": "collab-1", "name": "New Collaborator"},
+                    },
+                    {
+                        # novelty: already in library, must be filtered out
+                        "type": "member of band",
+                        "artist": {"id": _SEED_B, "name": "Library Played"},
+                    },
+                ],
+            },
+            _SEED_B: {
+                "tags": [],
+                "relations": [
+                    {
+                        "type": "recording contract",
+                        "label": {"id": "label-1", "name": "Test Label"},
+                    },
+                ],
+            },
+        }
+        label_releases = {
+            "label-1": [
+                {
+                    "title": "Label Album",
+                    "release-group": {"id": "rg-label-1", "title": "Label Album"},
+                    "artist-credit": [
+                        {"name": "Label Mate", "artist": {"id": "mate-1", "name": "Label Mate"}}
+                    ],
+                }
+            ]
+        }
+        tag_results = {
+            "shoegaze": [
+                SearchResult(
+                    type="album",
+                    title="Scene Album",
+                    musicbrainz_id="rg-scene-1",
+                    artist="Scene Artist",
+                )
+            ]
+        }
+        library_db = _library_db(
+            artists=[
+                {"mbid": _SEED_A, "name": "Seed Artist"},
+                {"mbid": _SEED_B, "name": "Library Played"},
+            ],
+        )
+        service = _service(
+            library_db=library_db,
+            mb_repo=_mb_repo(expansions, label_releases, tag_results),
+        )
+        result = await service.get_taste_graph("u1")
+
+        by_mbid = {i.mbid: i for i in result.items}
+        assert _SEED_B not in by_mbid  # novelty filter
+        assert by_mbid["member-1"].kind == "artist"
+        assert by_mbid["member-1"].reasons[0].type == "member"
+        assert by_mbid["member-1"].reasons[0].via_mbid == _SEED_A
+        assert by_mbid["collab-1"].reasons[0].type == "collaborator"
+        assert by_mbid["rg-label-1"].kind == "album"
+        assert by_mbid["rg-label-1"].artist_mbid == "mate-1"
+        assert by_mbid["rg-label-1"].reasons[0].type == "label"
+        assert by_mbid["rg-label-1"].reasons[0].via_name == "Test Label"
+        assert by_mbid["rg-scene-1"].reasons[0].type == "scene"
+        assert by_mbid["rg-scene-1"].reasons[0].via_name == "shoegaze"
+        # member/collab outrank label-mates which outrank scene matches
+        assert by_mbid["member-1"].score > by_mbid["rg-label-1"].score > by_mbid["rg-scene-1"].score
+        assert all(i.in_library is False for i in result.items)
+        assert len(result.items) <= 30
+
+    @pytest.mark.asyncio
+    async def test_per_seed_diversity_cap(self):
+        expansions = {
+            _SEED_A: {
+                "tags": [],
+                "relations": [
+                    {"type": "member of band", "artist": {"id": f"m-{i}", "name": f"M {i}"}}
+                    for i in range(6)
+                ],
+            },
+        }
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        service = _service(library_db=library_db, mb_repo=_mb_repo(expansions))
+        result = await service.get_taste_graph("u1")
+        assert len(result.items) == 3  # max 3 candidates per seed
+
+    @pytest.mark.asyncio
+    async def test_graph_is_cached_per_user(self):
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        mb_repo = _mb_repo({
+            _SEED_A: {
+                "tags": [],
+                "relations": [
+                    {"type": "member of band", "artist": {"id": "m-1", "name": "M 1"}}
+                ],
+            }
+        })
+        service = _service(library_db=library_db, mb_repo=mb_repo)
+        first = await service.get_taste_graph("u1")
+        second = await service.get_taste_graph("u1")
+        assert first == second
+        mb_repo.get_artist_expansion.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mb_failure_degrades_without_500(self):
+        library_db = _library_db(artists=[{"mbid": _SEED_A, "name": "Seed Artist"}])
+        mb_repo = AsyncMock()
+        mb_repo.get_artist_expansion = AsyncMock(side_effect=RuntimeError("mb down"))
+        service = _service(library_db=library_db, mb_repo=mb_repo)
+        result = await service.get_taste_graph("u1")
+        assert result.cold_start is False
+        assert result.items == []
+        assert [s.artist_mbid for s in result.seeds] == [_SEED_A]

--- a/backend/tests/services/test_top_picks.py
+++ b/backend/tests/services/test_top_picks.py
@@ -141,6 +141,7 @@ def _svc() -> DiscoverHomepageService:
     svc._memory_cache = None
     svc._mbid_store = None
     svc._genre_index = None
+    svc._genre_prefs_store = None
     svc._library_db = None
     svc._follow_service = None
     svc._integration = MagicMock()

--- a/backend/tests/test_discover_home_peruser.py
+++ b/backend/tests/test_discover_home_peruser.py
@@ -256,6 +256,9 @@ async def test_seed_artists_fall_back_to_broader_ranges():
 
     svc = DiscoverHomepageService.__new__(DiscoverHomepageService)
     svc._lfm_repo = None
+    # no genre index in this test: seed selection keeps the original tight target
+    svc._genre_index = None
+    svc._genre_prefs_store = None
 
     seed = ListenBrainzArtist(artist_name="A", listen_count=5, artist_mbids=["mbid-1"])
 
@@ -360,9 +363,20 @@ def _miss_service(built_at: dict):
     svc._integration = MagicMock()
     svc._integration.get_discover_cache_key.return_value = "discover_response:u1:True:False"
     svc._integration.get_integration_status.return_value = MagicMock()
+    svc._integration.is_jellyfin_enabled.return_value = False
+    svc._integration.is_library_configured.return_value = False
     svc._build_service_prompts = MagicMock(return_value=[])
     svc._trigger_warm = MagicMock()
     svc._built_at = built_at
+    # collaborators the cold-path quick response (library-derived zones) touches
+    svc._disk_cache = None
+    svc._disk_checked = set()
+    svc._mbid = MagicMock()
+    svc._mbid.get_library_artist_mbids = AsyncMock(return_value=set())
+    svc._library_db = None
+    svc._follow_service = None
+    svc._transformers = MagicMock()
+    svc._transformers.extract_genres_from_library.return_value = []
     return svc
 
 

--- a/frontend/src/lib/components/discover/TasteGraphZone.svelte
+++ b/frontend/src/lib/components/discover/TasteGraphZone.svelte
@@ -1,0 +1,141 @@
+<script lang="ts">
+	/*
+	 * TasteGraphZone — recommendations grown from the user's own collection via
+	 * canonical MusicBrainz relationships (collaborators, members, labels,
+	 * scenes). No charts, no crowds. Old backends lack the route, so any fetch
+	 * error settles into the same quiet invitation panel as a cold start.
+	 */
+	import { Network, Check } from 'lucide-svelte';
+	import { integrationStore } from '$lib/stores/integration';
+	import AlbumImage from '$lib/components/AlbumImage.svelte';
+	import ArtistImage from '$lib/components/ArtistImage.svelte';
+	import AlbumRequestButton from '$lib/components/AlbumRequestButton.svelte';
+	import RadioPlayButton from '$lib/components/discover/RadioPlayButton.svelte';
+	import { getTasteGraphQuery } from '$lib/queries/discover/TasteGraphQuery.svelte';
+
+	const tasteGraphQuery = getTasteGraphQuery();
+	const data = $derived(tasteGraphQuery.data ?? null);
+	const loading = $derived(tasteGraphQuery.isLoading);
+	// error (incl. 404 from old backends) and cold start share the invitation panel
+	const showInvitation = $derived(
+		!!tasteGraphQuery.error || (!!data && (data.cold_start || data.items.length === 0))
+	);
+</script>
+
+<section aria-label="Your taste graph">
+	<h3
+		class="mb-1 flex items-center gap-2.5 font-mono text-[0.68rem] font-bold uppercase tracking-[0.2em] text-base-content/50"
+	>
+		<Network class="h-4 w-4 text-accent" />
+		Your Taste Graph
+	</h3>
+	<p class="mb-5 text-xs text-base-content/50">
+		Grown from your collection and canonical MusicBrainz relationships — no charts, no crowds.
+	</p>
+
+	{#if loading}
+		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+			{#each Array(10) as _, i (`taste-graph-skeleton-${i}`)}
+				<div class="rounded-2xl border border-base-content/8 bg-base-200/50 p-3">
+					<div class="skeleton skeleton-shimmer aspect-square w-full rounded-xl"></div>
+					<div class="skeleton skeleton-shimmer mt-3 h-4 w-3/4"></div>
+					<div class="skeleton skeleton-shimmer mt-2 h-3 w-1/2"></div>
+				</div>
+			{/each}
+		</div>
+	{:else if showInvitation}
+		<div
+			class="flex flex-col items-center rounded-2xl border border-dashed border-base-content/12 px-6 py-10 text-center"
+		>
+			<Network class="mb-3 h-8 w-8 text-base-content/40" />
+			<p class="max-w-md text-sm text-base-content/60">
+				The graph grows from your music — scan your library or follow artists and check back.
+			</p>
+		</div>
+	{:else if data}
+		{#if data.seeds.length > 0}
+			<div class="mb-5 flex flex-wrap items-center gap-2">
+				<span
+					class="font-mono text-[0.62rem] font-bold uppercase tracking-[0.2em] text-base-content/40"
+					>Seeded by:</span
+				>
+				{#each data.seeds as seed (seed.artist_mbid)}
+					<span
+						class="rounded-full border border-base-content/10 px-2.5 py-0.5 text-xs text-base-content/60"
+						>{seed.name}</span
+					>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+			{#each data.items as item (`${item.kind}-${item.mbid}`)}
+				<div
+					class="group flex flex-col rounded-2xl border border-base-content/8 bg-base-200/50 p-3 transition-colors hover:border-primary/30"
+				>
+					<a
+						href={item.kind === 'album' ? `/album/${item.mbid}` : `/artist/${item.mbid}`}
+						data-sveltekit-preload-data="hover"
+						class="min-w-0"
+					>
+						<div class="aspect-square w-full overflow-hidden rounded-xl">
+							{#if item.kind === 'album'}
+								<AlbumImage mbid={item.mbid} alt={item.name} size="md" className="h-full w-full" />
+							{:else}
+								<ArtistImage
+									mbid={item.mbid}
+									alt={item.name}
+									size="md"
+									rounded="lg"
+									className="h-full w-full"
+								/>
+							{/if}
+						</div>
+						<h4 class="mt-3 truncate font-display text-sm font-semibold tracking-tight">
+							{item.name}
+						</h4>
+						{#if item.kind === 'album' && item.artist_name}
+							<p class="mt-0.5 truncate text-xs text-base-content/50">{item.artist_name}</p>
+						{/if}
+					</a>
+
+					{#if item.reasons.length > 0 || item.in_library}
+						<div class="mt-2 flex flex-wrap gap-1">
+							{#if item.in_library}
+								<span
+									class="inline-flex items-center gap-1 rounded-full bg-accent/15 px-2 py-0.5 font-mono text-[0.55rem] font-bold uppercase tracking-[0.15em] text-accent"
+								>
+									<Check class="h-2.5 w-2.5" />
+									In collection
+								</span>
+							{/if}
+							{#each item.reasons as reason, i (`${item.mbid}-reason-${i}`)}
+								<span
+									class="rounded-full border border-base-content/10 px-2 py-0.5 font-mono text-[0.55rem] font-bold uppercase tracking-[0.15em] text-base-content/50"
+									>{reason.label}</span
+								>
+							{/each}
+						</div>
+					{/if}
+
+					<div class="mt-auto flex items-center justify-end gap-2 pt-2">
+						{#if item.kind === 'artist'}
+							<RadioPlayButton
+								seed={{ seed_type: 'artist', seed_id: item.mbid }}
+								size="sm"
+								label=""
+							/>
+						{:else if !item.in_library && $integrationStore.download_client}
+							<AlbumRequestButton
+								mbid={item.mbid}
+								artistName={item.artist_name ?? ''}
+								albumName={item.name}
+								artistMbid={item.artist_mbid ?? undefined}
+							/>
+						{/if}
+					</div>
+				</div>
+			{/each}
+		</div>
+	{/if}
+</section>

--- a/frontend/src/lib/components/settings/SettingsDiscover.svelte
+++ b/frontend/src/lib/components/settings/SettingsDiscover.svelte
@@ -1,9 +1,14 @@
 <script lang="ts">
 	import SectionPrefsManager from './SectionPrefsManager.svelte';
+	import SettingsGenreBalance from './SettingsGenreBalance.svelte';
 </script>
 
-<SectionPrefsManager
-	page="discover"
-	title="Discover"
-	description="Pick which discovery sections appear on your Discover page. Changes save automatically and only affect your account."
-/>
+<div class="space-y-6">
+	<SectionPrefsManager
+		page="discover"
+		title="Discover"
+		description="Pick which discovery sections appear on your Discover page. Changes save automatically and only affect your account."
+	/>
+
+	<SettingsGenreBalance />
+</div>

--- a/frontend/src/lib/components/settings/SettingsGenreBalance.svelte
+++ b/frontend/src/lib/components/settings/SettingsGenreBalance.svelte
@@ -1,0 +1,163 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import { Check } from 'lucide-svelte';
+	import type { GenrePrefItem, GenrePrefLevel } from '$lib/types';
+	import {
+		getGenrePrefsQuery,
+		saveGenrePrefs
+	} from '$lib/queries/genre-prefs/GenrePrefsQuery.svelte';
+	import { toastStore } from '$lib/stores/toast';
+
+	const prefsQuery = getGenrePrefsQuery();
+
+	const LEVELS: { value: GenrePrefLevel; label: string }[] = [
+		{ value: 'normal', label: 'Normal' },
+		{ value: 'reduce', label: 'Reduce' },
+		{ value: 'mute', label: 'Mute' }
+	];
+
+	// local working copy so level changes apply instantly; server state re-syncs it
+	let genres = $state<GenrePrefItem[]>([]);
+	let loaded = $state(false);
+	let saveTimer: ReturnType<typeof setTimeout> | null = null;
+	let saving = $state(false);
+	let savedFlash = $state(false);
+	let savedFlashTimer: ReturnType<typeof setTimeout> | null = null;
+
+	$effect(() => {
+		const serverGenres = prefsQuery.data?.genres;
+		// adopt server state on first load, but never mid-edit
+		if (serverGenres && !loaded && !saveTimer && !saving) {
+			genres = serverGenres.map((g) => ({ ...g }));
+			loaded = true;
+		}
+	});
+
+	const adjustedCount = $derived(genres.filter((g) => g.level !== 'normal').length);
+
+	function scheduleSave() {
+		if (saveTimer) clearTimeout(saveTimer);
+		saveTimer = setTimeout(() => void flushSave(), 600);
+	}
+
+	async function flushSave() {
+		saveTimer = null;
+		saving = true;
+		try {
+			await saveGenrePrefs({
+				genres: genres.map((g) => ({ family: g.family, level: g.level }))
+			});
+			savedFlash = true;
+			if (savedFlashTimer) clearTimeout(savedFlashTimer);
+			savedFlashTimer = setTimeout(() => (savedFlash = false), 1500);
+		} catch {
+			toastStore.show({ message: "Couldn't save your genre balance", type: 'error' });
+			// revert to server truth
+			loaded = false;
+			await prefsQuery.refetch();
+		} finally {
+			saving = false;
+		}
+	}
+
+	function setLevel(family: string, level: GenrePrefLevel) {
+		genres = genres.map((g) => (g.family === family ? { ...g, level } : g));
+		scheduleSave();
+	}
+
+	onDestroy(() => {
+		if (saveTimer) {
+			clearTimeout(saveTimer);
+			void flushSave();
+		}
+		if (savedFlashTimer) clearTimeout(savedFlashTimer);
+	});
+</script>
+
+<div class="card bg-base-200">
+	<div class="card-body">
+		<div class="flex items-start justify-between gap-3">
+			<div>
+				<h2 class="card-title text-2xl">Genre balance</h2>
+				<p class="text-base-content/70">
+					Keep one genre from dominating your recommendations. Reduce halves a genre's weight in
+					Discover and the Taste Graph; Mute removes it entirely. Your library and listening history
+					are unaffected.
+				</p>
+			</div>
+			<div
+				class="flex items-center gap-1.5 text-xs text-success transition-opacity duration-300"
+				class:opacity-0={!savedFlash}
+				aria-hidden={!savedFlash}
+			>
+				<Check class="h-3.5 w-3.5" />
+				Saved
+			</div>
+		</div>
+
+		{#if prefsQuery.isLoading && genres.length === 0}
+			<div class="flex justify-center items-center py-12">
+				<span class="loading loading-spinner loading-lg"></span>
+			</div>
+		{:else if prefsQuery.isError && genres.length === 0}
+			<div class="alert alert-error mt-4">
+				<span>Couldn't load your genre balance settings.</span>
+				<button class="btn btn-sm" onclick={() => prefsQuery.refetch()}>Retry</button>
+			</div>
+		{:else if genres.length === 0}
+			<p class="mt-4 text-sm text-base-content/50">
+				No genres found yet - genres appear here once your library has been scanned.
+			</p>
+		{:else}
+			<p class="px-1 pt-2 text-xs text-base-content/50">
+				{adjustedCount === 0
+					? 'All genres at normal weight'
+					: `${adjustedCount} ${adjustedCount === 1 ? 'genre' : 'genres'} adjusted`}
+			</p>
+			<div class="mt-2 divide-y divide-base-content/5 rounded-xl bg-base-100/40">
+				{#each genres as genre (genre.family)}
+					<div class="flex items-center justify-between gap-4 px-4 py-3">
+						<div class="min-w-0 flex-1">
+							<span
+								class="font-medium {genre.level === 'mute'
+									? 'text-base-content/40 line-through'
+									: ''}"
+							>
+								{genre.label}
+							</span>
+							{#if genre.artist_count > 0}
+								<p class="text-xs text-base-content/50">
+									{genre.artist_count}
+									{genre.artist_count === 1 ? 'artist' : 'artists'} in your library
+								</p>
+							{/if}
+						</div>
+						<div
+							class="join shrink-0"
+							role="radiogroup"
+							aria-label="Balance level for {genre.label}"
+						>
+							{#each LEVELS as option (option.value)}
+								<button
+									type="button"
+									role="radio"
+									aria-checked={genre.level === option.value}
+									class="btn btn-xs join-item {genre.level === option.value
+										? option.value === 'mute'
+											? 'btn-error'
+											: option.value === 'reduce'
+												? 'btn-warning'
+												: 'btn-primary'
+										: 'btn-ghost bg-base-100/60'}"
+									onclick={() => setLevel(genre.family, option.value)}
+								>
+									{option.label}
+								</button>
+							{/each}
+						</div>
+					</div>
+				{/each}
+			</div>
+		{/if}
+	</div>
+</div>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -254,6 +254,7 @@ export const API = {
 		`/api/v1/discover/album-preview?artist=${encodeURIComponent(artist)}&album=${encodeURIComponent(album)}`,
 	discoverPlaylistSuggestions: () => '/api/v1/discover/playlist-suggestions',
 	discoverGenreDetail: (tag: string) => `/api/v1/discover/genres/${encodeURIComponent(tag)}`,
+	discoverTasteGraph: () => '/api/v1/discover/taste-graph',
 	youtube: {
 		generate: () => '/api/v1/youtube/generate',
 		link: (albumId: string) => `/api/v1/youtube/link/${albumId}`,

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -299,6 +299,7 @@ export const API = {
 		connection: (service: string) => `/api/v1/me/connections/${service}`,
 		scrobblePreferences: () => '/api/v1/me/scrobble-preferences',
 		sectionPrefs: () => '/api/v1/me/section-prefs',
+		genrePrefs: () => '/api/v1/me/genre-prefs',
 		lastfmAuthToken: () => '/api/v1/me/connections/lastfm/auth/token',
 		lastfmAuthSession: () => '/api/v1/me/connections/lastfm/auth/session',
 		listenbrainz: () => '/api/v1/me/connections/listenbrainz',

--- a/frontend/src/lib/queries/discover/DiscoverQuery.svelte.ts
+++ b/frontend/src/lib/queries/discover/DiscoverQuery.svelte.ts
@@ -41,13 +41,17 @@ export const getDiscoverQueryOptions = (userId: string | null | undefined) =>
 		queryFn: ({ signal }) => fetchDiscover(userId, signal)
 	});
 
+// While the backend is still building (`refreshing === true`), poll gently so the page
+// fills in zone-by-zone as the background build completes; stop as soon as it settles.
+const DISCOVER_REFRESHING_POLL_MS = 8_000;
+
 export const getDiscoverQuery = () =>
 	createQuery(() => ({
 		staleTime: DISCOVER_REVALIDATE_MS,
 		queryKey: DiscoverQueryKeyFactory.discover(authStore.user?.id),
 		queryFn: ({ signal }) => fetchDiscover(authStore.user?.id, signal),
 		refetchInterval: (query: { state: { data?: DiscoverResponse | undefined } }) =>
-			query.state.data?.refreshing ? 3000 : false
+			query.state.data?.refreshing ? DISCOVER_REFRESHING_POLL_MS : false
 	}));
 
 export const getRadioQuery = (getParams: Getter<{ seedType: string; seedId: string }>) =>

--- a/frontend/src/lib/queries/discover/TasteGraphQuery.svelte.ts
+++ b/frontend/src/lib/queries/discover/TasteGraphQuery.svelte.ts
@@ -1,0 +1,57 @@
+import { api } from '$lib/api/client';
+import { API } from '$lib/constants';
+import { authStore } from '$lib/stores/authStore.svelte';
+import { createQuery } from '@tanstack/svelte-query';
+import { DiscoverQueryKeyFactory } from './DiscoverQueryKeyFactory';
+
+export interface TasteGraphReason {
+	type: 'collaborator' | 'member' | 'label' | 'scene';
+	label: string;
+	via_mbid?: string | null;
+	via_name?: string | null;
+}
+
+export interface TasteGraphSeed {
+	artist_mbid: string;
+	name: string;
+	weight: number;
+}
+
+export interface TasteGraphItem {
+	kind: 'artist' | 'album';
+	mbid: string;
+	name: string;
+	artist_mbid?: string | null;
+	artist_name?: string | null;
+	score: number;
+	reasons: TasteGraphReason[];
+	in_library: boolean;
+}
+
+export interface TasteGraphResponse {
+	cold_start: boolean;
+	generated_at: string;
+	seeds: TasteGraphSeed[];
+	items: TasteGraphItem[];
+}
+
+// The graph is rebuilt server-side on library changes at a slow cadence, so a
+// long client staleTime is fine. retry: false — old backends lack the route and
+// a 404 should settle into the quiet invitation state immediately. Focus refetch
+// is off: an errored query is permanently stale, so a missing route would
+// otherwise re-404 on every tab focus.
+const TASTE_GRAPH_STALE_MS = 24 * 60 * 60 * 1000;
+
+export const getTasteGraphQuery = () =>
+	createQuery(() => ({
+		staleTime: TASTE_GRAPH_STALE_MS,
+		retry: false,
+		refetchOnWindowFocus: false,
+		queryKey: [
+			...DiscoverQueryKeyFactory.prefix,
+			authStore.user?.id ?? null,
+			'taste-graph'
+		] as const,
+		queryFn: ({ signal }) =>
+			api.global.get<TasteGraphResponse>(API.discoverTasteGraph(), { signal })
+	}));

--- a/frontend/src/lib/queries/genre-prefs/GenrePrefsQuery.svelte.ts
+++ b/frontend/src/lib/queries/genre-prefs/GenrePrefsQuery.svelte.ts
@@ -1,0 +1,31 @@
+import { api } from '$lib/api/client';
+import { API } from '$lib/constants';
+import { authStore } from '$lib/stores/authStore.svelte';
+import type { GenrePrefsResponse, GenrePrefsUpdate } from '$lib/types';
+import { createQuery } from '@tanstack/svelte-query';
+import { DiscoverQueryKeyFactory } from '$lib/queries/discover/DiscoverQueryKeyFactory';
+import {
+	invalidateQueriesWithPersister,
+	setQueryDataWithPersister
+} from '$lib/queries/QueryClient';
+import { GenrePrefsQueryKeyFactory } from './GenrePrefsQueryKeyFactory';
+
+export const getGenrePrefsQuery = () =>
+	createQuery(() => ({
+		staleTime: 60_000,
+		queryKey: GenrePrefsQueryKeyFactory.prefs(authStore.user?.id),
+		queryFn: ({ signal }) => api.global.get<GenrePrefsResponse>(API.me.genrePrefs(), { signal })
+	}));
+
+/** Save the user's genre balance levels; refreshes the prefs cache and
+ * invalidates the Discover data (incl. the taste graph) since the backend
+ * rebuilds recommendations with the new levels. */
+export async function saveGenrePrefs(update: GenrePrefsUpdate): Promise<void> {
+	const saved = await api.global.put<GenrePrefsResponse>(API.me.genrePrefs(), update);
+	const userId = authStore.user?.id;
+	await setQueryDataWithPersister<GenrePrefsResponse>(
+		GenrePrefsQueryKeyFactory.prefs(userId),
+		() => saved
+	);
+	await invalidateQueriesWithPersister({ queryKey: DiscoverQueryKeyFactory.prefix });
+}

--- a/frontend/src/lib/queries/genre-prefs/GenrePrefsQueryKeyFactory.ts
+++ b/frontend/src/lib/queries/genre-prefs/GenrePrefsQueryKeyFactory.ts
@@ -1,0 +1,7 @@
+export const GenrePrefsQueryKeyFactory = {
+	prefix: ['genre-prefs'] as const,
+	// userId dimension: prefs are per-user and the cache persists across refreshes
+	// on shared browsers.
+	prefs: (userId: string | null | undefined) =>
+		[...GenrePrefsQueryKeyFactory.prefix, userId ?? null] as const
+};

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -2105,6 +2105,23 @@ export interface SectionPrefsUpdate {
 	sections: { key: string; enabled: boolean }[];
 }
 
+export type GenrePrefLevel = 'normal' | 'reduce' | 'mute';
+
+export interface GenrePrefItem {
+	family: string;
+	label: string;
+	artist_count: number;
+	level: GenrePrefLevel;
+}
+
+export interface GenrePrefsResponse {
+	genres: GenrePrefItem[];
+}
+
+export interface GenrePrefsUpdate {
+	genres: { family: string; level: GenrePrefLevel }[];
+}
+
 export interface PreviewTrackItem {
 	title: string;
 	artist_name: string;


### PR DESCRIPTION
**Stacked on #169 (discover perf) and #162 (taste graph)** - it wires the `genre_prefs_store` both of those left unwired and uses #162's taste-graph cache key for invalidation. Until they merge, this PR shows their commits too - review the last commit.

## What

Genre balancing becomes user-controllable:

- `UserGenrePrefsStore` (library DB): per-user genre-family levels - `normal` / `reduce` (halved weight) / `mute` (excluded)
- `GET/PUT /api/v1/me/genre-prefs`: the user's library genre FAMILIES ("k-pop" + "korean pop" + "kpop" count as one) with artist counts and current level; stored families no longer in the library stay listed so a mute can always be undone
- The balance engine from #169 (`services/discover/genre_balance.py`) now honors those levels everywhere it runs: seed selection, daily-mix cluster seeding (max 2 clusters per family, sqrt-damped), Top Picks zone cap, and the page-wide ~40% family share cap; a muted seed family takes its whole "Because You Listen To" rail with it
- Taste graph (#162) honors reduce/mute in candidate scoring
- Saving prefs invalidates the per-user recommendation caches (taste graph, daily mixes, top picks) and kicks a background Discover rebuild, so changes show on the next page load
- Settings UI: `SettingsGenreBalance.svelte` on the Discover settings tab - per-family Normal/Reduce/Mute toggles with artist counts

## Why

A 40% K-pop library previously produced a 90% K-pop Discover page. Automatic capping (in #169) fixes the default; this PR lets the listener say "less of this, none of that" per genre family.

## How tested

`tests/routes/test_genre_prefs_routes.py` + `tests/services/test_genre_balance.py` - **26 passed** (Windows, Python 3.13): family merging, level persistence, cap math (per-zone and page-wide), mute/reduce semantics in seeds/clusters/top-picks, cache invalidation, route validation (422 on unknown family).
