### PR TITLE
fix(radio): library-first station plans + honest thin-queue feedback

### DIFF
--- a/backend/services/discover/radio_plan_service.py
+++ b/backend/services/discover/radio_plan_service.py
@@ -34,6 +34,10 @@ _FAST_SEED_ARTISTS = 2
 _TRACKS_PER_ARTIST_EXTERNAL = 5
 _MAX_PER_ARTIST = 4
 _MAX_CONSECUTIVE_SAME_ARTIST = 2
+# library-first pool depth: caps below keep the IN(...) placeholder count safe
+# (mbids are bound twice in get_files_by_artist_mbids; SQLite default cap is 999)
+_MAX_POOL_ARTISTS = 300
+_ADJACENT_GENRES = 6
 
 
 class RadioPlanService:
@@ -55,18 +59,32 @@ class RadioPlanService:
         self._lfm_repo = lfm_repo
         self._preview_repo = preview_repo
 
-    async def build_plan(self, user_id: str, request: RadioPlanRequest) -> RadioPlanResponse:
+    async def build_plan(
+        self, user_id: str, request: RadioPlanRequest, *, max_count: int = 50
+    ) -> RadioPlanResponse:
+        # max_count lets non-radio callers (Smart Mix saved playlists) ask for a
+        # deeper plan than the live-radio default cap of 50
         seeds, title = await self._expand_seeds(user_id, request)
-        if not seeds:
+        # library-mode genre stations can still fill from file-tag genre matches
+        # even when the genre index yields no seed artists - don't bail early
+        library_genre_station = request.mode == "library" and request.seed_type == "genre"
+        if not seeds and not library_genre_station:
             return RadioPlanResponse(title=title, tracks=[])
 
         exclude_recordings = {m.lower() for m in request.exclude_recording_mbids}
-        count = max(5, min(request.count, 50))
+        count = max(5, min(request.count, max_count))
 
         library_pool = await self._library_tracks(seeds, exclude_recordings)
         external_pool: list[RadioPlanTrack] = []
         if request.mode == "hybrid":
             external_pool = await self._external_tracks(seeds, exclude_recordings)
+        elif len(library_pool) < count:
+            # library-first: the seed pool alone is thin (a genre station samples
+            # only a few index artists) - deepen it from the user's own files.
+            # Pure library-DB work: fast, offline, no external calls.
+            library_pool = await self._library_first_pool(
+                request, seeds, library_pool, exclude_recordings, count
+            )
 
         tracks = self._mix(library_pool, external_pool, count, request.mode)
         return RadioPlanResponse(title=title, tracks=tracks)
@@ -195,8 +213,20 @@ class RadioPlanService:
         except Exception as e:  # noqa: BLE001
             logger.debug("Library radio pool failed: %s", e)
             return []
+        return self._rows_to_plan_tracks(rows, exclude_recordings, set())
+
+    @staticmethod
+    def _rows_to_plan_tracks(
+        rows: list[dict[str, Any]],
+        exclude_recordings: set[str],
+        seen_titles: set[str],
+    ) -> list[RadioPlanTrack]:
+        """Convert library_files rows into plan tracks, deduped by artist|title.
+
+        ``seen_titles`` is shared across pools so successive fills never re-add
+        a track already claimed by an earlier pool.
+        """
         tracks: list[RadioPlanTrack] = []
-        seen_titles: set[str] = set()
         for row in rows:
             recording = (row.get("recording_mbid") or "").lower()
             if recording and recording in exclude_recordings:
@@ -218,6 +248,83 @@ class RadioPlanService:
                 duration_s=row.get("duration_seconds"),
             ))
         return tracks
+
+    async def _library_first_pool(
+        self,
+        request: RadioPlanRequest,
+        seeds: list[tuple[str, str]],
+        base_pool: list[RadioPlanTrack],
+        exclude_recordings: set[str],
+        count: int,
+    ) -> list[RadioPlanTrack]:
+        """Deepen a thin library pool from the user's own files (library mode).
+
+        Genre stations pull EVERY library artist tagged with the genre plus
+        file-tag genre matches; artist/album/items stations pull artists
+        adjacent to the seeds through shared library genres. Everything here is
+        local SQLite - no external calls, so it also runs on ``fast`` plans.
+        Seed-artist tracks stay at the head; the widened pool is shuffled so the
+        _mix diversity pass has varied material.
+        """
+        if self._library_db is None:
+            return base_pool
+        seen_titles = {f"{t.artist_name.lower()}|{t.track_name.lower()}" for t in base_pool}
+        extra: list[RadioPlanTrack] = []
+        fetch_limit = max(count * 6, 200)
+        genre = request.seed_id if request.seed_type == "genre" else None
+        seed_mbids = {mbid for mbid, _ in seeds if mbid}
+
+        pool_artist_mbids: list[str] = []
+        if self._genre_index is not None:
+            try:
+                if genre:
+                    by_genre = await self._genre_index.get_artists_for_genres([genre])
+                    pool_artist_mbids = list(by_genre.get(genre.strip().lower(), []))
+                elif seed_mbids:
+                    genres_by_artist = await self._genre_index.get_genres_for_artists(
+                        sorted(seed_mbids)
+                    )
+                    adjacent_genres: list[str] = []
+                    seen_genres: set[str] = set()
+                    for artist_genres in genres_by_artist.values():
+                        for g in artist_genres:
+                            g_lower = g.strip().lower()
+                            if g_lower and g_lower not in seen_genres:
+                                seen_genres.add(g_lower)
+                                adjacent_genres.append(g)
+                    if adjacent_genres:
+                        by_genre = await self._genre_index.get_artists_for_genres(
+                            adjacent_genres[:_ADJACENT_GENRES]
+                        )
+                        seen_mbids: set[str] = set()
+                        for mbids in by_genre.values():
+                            for mbid in mbids:
+                                if mbid not in seen_mbids:
+                                    seen_mbids.add(mbid)
+                                    pool_artist_mbids.append(mbid)
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Library-first adjacency lookup failed: %s", e)
+
+        pool_artist_mbids = [m for m in pool_artist_mbids if m not in seed_mbids]
+        if pool_artist_mbids:
+            try:
+                rows = await self._library_db.get_files_by_artist_mbids(
+                    pool_artist_mbids[:_MAX_POOL_ARTISTS], limit=fetch_limit
+                )
+                extra.extend(self._rows_to_plan_tracks(rows, exclude_recordings, seen_titles))
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Library-first artist pool failed: %s", e)
+
+        # file-tag genre matches catch tracks whose artists never made the index
+        if genre:
+            try:
+                rows = await self._library_db.get_files_by_genre(genre, limit=fetch_limit)
+                extra.extend(self._rows_to_plan_tracks(rows, exclude_recordings, seen_titles))
+            except Exception as e:  # noqa: BLE001
+                logger.debug("Library-first genre pool failed: %s", e)
+
+        random.shuffle(extra)
+        return base_pool + extra
 
     async def _artist_top_tracks(
         self, artist_mbid: str, artist_name: str
@@ -336,4 +443,36 @@ class RadioPlanService:
             per_artist[a_key] = per_artist.get(a_key, 0) + 1
             selected.append(track)
             stall = 0
+
+        if mode == "library" and len(selected) < count:
+            # relaxed fill (library mode only - hybrid stays as before): lift
+            # the per-artist cap (a library with few artists in a genre must
+            # still fill the station) but KEEP the consecutive-same-artist rule
+            # so diversity survives
+            remaining = [
+                t
+                for pool in pools
+                for t in pool
+                if f"{t.artist_name.lower()}|{t.track_name.lower()}" not in seen_keys
+            ]
+            progress = True
+            while len(selected) < count and remaining and progress:
+                progress = False
+                for i, track in enumerate(remaining):
+                    key = f"{track.artist_name.lower()}|{track.track_name.lower()}"
+                    if key in seen_keys:
+                        remaining.pop(i)
+                        progress = True
+                        break
+                    a_key = artist_key(track)
+                    recent = [artist_key(t) for t in selected[-_MAX_CONSECUTIVE_SAME_ARTIST:]]
+                    if len(recent) == _MAX_CONSECUTIVE_SAME_ARTIST and all(
+                        r == a_key for r in recent
+                    ):
+                        continue
+                    seen_keys.add(key)
+                    selected.append(track)
+                    remaining.pop(i)
+                    progress = True
+                    break
         return selected

--- a/backend/tests/services/test_radio_plan_service.py
+++ b/backend/tests/services/test_radio_plan_service.py
@@ -23,8 +23,10 @@ def _svc(**overrides) -> RadioPlanService:
     mbid.normalize_mbid = staticmethod(lambda m: m.lower() if m else None)
     library_db = MagicMock()
     library_db.get_files_by_artist_mbids = AsyncMock(return_value=[])
+    library_db.get_files_by_genre = AsyncMock(return_value=[])
     genre_index = MagicMock()
     genre_index.get_artists_for_genres = AsyncMock(return_value={})
+    genre_index.get_genres_for_artists = AsyncMock(return_value={})
     lfm = MagicMock()
     lfm.get_tag_top_artists = AsyncMock(return_value=[])
     deps = dict(
@@ -184,6 +186,125 @@ class TestPoolsAndMixing:
         req = RadioPlanRequest(seed_type="artist", seed_id="a-0", mode="library", fast=True, count=500)
         resp = await svc.build_plan(_UID, req)
         assert len(resp.tracks) <= 50
+
+
+class TestLibraryFirstFill:
+    """Library-mode stations must fill from the user's own files, never 1 track."""
+
+    @pytest.mark.asyncio
+    async def test_genre_station_fills_from_whole_library_genre(self):
+        # a large library: 20 artists in the genre index, 3 tracks each; the
+        # sampled seeds cover only a couple of them, but the plan must still
+        # reach the requested count from the rest of the library
+        svc = _svc()
+        all_artists = [f"lib-{i}" for i in range(20)]
+        svc._genre_index.get_artists_for_genres = AsyncMock(
+            return_value={"shoegaze": all_artists}
+        )
+
+        async def files_for(mbids, *, limit=50):
+            return [
+                _lib_row(f"{m}-t{j}", f"Artist {m}", m)
+                for m in mbids
+                for j in range(3)
+            ][:limit]
+
+        svc._library_db.get_files_by_artist_mbids = AsyncMock(side_effect=files_for)
+        req = RadioPlanRequest(seed_type="genre", seed_id="shoegaze", mode="library", count=50)
+        resp = await svc.build_plan(_UID, req)
+        assert len(resp.tracks) >= 40
+        assert all(t.in_library for t in resp.tracks)
+
+    @pytest.mark.asyncio
+    async def test_genre_station_fast_mode_also_fills(self):
+        # the fast (first-audio) call is library-DB only, so it gets the same
+        # deep pool - a genre station must never open with a 1-track queue
+        svc = _svc()
+        svc._genre_index.get_artists_for_genres = AsyncMock(
+            return_value={"jazz": [f"lib-{i}" for i in range(12)]}
+        )
+
+        async def files_for(mbids, *, limit=50):
+            return [_lib_row(f"{m}-t{j}", f"Artist {m}", m) for m in mbids for j in range(4)][
+                :limit
+            ]
+
+        svc._library_db.get_files_by_artist_mbids = AsyncMock(side_effect=files_for)
+        req = RadioPlanRequest(seed_type="genre", seed_id="jazz", mode="library", fast=True, count=30)
+        resp = await svc.build_plan(_UID, req)
+        assert len(resp.tracks) >= 20
+
+    @pytest.mark.asyncio
+    async def test_genre_station_uses_file_tag_matches_without_index(self):
+        # genre exists only as file tags (artists never made the genre index)
+        svc = _svc()
+        svc._lfm_repo = None
+        svc._library_db.get_files_by_genre = AsyncMock(
+            return_value=[_lib_row(f"T{i}", f"A{i}", f"a-{i}") for i in range(20)]
+        )
+        req = RadioPlanRequest(seed_type="genre", seed_id="dungeon synth", mode="library", count=20)
+        resp = await svc.build_plan(_UID, req)
+        assert len(resp.tracks) >= 15
+        svc._library_db.get_files_by_genre.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_artist_station_pulls_genre_adjacent_library_artists(self):
+        svc = _svc()
+        svc._genre_index.get_genres_for_artists = AsyncMock(
+            return_value={"seed-1": ["Post-Rock"]}
+        )
+        svc._genre_index.get_artists_for_genres = AsyncMock(
+            return_value={"post-rock": ["seed-1", "adj-1", "adj-2"]}
+        )
+
+        async def files_for(mbids, *, limit=50):
+            return [_lib_row(f"{m}-t{j}", f"Artist {m}", m) for m in mbids for j in range(5)][
+                :limit
+            ]
+
+        svc._library_db.get_files_by_artist_mbids = AsyncMock(side_effect=files_for)
+        req = RadioPlanRequest(seed_type="artist", seed_id="seed-1", mode="library", fast=True, count=15)
+        resp = await svc.build_plan(_UID, req)
+        # adjacency query must exclude the seed itself
+        adjacency_call = svc._library_db.get_files_by_artist_mbids.await_args_list[-1]
+        assert "seed-1" not in adjacency_call.args[0]
+        artists = {t.artist_mbid for t in resp.tracks}
+        assert {"adj-1", "adj-2"} & artists
+        assert len(resp.tracks) == 15
+
+    @pytest.mark.asyncio
+    async def test_diversity_no_three_consecutive_same_artist(self):
+        svc = _svc()
+        svc._genre_index.get_artists_for_genres = AsyncMock(
+            return_value={"rock": ["a-1", "a-2", "a-3"]}
+        )
+
+        async def files_for(mbids, *, limit=50):
+            return [_lib_row(f"{m}-t{j}", f"Artist {m}", m) for m in mbids for j in range(30)][
+                :limit
+            ]
+
+        svc._library_db.get_files_by_artist_mbids = AsyncMock(side_effect=files_for)
+        req = RadioPlanRequest(seed_type="genre", seed_id="rock", mode="library", count=50)
+        resp = await svc.build_plan(_UID, req)
+        # relaxed fill lifts the per-artist cap to reach the count...
+        assert len(resp.tracks) == 50
+        # ...but never allows 3 in a row by the same artist
+        for i in range(len(resp.tracks) - 2):
+            window = {t.artist_mbid for t in resp.tracks[i : i + 3]}
+            assert len(window) > 1
+
+    @pytest.mark.asyncio
+    async def test_hybrid_mode_does_not_run_library_first_fill(self):
+        # YouTube-configured behavior stays exactly as before
+        svc = _svc()
+        svc._lb_repo.get_artist_top_recordings = AsyncMock(
+            return_value=[_recording(f"Ext{i}", f"E{i}", f"rec-{i}") for i in range(5)]
+        )
+        req = RadioPlanRequest(seed_type="artist", seed_id="a-1", mode="hybrid", fast=True)
+        await svc.build_plan(_UID, req)
+        svc._genre_index.get_genres_for_artists.assert_not_awaited()
+        svc._library_db.get_files_by_genre.assert_not_awaited()
 
 
 class TestExternalFallbackChain:

--- a/frontend/src/lib/player/launchRadio.ts
+++ b/frontend/src/lib/player/launchRadio.ts
@@ -29,6 +29,10 @@ import type { RadioPlanRequest, RadioPlanResponse, RadioPlanTrack } from '$lib/t
 
 export type RadioMode = 'library' | 'hybrid';
 
+/** Below this many playable tracks a station is "sparse": it still plays, but
+ * the listener gets an honest toast instead of a silent one-track queue. */
+const MIN_RICH_STATION = 5;
+
 export interface LaunchRadioOptions {
 	shuffle?: boolean;
 	mode?: RadioMode;
@@ -114,7 +118,11 @@ export async function launchRadio(
 	ytConfigured: boolean,
 	options: LaunchRadioOptions = {}
 ): Promise<boolean> {
-	const mode: RadioMode = options.mode ?? seed.mode ?? 'hybrid';
+	const requestedMode: RadioMode = options.mode ?? seed.mode ?? 'hybrid';
+	// Without YouTube the player can't stream un-owned tracks (they'd all be
+	// dropped from the queue), so every station degrades to a library-first
+	// plan the backend fills from the user's own files.
+	const mode: RadioMode = ytConfigured ? requestedMode : 'library';
 	const effectiveYt = ytConfigured;
 	const request = { ...seed, mode, count: options.count ?? seed.count ?? 30 };
 
@@ -171,8 +179,20 @@ export async function launchRadio(
 	playerStore.playQueue(items, 0, options.shuffle ?? false);
 	startRadioHydration();
 
-	// full plan in the background; append what the fast plan didn't cover
-	void extendRadio(effectiveYt);
+	// full plan in the background; append what the fast plan didn't cover.
+	// Once it lands, a still-tiny queue means the station genuinely has almost
+	// nothing to play - say so instead of silently looping one track.
+	void extendRadio(effectiveYt).then(() => {
+		if (!radioSession.active) return;
+		const playable = playerStore.queue.length;
+		if (playable > 0 && playable < MIN_RICH_STATION) {
+			playbackToast.show(
+				`Station found only ${playable} ${playable === 1 ? 'match' : 'matches'}` +
+					(effectiveYt ? '' : ' - add more music or connect YouTube'),
+				'warning'
+			);
+		}
+	});
 	return true;
 }
 


### PR DESCRIPTION
## What

Station (radio) plans stop returning near-empty queues for library-mode listeners:

- `RadioPlanService._library_first_pool`: library mode seeds the plan from the user's own files first (matching artist / genre-family / similar-artist tracks), then relaxes the fill criteria in stages instead of giving up when the strict pass finds too little
- `max_count` parameter on plan building so callers (and the upcoming Smart Mix generator) can size plans explicitly
- `launchRadio.ts`: without YouTube configured, every station now degrades to a library-first plan up front (previously un-owned hybrid tracks were silently dropped from the queue, sometimes leaving one looping track). When the full background plan lands and the queue is still thin (<5 playable tracks), the listener gets an honest toast ("Station found only N matches - add more music or connect YouTube") instead of a silent one-track loop.

## Why

Users without YouTube reported stations that "played one song forever" with no explanation. The plan was built for a hybrid world and the frontend hid the degradation.

## How tested

`tests/services/test_radio_plan_service.py` - **18 passed** (Windows, Python 3.13), including 6 new tests for the library-first pool, staged relaxation, and max_count behavior.
