### PR TITLE
feat(plugins): typed acquisition plugin layer (AcquisitionPlugin ABC) + authoring docs [needs reconciliation with manifest plugin API]

### DIFF
--- a/backend/api/v1/routes/download_client.py
+++ b/backend/api/v1/routes/download_client.py
@@ -42,40 +42,11 @@ async def update_config(
 ):
     preferences.save_download_client_settings(settings)
     # bust the whole download-client singleton chain so new settings take effect
-    # immediately; scorer/matcher/DownloadService/orchestrator capture these at
-    # construction and hold the client, so they must be cleared too, not just slskd
-    # client/repository. The orchestrator is built eagerly at startup (resume task),
-    # so omitting it leaves every download running against the old/empty URL.
-    from core.dependencies import (
-        get_album_preflight_scorer,
-        get_download_client_repository as _dc,
-        get_download_orchestrator,
-        get_download_service,
-        get_file_processor,
-        get_newznab_release_scorer,
-        get_slskd_client,
-        get_slskd_indexer,
-        get_slskd_repository,
-        get_status_service,
-        get_track_matcher,
-    )
+    # immediately (shared with the plugin settings API - see
+    # core/dependencies/invalidation.py for the why of each entry)
+    from core.dependencies.invalidation import clear_soulseek_chain
 
-    for provider in (
-        get_slskd_client,
-        get_slskd_repository,
-        get_slskd_indexer,
-        _dc,
-        get_album_preflight_scorer,
-        get_track_matcher,
-        get_newznab_release_scorer,
-        # FileProcessor + StatusService capture the slskd repo (mount/URL) at construction,
-        # so they must be cleared too - else the rebuilt orchestrator reuses a stale one.
-        get_file_processor,
-        get_status_service,
-        get_download_orchestrator,
-        get_download_service,
-    ):
-        provider.cache_clear()
+    clear_soulseek_chain()
     return preferences.get_download_client_settings()
 
 

--- a/backend/api/v1/routes/download_clients.py
+++ b/backend/api/v1/routes/download_clients.py
@@ -29,32 +29,11 @@ router = APIRouter(route_class=MsgSpecRoute, prefix="/download-clients", tags=["
 
 def _clear_download_client_cache() -> None:
     # Both the SABnzbd connection and the shared policy feed the scorers, file processor,
-    # orchestrator and service - clear the whole chain so a save takes effect at once.
-    from core.dependencies import (
-        get_album_preflight_scorer,
-        get_download_orchestrator,
-        get_download_service,
-        get_file_processor,
-        get_newznab_indexer,
-        get_newznab_release_scorer,
-        get_sabnzbd_client,
-        get_sabnzbd_download_client,
-        get_track_matcher,
-    )
+    # orchestrator and service - clear the whole chain so a save takes effect at once
+    # (shared with the plugin settings API - see core/dependencies/invalidation.py).
+    from core.dependencies.invalidation import clear_usenet_chain
 
-    for provider in (
-        get_sabnzbd_client,
-        get_sabnzbd_download_client,
-        get_album_preflight_scorer,
-        get_track_matcher,
-        get_newznab_release_scorer,
-        # the indexer derives its search-cache TTL from the policy's auto-retry interval
-        get_newznab_indexer,
-        get_file_processor,
-        get_download_orchestrator,
-        get_download_service,
-    ):
-        provider.cache_clear()
+    clear_usenet_chain()
 
 
 @router.get("/sabnzbd", response_model=SabnzbdConnectionSettings)

--- a/backend/api/v1/routes/plugins.py
+++ b/backend/api/v1/routes/plugins.py
@@ -1,135 +1,130 @@
-"""Plugin API routes (phase 01b).
+"""Acquisition-plugin admin routes.
 
-Admin-only: list plugins, install one from GitHub, enable/disable, edit their
-settings (mask-sentinel for secret fields), uninstall. There is deliberately no
-route that makes a plugin acquire content (D22).
+Registry list, enable/disable, per-plugin settings (schema + values, secrets
+masked on GET / preserved on masked PUT) and connection test. All admin-gated,
+matching the other settings surfaces.
 """
 
-import asyncio
 import logging
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
 from api.v1.schemas.plugins import (
-    PLUGIN_SECRET_MASK,
     PluginInfo,
-    PluginInstallRequest,
     PluginListResponse,
-    PluginSettingFieldInfo,
-    PluginUpdateRequest,
+    PluginSettingsResponse,
+    PluginSettingsUpdate,
+    PluginTestRequest,
+    PluginTestResponse,
+    PluginToggleResponse,
 )
-from api.v1.schemas.settings import PluginConfig
-from core.dependencies import get_plugin_host, get_preferences_service
-from api.v1.schemas.common import StatusMessageResponse
-from core.exceptions import ResourceNotFoundError, ValidationError
+from core.dependencies import get_plugin_manager
 from infrastructure.msgspec_fastapi import MsgSpecBody, MsgSpecRoute
 from middleware import CurrentAdminDep
+from plugins.base import API_VERSION
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(route_class=MsgSpecRoute, prefix="/plugins", tags=["plugins"])
 
-# Route order: the literal path (/install) is declared before the /{plugin_name}
-# handlers, so a future GET /{plugin_name} can never swallow it.
 
-
-def _to_info(plugin, prefs) -> PluginInfo:  # noqa: ANN001 - LoadedPlugin / PreferencesService
-    manifest = plugin.manifest
-    config = prefs.get_plugin_config(manifest.name)
-    values: dict[str, str] = {}
-    for field in manifest.settings:
-        stored = config.settings.get(field.key, "")
-        values[field.key] = (PLUGIN_SECRET_MASK if stored else "") if field.secret else stored
+def _info(manager, record) -> PluginInfo:
+    plugin = record.plugin
     return PluginInfo(
-        name=manifest.name,
-        display_name=manifest.display_name,
-        version=manifest.version,
-        enabled=plugin.enabled,
-        capabilities=manifest.capabilities,
-        active_capabilities=plugin.active_capabilities,
-        description=manifest.description,
-        author=manifest.author,
-        homepage=manifest.homepage,
-        error=plugin.error,
-        settings_fields=[
-            PluginSettingFieldInfo(
-                key=f.key, label=f.label, help=f.help, secret=f.secret
-            )
-            for f in manifest.settings
-        ],
-        settings_values=values,
+        id=record.id,
+        name=record.name or record.id,
+        version=record.version,
+        builtin=record.builtin,
+        enabled=manager.is_enabled(record.id) if record.loaded else False,
+        loaded=record.loaded,
+        error=record.error,
+        source=record.source,
+        api_version=getattr(plugin, "api_version", None) if plugin else None,
     )
 
 
+def _record_or_404(manager, plugin_id: str):
+    record = manager.get_record(plugin_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Unknown plugin '{plugin_id}'")
+    return record
+
+
 @router.get("", response_model=PluginListResponse)
-async def list_plugins(
-    _: CurrentAdminDep,
-    host=Depends(get_plugin_host),
-    prefs=Depends(get_preferences_service),
+async def list_plugins(_: CurrentAdminDep, manager=Depends(get_plugin_manager)):
+    return PluginListResponse(
+        plugins=[_info(manager, r) for r in manager.list_records()],
+        api_version=API_VERSION,
+    )
+
+
+@router.post("/{plugin_id}/enable", response_model=PluginToggleResponse)
+async def enable_plugin(
+    plugin_id: str, _: CurrentAdminDep, manager=Depends(get_plugin_manager)
 ):
-    return PluginListResponse(plugins=[_to_info(p, prefs) for p in host.list_plugins()])
+    record = _record_or_404(manager, plugin_id)
+    if not record.loaded:
+        raise HTTPException(
+            status_code=409, detail=record.error or "Plugin failed to load"
+        )
+    manager.set_enabled(plugin_id, True)
+    return PluginToggleResponse(id=plugin_id, enabled=manager.is_enabled(plugin_id))
 
 
-@router.post("/install", response_model=PluginInfo, status_code=201)
-async def install_plugin(
-    _: CurrentAdminDep,
-    body: PluginInstallRequest = MsgSpecBody(PluginInstallRequest),
-    host=Depends(get_plugin_host),
-    prefs=Depends(get_preferences_service),
+@router.post("/{plugin_id}/disable", response_model=PluginToggleResponse)
+async def disable_plugin(
+    plugin_id: str, _: CurrentAdminDep, manager=Depends(get_plugin_manager)
 ):
-    """Download a public GitHub repo into the plugins folder. The code is stored,
-    never executed: the plugin arrives DISABLED and an admin must enable it,
-    exactly like a hand-copied folder."""
-    from infrastructure.http.client import HttpClientFactory
-    from infrastructure.plugins.host import PluginInstallError
-
-    http = HttpClientFactory.get_client(name="plugin-install", timeout=60.0)
-    try:
-        name = await host.install_from_github(body.repository_url, http)
-    except PluginInstallError as exc:
-        raise ValidationError(str(exc)) from exc
-    plugin = host.get(name)
-    if plugin is None:
-        raise ValidationError("The plugin installed but could not be read back")
-    return _to_info(plugin, prefs)
+    record = _record_or_404(manager, plugin_id)
+    if not record.loaded:
+        raise HTTPException(
+            status_code=409, detail=record.error or "Plugin failed to load"
+        )
+    manager.set_enabled(plugin_id, False)
+    return PluginToggleResponse(id=plugin_id, enabled=manager.is_enabled(plugin_id))
 
 
-@router.put("/{plugin_name}", response_model=PluginInfo)
-async def update_plugin(
-    plugin_name: str,
-    _: CurrentAdminDep,
-    body: PluginUpdateRequest = MsgSpecBody(PluginUpdateRequest),
-    host=Depends(get_plugin_host),
-    prefs=Depends(get_preferences_service),
+@router.get("/{plugin_id}/settings", response_model=PluginSettingsResponse)
+async def get_plugin_settings(
+    plugin_id: str, _: CurrentAdminDep, manager=Depends(get_plugin_manager)
 ):
-    plugin = host.get(plugin_name)
-    if plugin is None:
-        raise ResourceNotFoundError("Plugin not found")
-    current = prefs.get_plugin_config(plugin_name)
-    secret_keys = {f.key for f in plugin.manifest.settings if f.secret}
-    merged: dict[str, str] = {}
-    for key, value in body.settings.items():
-        if key in secret_keys and value == PLUGIN_SECRET_MASK:
-            merged[key] = current.settings.get(key, "")
-        else:
-            merged[key] = value
-    prefs.save_plugin_config(plugin_name, PluginConfig(enabled=body.enabled, settings=merged))
-    # reload so enable/disable and entrypoint changes apply immediately; module
-    # import is blocking work, so keep it off the event loop
-    await asyncio.to_thread(host.load_all)
-    refreshed = host.get(plugin_name)
-    if refreshed is None:
-        raise ResourceNotFoundError("Plugin not found")
-    return _to_info(refreshed, prefs)
+    record = _record_or_404(manager, plugin_id)
+    return PluginSettingsResponse(
+        id=plugin_id,
+        schema=manager.get_settings_schema(plugin_id),
+        values=manager.get_settings_values(record),  # secrets masked
+    )
 
 
-@router.delete("/{plugin_name}", response_model=StatusMessageResponse)
-async def uninstall_plugin(
-    plugin_name: str,
+@router.put("/{plugin_id}/settings", response_model=PluginSettingsResponse)
+async def update_plugin_settings(
+    plugin_id: str,
     _: CurrentAdminDep,
-    host=Depends(get_plugin_host),
+    body: PluginSettingsUpdate = MsgSpecBody(PluginSettingsUpdate),
+    manager=Depends(get_plugin_manager),
 ):
-    """Remove the plugin's folder. Its saved settings stay in config.json, so a
-    reinstall picks them back up."""
-    await asyncio.to_thread(host.uninstall, plugin_name)
-    return StatusMessageResponse(status="ok", message=f"Removed {plugin_name}")
+    record = _record_or_404(manager, plugin_id)
+    if not record.loaded:
+        raise HTTPException(
+            status_code=409, detail=record.error or "Plugin failed to load"
+        )
+    manager.save_settings(plugin_id, body.values)
+    return PluginSettingsResponse(
+        id=plugin_id,
+        schema=manager.get_settings_schema(plugin_id),
+        values=manager.get_settings_values(record),  # secrets masked
+    )
+
+
+@router.post("/{plugin_id}/test", response_model=PluginTestResponse)
+async def test_plugin(
+    plugin_id: str,
+    _: CurrentAdminDep,
+    body: PluginTestRequest = MsgSpecBody(PluginTestRequest),
+    manager=Depends(get_plugin_manager),
+):
+    """Tests the submitted values (masked secrets resolve to stored ones) without
+    saving; an empty body tests the currently saved configuration."""
+    _record_or_404(manager, plugin_id)
+    result = await manager.test(plugin_id, body.values or None)
+    return PluginTestResponse(valid=result.ok, message=result.message, version=result.version)

--- a/backend/api/v1/schemas/plugins.py
+++ b/backend/api/v1/schemas/plugins.py
@@ -1,45 +1,52 @@
-"""Wire schemas for the plugin API surfaces (phase 01b).
+"""Admin plugin-registry API schemas."""
 
-Secret-marked plugin settings follow the house mask-sentinel pattern: reads
-return the mask when a value exists, and a save that sends the mask back keeps
-the stored value.
-"""
+from typing import Any
 
 from infrastructure.msgspec_fastapi import AppStruct
-
-PLUGIN_SECRET_MASK = "plugin****"
-
-
-class PluginSettingFieldInfo(AppStruct):
-    key: str
-    label: str
-    help: str = ""
-    secret: bool = False
+from plugins.base import SettingsField
 
 
 class PluginInfo(AppStruct):
+    id: str
     name: str
-    display_name: str
     version: str
+    builtin: bool
     enabled: bool
-    capabilities: list[str] = []
-    active_capabilities: list[str] = []
-    description: str = ""
-    author: str = ""
-    homepage: str = ""
+    loaded: bool
     error: str | None = None
-    settings_fields: list[PluginSettingFieldInfo] = []
-    settings_values: dict[str, str] = {}
+    source: str = "external"
+    api_version: int | None = None
 
 
 class PluginListResponse(AppStruct):
     plugins: list[PluginInfo] = []
+    api_version: int = 0
 
 
-class PluginUpdateRequest(AppStruct):
+class PluginToggleResponse(AppStruct):
+    id: str
     enabled: bool
-    settings: dict[str, str] = {}
 
 
-class PluginInstallRequest(AppStruct):
-    repository_url: str
+class PluginSettingsResponse(AppStruct):
+    """Schema + current values (secrets masked)."""
+
+    id: str
+    schema: list[SettingsField] = []
+    values: dict[str, Any] = {}
+
+
+class PluginSettingsUpdate(AppStruct):
+    values: dict[str, Any] = {}
+
+
+class PluginTestRequest(AppStruct):
+    """Optional values to test WITHOUT saving (masked secrets resolve to stored)."""
+
+    values: dict[str, Any] = {}
+
+
+class PluginTestResponse(AppStruct):
+    valid: bool
+    message: str = ""
+    version: str | None = None

--- a/backend/core/dependencies/__init__.py
+++ b/backend/core/dependencies/__init__.py
@@ -143,6 +143,10 @@ from .service_providers import (  # noqa: F401
     get_quota_service,
 )
 
+from .plugin_providers import (  # noqa: F401
+    get_plugin_manager,
+)
+
 from .type_aliases import (  # noqa: F401
     SettingsDep,
     CacheDep,

--- a/backend/core/dependencies/cleanup.py
+++ b/backend/core/dependencies/cleanup.py
@@ -63,6 +63,16 @@ async def init_app_state(app) -> None:
 
 
 async def cleanup_app_state() -> None:
+    # Give acquisition plugins their shutdown hook (best-effort; only if the
+    # manager was ever built - constructing it during teardown would be wasted work).
+    from .plugin_providers import get_plugin_manager
+
+    try:
+        if get_plugin_manager.cache_info().currsize:
+            await get_plugin_manager().shutdown_all()
+    except Exception as exc:  # noqa: BLE001 - cleanup must never abort shutdown
+        logger.error("Failed to shut down acquisition plugins during cleanup: %s", exc)
+
     # Graceful service shutdown
     try:
         queue_mgr = get_discover_queue_manager()

--- a/backend/core/dependencies/invalidation.py
+++ b/backend/core/dependencies/invalidation.py
@@ -1,0 +1,77 @@
+"""Singleton-chain invalidation for acquisition settings saves.
+
+A download-client settings save must rebuild every singleton that captured the
+old client/policy at construction (scorer/matcher/file-processor/orchestrator/
+service chain) - see the comments in ``routes/download_client.py``. The chains
+were previously inlined in the two routes; they live here so the plugin settings
+API (which proxies the same preference sections) reuses the exact same lists.
+"""
+
+from __future__ import annotations
+
+
+def clear_soulseek_chain() -> None:
+    """Bust the slskd singleton chain so new download-client settings take effect
+    immediately. The orchestrator is built eagerly at startup (resume task), so
+    omitting it leaves every download running against the old/empty URL."""
+    from core.dependencies import (
+        get_album_preflight_scorer,
+        get_download_client_repository,
+        get_download_orchestrator,
+        get_download_service,
+        get_file_processor,
+        get_newznab_release_scorer,
+        get_slskd_client,
+        get_slskd_indexer,
+        get_slskd_repository,
+        get_status_service,
+        get_track_matcher,
+    )
+
+    for provider in (
+        get_slskd_client,
+        get_slskd_repository,
+        get_slskd_indexer,
+        get_download_client_repository,
+        get_album_preflight_scorer,
+        get_track_matcher,
+        get_newznab_release_scorer,
+        # FileProcessor + StatusService capture the slskd repo (mount/URL) at construction,
+        # so they must be cleared too - else the rebuilt orchestrator reuses a stale one.
+        get_file_processor,
+        get_status_service,
+        get_download_orchestrator,
+        get_download_service,
+    ):
+        provider.cache_clear()
+
+
+def clear_usenet_chain() -> None:
+    """Bust the SABnzbd/policy singleton chain. Both the SABnzbd connection and the
+    shared policy feed the scorers, file processor, orchestrator and service - clear
+    the whole chain so a save takes effect at once."""
+    from core.dependencies import (
+        get_album_preflight_scorer,
+        get_download_orchestrator,
+        get_download_service,
+        get_file_processor,
+        get_newznab_indexer,
+        get_newznab_release_scorer,
+        get_sabnzbd_client,
+        get_sabnzbd_download_client,
+        get_track_matcher,
+    )
+
+    for provider in (
+        get_sabnzbd_client,
+        get_sabnzbd_download_client,
+        get_album_preflight_scorer,
+        get_track_matcher,
+        get_newznab_release_scorer,
+        # the indexer derives its search-cache TTL from the policy's auto-retry interval
+        get_newznab_indexer,
+        get_file_processor,
+        get_download_orchestrator,
+        get_download_service,
+    ):
+        provider.cache_clear()

--- a/backend/core/dependencies/plugin_providers.py
+++ b/backend/core/dependencies/plugin_providers.py
@@ -1,0 +1,28 @@
+"""DI provider for the acquisition ``PluginManager``.
+
+One process-wide manager: discovery (built-ins + ``{ROOT_APP_DIR}/plugins`` +
+the ``droppedneedle.plugins`` entry-point group) runs once on first access and
+never raises - a broken plugin is quarantined in the registry instead.
+
+The manager singleton survives download-settings saves on purpose: built-in
+plugins resolve their client singletons lazily per call, so the existing
+cache-clear chains rebuild what matters without reloading plugin modules.
+"""
+
+from __future__ import annotations
+
+from ._registry import singleton
+from .cache_providers import get_preferences_service
+
+
+@singleton
+def get_plugin_manager() -> "PluginManager":
+    from core.config import get_settings
+    from plugins.manager import PluginManager
+
+    manager = PluginManager(
+        preferences=get_preferences_service(),
+        external_dir=get_settings().root_app_dir / "plugins",
+    )
+    manager.load()
+    return manager

--- a/backend/core/dependencies/repo_providers.py
+++ b/backend/core/dependencies/repo_providers.py
@@ -692,10 +692,18 @@ def get_download_client(client_type: str) -> "DownloadClientProtocol":
             raise ConfigurationError(f"Unknown download client type: {other!r}")
 
 
-# Fixed v1 source → client_type map (assembled in get_sources, dispatched here).
+# Fixed v1 source → client_type map (fallback for the built-in sources when the
+# plugin registry can't answer - should never happen once the manager has loaded).
 _SOURCE_CLIENT_TYPE = {"soulseek": "slskd", "usenet": "sabnzbd"}
 
 
 def get_download_client_for_source(source: str) -> "DownloadClientProtocol":
-    """Resolve the download client that owns a given acquisition source."""
+    """Resolve the download client that owns a given acquisition source, via the
+    plugin registry (source ids ARE plugin ids: 'soulseek'/'usenet' plus any
+    third-party plugin). Falls back to the fixed built-in map."""
+    from .plugin_providers import get_plugin_manager
+
+    plugin = get_plugin_manager().get_plugin(source)
+    if plugin is not None:
+        return plugin.get_download_client()
     return get_download_client(_SOURCE_CLIENT_TYPE.get(source, source))

--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -1075,6 +1075,36 @@ def get_download_manifest_codec() -> "ManifestCodec":
     return ManifestCodec()
 
 
+def _resolve_acquisition_providers() -> tuple:
+    """Resolve the per-source (indexer, download-client) pairs through the plugin
+    registry - the acquisition seam. The built-in plugins return the exact same
+    singletons the orchestrator used pre-plugins (``get_slskd_repository`` /
+    ``get_slskd_indexer`` / ``get_newznab_indexer`` / ``get_sabnzbd_download_client``),
+    so behaviour is unchanged; the direct providers remain only as a fallback for
+    the (should-never-happen) case of a quarantined built-in."""
+    from .plugin_providers import get_plugin_manager
+    from .repo_providers import (
+        get_download_client_repository,
+        get_newznab_indexer,
+        get_sabnzbd_download_client,
+        get_slskd_indexer,
+    )
+
+    manager = get_plugin_manager()
+    soulseek = manager.get_plugin("soulseek")
+    usenet = manager.get_plugin("usenet")
+    if soulseek is None or usenet is None:  # pragma: no cover - built-ins always load
+        logger.error(
+            "plugins.builtin_missing - falling back to direct providers",
+            extra={"soulseek": soulseek is not None, "usenet": usenet is not None},
+        )
+    client = soulseek.get_download_client() if soulseek else get_download_client_repository()
+    indexer = soulseek.get_indexer() if soulseek else get_slskd_indexer()
+    usenet_client = usenet.get_download_client() if usenet else get_sabnzbd_download_client()
+    usenet_indexer = usenet.get_indexer() if usenet else get_newznab_indexer()
+    return client, indexer, usenet_client, usenet_indexer
+
+
 @singleton
 def get_download_orchestrator() -> "DownloadOrchestrator":
     from pathlib import Path
@@ -1082,14 +1112,9 @@ def get_download_orchestrator() -> "DownloadOrchestrator":
     from core.config import get_settings
     from services.native.download_orchestrator import DownloadOrchestrator
 
-    from .repo_providers import (
-        get_download_client_repository,
-        get_download_store,
-        get_newznab_indexer,
-        get_sabnzbd_download_client,
-        get_slskd_indexer,
-    )
+    from .repo_providers import get_download_store
 
+    client, indexer, usenet_client, usenet_indexer = _resolve_acquisition_providers()
     prefs = get_preferences_service()
     lib = prefs.get_library_settings_raw()
     policy = prefs.get_download_policy()
@@ -1103,8 +1128,8 @@ def get_download_orchestrator() -> "DownloadOrchestrator":
         else Path(get_settings().cache_dir) / "download-staging"
     )
     return DownloadOrchestrator(
-        client=get_download_client_repository(),
-        indexer=get_slskd_indexer(),
+        client=client,
+        indexer=indexer,
         download_store=get_download_store(),
         file_processor=get_file_processor(),
         library_manager=get_library_manager(),
@@ -1127,8 +1152,8 @@ def get_download_orchestrator() -> "DownloadOrchestrator":
         on_import_callback=_build_import_invalidation(
             get_cache(), get_disk_cache(), get_library_db()
         ),
-        usenet_indexer=get_newznab_indexer(),
-        usenet_client=get_sabnzbd_download_client(),
+        usenet_indexer=usenet_indexer,
+        usenet_client=usenet_client,
         usenet_scorer=get_newznab_release_scorer(),
         usenet_enabled=usenet_enabled,
         soulseek_enabled=dc.enabled,
@@ -1150,12 +1175,10 @@ def get_download_service() -> "DownloadService":
 
     from .repo_providers import (
         get_album_release_pin_store,
-        get_download_client_repository,
         get_download_store,
-        get_newznab_indexer,
-        get_slskd_indexer,
     )
 
+    client, indexer, _usenet_client, usenet_indexer = _resolve_acquisition_providers()
     prefs = get_preferences_service()
     dc = prefs.get_download_client_settings_raw()
     policy = prefs.get_download_policy()
@@ -1163,8 +1186,8 @@ def get_download_service() -> "DownloadService":
     # The service is "enabled" if ANY source can act (slskd OR usenet), so a Usenet-only
     # install isn't blocked by the slskd-disabled guard.
     return DownloadService(
-        download_client=get_download_client_repository(),
-        indexer=get_slskd_indexer(),
+        download_client=client,
+        indexer=indexer,
         scorer=get_album_preflight_scorer(),
         library_manager=get_library_repository(),
         download_store=get_download_store(),
@@ -1178,7 +1201,7 @@ def get_download_service() -> "DownloadService":
         auto_accept_threshold=policy.preflight_score_auto_accept,
         manual_threshold=policy.preflight_score_manual_min,
         enabled=dc.enabled or usenet_enabled,
-        usenet_indexer=get_newznab_indexer(),
+        usenet_indexer=usenet_indexer,
         usenet_scorer=get_newznab_release_scorer(),
         usenet_enabled=usenet_enabled,
         soulseek_enabled=dc.enabled,

--- a/backend/plugins/__init__.py
+++ b/backend/plugins/__init__.py
@@ -1,0 +1,27 @@
+"""DroppedNeedle acquisition plugins.
+
+The acquisition layer (search for release candidates, enqueue downloads, track
+progress, locate completed files, cancel) is plugin-driven. Today's Soulseek
+(slskd) and Usenet (SABnzbd) support are the first two built-in plugins; they
+live in ``plugins/builtin`` and wrap the existing client code unchanged.
+
+Third-party plugins are single ``.py`` modules or packages dropped into
+``{ROOT_APP_DIR}/plugins``, or installed packages exposing the
+``droppedneedle.plugins`` entry-point group. See ``docs/plugins/`` for the
+full authoring guide.
+
+The IMPORT pipeline (post-download identification / move / registration) is
+core and NOT pluggable - a plugin's job ends at "the finished files are here".
+"""
+
+from plugins.base import (  # noqa: F401
+    API_VERSION,
+    AcquisitionPlugin,
+    Candidate,
+    PLUGIN_SECRET_MASK,
+    SearchRequest,
+    SelectOption,
+    SettingsField,
+    TestResult,
+)
+from plugins.manager import PluginManager, PluginRecord  # noqa: F401

--- a/backend/plugins/base.py
+++ b/backend/plugins/base.py
@@ -1,0 +1,358 @@
+"""``AcquisitionPlugin`` - the versioned contract every acquisition plugin implements.
+
+The plugin seam is ACQUISITION only: search for release candidates, enqueue a
+download with the external client, report progress, report where the finished
+files landed, cancel. Everything after that (identification, move into the
+library, registration) is the core import pipeline and is not pluggable.
+
+The exchange types are NOT invented for the plugin layer - they are the exact
+structs the download orchestrator already exchanges with the slskd and SABnzbd
+clients (``repositories/protocols``), re-exported here, so wrapping the two
+built-in clients as plugins is lossless:
+
+- ``Candidate``          = ``IndexerResult``      (one search hit, tagged by source)
+- ``EnqueueRequest``     -> ``TaskHandle``        (start a download, get a correlation handle)
+- ``TaskHandle``         -> ``DownloadTaskStatus``(poll progress)
+- ``completed_path``     -> ``list[Path]``        (where the finished audio files are)
+
+This module deliberately does NOT use ``from __future__ import annotations``:
+the protocol conformance contract tests compare real ``inspect.signature``
+objects (including return annotations) between ``IndexerProtocol`` /
+``DownloadClientProtocol`` and the adapters defined at the bottom of this file,
+so annotations must be real objects and byte-identical to the protocols'.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, ClassVar, Literal
+
+from infrastructure.msgspec_fastapi import AppStruct
+from models.common import ServiceStatus
+from repositories.protocols.download_client import (  # noqa: F401 - re-exported plugin API
+    DownloadFileRef,
+    DownloadSearchResult,
+    DownloadTaskStatus,
+    EnqueueRequest,
+    MountDiagnosis,
+    TaskHandle,
+)
+from repositories.protocols.indexer import (  # noqa: F401 - re-exported plugin API
+    IndexerResult,
+    UsenetRelease,
+)
+
+logger = logging.getLogger(__name__)
+
+# The plugin API version this server implements. A plugin declares the version it
+# was written against via ``AcquisitionPlugin.api_version``; the manager refuses to
+# load a plugin whose declared version differs (see docs/plugins/AUTHORING.md for
+# the compatibility policy).
+API_VERSION = 1
+
+# Generic masked-secret sentinel for plugin settings values. A ``secret`` field
+# whose stored value is non-empty is returned as this mask; saving the mask back
+# preserves the stored value (the house pattern used by every settings section).
+PLUGIN_SECRET_MASK = "plugin****"
+
+# One search hit. Exactly the struct the orchestrator's scorers consume today: a
+# tagged union whose ``source`` names the plugin/source id, carrying either a
+# per-file Soulseek-shaped result (``soulseek``) or a release-shaped result
+# (``usenet``). Third-party plugins emit whichever archetype fits their network:
+# per-file peer-to-peer results or single-archive release results.
+Candidate = IndexerResult
+
+FieldType = Literal["str", "int", "bool", "select", "secret"]
+
+
+class SelectOption(AppStruct):
+    """One choice of a ``select`` field. ``value`` is what gets stored."""
+
+    value: str | int
+    label: str = ""
+
+
+class SettingsField(AppStruct):
+    """One typed field of a plugin's settings schema.
+
+    The admin UI renders the form from these descriptors; the manager uses
+    ``type == "secret"`` to encrypt at rest and mask in API responses.
+    """
+
+    key: str
+    type: FieldType = "str"
+    label: str = ""
+    help: str = ""
+    default: str | int | float | bool | None = None
+    required: bool = False
+    options: list[SelectOption] = []
+
+
+class TestResult(AppStruct):
+    """Outcome of ``test_connection``. ``ok=False`` carries a human-readable
+    ``message`` the admin UI shows verbatim."""
+
+    ok: bool
+    message: str = ""
+    version: str | None = None
+
+
+class SearchRequest(AppStruct):
+    """One search the orchestrator asks a plugin to run.
+
+    ``kind`` selects the shape: an ``album`` search carries ``album_title`` /
+    ``track_count``; a ``track`` search carries ``track_title`` /
+    ``duration_seconds`` (and optionally ``album_title`` for context).
+    """
+
+    kind: Literal["album", "track"] = "album"
+    artist_name: str = ""
+    album_title: str | None = None
+    track_title: str | None = None
+    year: int | None = None
+    track_count: int | None = None
+    duration_seconds: int | None = None
+    timeout: float = 30.0
+
+
+class AcquisitionPlugin(ABC):
+    """Base class for acquisition plugins.
+
+    Identity is declared as class attributes (``id``, ``name``, ``version``,
+    ``api_version``). The lifecycle is: instantiate -> ``configure(settings)``
+    -> serve ``search`` / ``enqueue`` / ``get_status`` / ``cancel`` /
+    ``completed_path`` -> ``shutdown()`` on app exit.
+
+    A plugin instance is a process-wide singleton owned by the ``PluginManager``.
+    Methods may be called concurrently from the event loop; do not block.
+    """
+
+    # -- identity (override all three; api_version pins the contract version) --
+    id: ClassVar[str] = ""
+    name: ClassVar[str] = ""
+    version: ClassVar[str] = "0.0.0"
+    api_version: ClassVar[int] = API_VERSION
+
+    # ---------------------------------------------------------------- lifecycle
+
+    @abstractmethod
+    def settings_schema(self) -> list[SettingsField]:
+        """The typed field descriptors the admin settings form is rendered from."""
+
+    @abstractmethod
+    def configure(self, settings: dict[str, Any]) -> None:
+        """Apply a settings mapping (schema keys -> values, secrets decrypted).
+
+        Called once after load with the persisted values and again after every
+        settings save. Must be cheap and must not perform I/O; validate lazily
+        in ``test_connection`` / first use instead of raising here.
+        """
+
+    @abstractmethod
+    async def test_connection(self, settings: dict[str, Any] | None = None) -> TestResult:
+        """Verify connectivity/credentials. ``settings=None`` tests the currently
+        configured values; a mapping tests those values WITHOUT persisting them
+        (the admin UI tests before saving)."""
+
+    async def shutdown(self) -> None:
+        """Release resources (HTTP clients, background tasks). Best-effort;
+        exceptions are logged and swallowed by the manager."""
+        return None
+
+    # -------------------------------------------------------------- capabilities
+
+    def is_configured(self) -> bool:
+        """True when the plugin has enough configuration to be used at all
+        (distinct from the admin enable toggle)."""
+        return True
+
+    async def health_check(self) -> ServiceStatus:
+        """Liveness of the backing service. Default: derived from
+        ``test_connection()``."""
+        result = await self.test_connection()
+        return ServiceStatus(
+            status="ok" if result.ok else "error",
+            version=result.version,
+            message=result.message or None,
+        )
+
+    @abstractmethod
+    async def search(self, request: SearchRequest) -> list[Candidate]:
+        """Run one search and return candidates tagged with this plugin's source id."""
+
+    @abstractmethod
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        """Start downloading and return the correlation handle the orchestrator
+        persists and hands back to ``get_status`` / ``cancel`` / ``completed_path``."""
+
+    @abstractmethod
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        """Progress of an enqueued download."""
+
+    @abstractmethod
+    async def cancel(self, handle: TaskHandle) -> bool:
+        """Cancel an in-flight download AND/OR remove its completed transfer
+        records (also used for post-import cleanup)."""
+
+    @abstractmethod
+    async def completed_path(self, handle: TaskHandle) -> list[Path]:
+        """On-disk paths of the finished job's audio files - the hand-off point
+        to the core import pipeline."""
+
+    async def get_file_path(
+        self,
+        handle: TaskHandle,
+        remote_filename: str,
+        size: int | None = None,
+    ) -> Path | None:
+        """Local path of ONE completed file, when the plugin can resolve remote
+        names to disk names. Optional; ``None`` makes the orchestrator fall back
+        to ``completed_path`` / ``get_status``."""
+        return None
+
+    async def diagnose_downloads_mount(self) -> MountDiagnosis:
+        """Optional cross-check of the client's completed downloads against the
+        configured import mount. Default: not supported."""
+        return MountDiagnosis(supported=False)
+
+    # -------------------------------------------------- orchestrator integration
+    # The download orchestrator speaks IndexerProtocol + DownloadClientProtocol.
+    # The default adapters below wrap this plugin's own methods; built-in plugins
+    # override these to return the exact pre-existing client objects, making the
+    # refactor lossless.
+
+    def get_indexer(self):  # noqa: ANN201 - IndexerProtocol (structural)
+        """This plugin's search side as an ``IndexerProtocol``."""
+        return PluginIndexerAdapter(self)
+
+    def get_download_client(self):  # noqa: ANN201 - DownloadClientProtocol (structural)
+        """This plugin's acquire/track/locate side as a ``DownloadClientProtocol``."""
+        return PluginDownloadClientAdapter(self)
+
+    # ------------------------------------------------------- built-in overrides
+    # Hooks that let a plugin proxy its enable flag / settings values to an
+    # existing persistence location instead of the manager's generic
+    # ``plugins.{id}`` config namespace. Third-party plugins never override these.
+
+    def enabled_override(self) -> bool | None:
+        """Return the live enable flag when the plugin owns it elsewhere
+        (built-ins proxy the existing settings sections); ``None`` means the
+        manager persists it in the plugin config namespace."""
+        return None
+
+    def apply_enabled(self, enabled: bool) -> bool:
+        """Persist the enable flag when the plugin owns it elsewhere. Return
+        ``True`` when handled; ``False`` lets the manager persist it."""
+        return False
+
+    def settings_values(self) -> dict[str, Any] | None:
+        """Return current settings values (secrets in the clear) when the plugin
+        stores them elsewhere; ``None`` means the manager owns persistence."""
+        return None
+
+    def apply_settings(self, values: dict[str, Any]) -> bool:
+        """Persist a full settings mapping when the plugin stores them elsewhere.
+        Return ``True`` when handled; ``False`` lets the manager persist them."""
+        return False
+
+
+class PluginIndexerAdapter:
+    """``IndexerProtocol`` view over a plugin's ``search`` capability.
+
+    Signatures are byte-identical to ``IndexerProtocol`` (contract-tested), so
+    the orchestrator needs zero changes to consume a third-party plugin's search.
+    """
+
+    def __init__(self, plugin: AcquisitionPlugin) -> None:
+        self._plugin = plugin
+
+    @property
+    def indexer_name(self) -> str:
+        return self._plugin.id
+
+    def is_configured(self) -> bool:
+        return self._plugin.is_configured()
+
+    async def health_check(self) -> ServiceStatus:
+        return await self._plugin.health_check()
+
+    async def search_album(
+        self,
+        artist_name: str,
+        album_title: str,
+        year: int | None = None,
+        track_count: int | None = None,
+        *,
+        timeout: float = 30.0,
+    ) -> list[IndexerResult]:
+        return await self._plugin.search(
+            SearchRequest(
+                kind="album",
+                artist_name=artist_name,
+                album_title=album_title,
+                year=year,
+                track_count=track_count,
+                timeout=timeout,
+            )
+        )
+
+    async def search_track(
+        self,
+        artist_name: str,
+        track_title: str,
+        album_title: str | None = None,
+        duration_seconds: int | None = None,
+        *,
+        timeout: float = 30.0,
+    ) -> list[IndexerResult]:
+        return await self._plugin.search(
+            SearchRequest(
+                kind="track",
+                artist_name=artist_name,
+                track_title=track_title,
+                album_title=album_title,
+                duration_seconds=duration_seconds,
+                timeout=timeout,
+            )
+        )
+
+
+class PluginDownloadClientAdapter:
+    """``DownloadClientProtocol`` view over a plugin's acquire/track/locate
+    capabilities. Signatures are byte-identical to the protocol (contract-tested)."""
+
+    def __init__(self, plugin: AcquisitionPlugin) -> None:
+        self._plugin = plugin
+
+    @property
+    def client_name(self) -> str:
+        return self._plugin.id
+
+    def is_configured(self) -> bool:
+        return self._plugin.is_configured()
+
+    async def health_check(self) -> ServiceStatus:
+        return await self._plugin.health_check()
+
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        return await self._plugin.enqueue(request)
+
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        return await self._plugin.get_status(handle)
+
+    async def cancel(self, handle: TaskHandle) -> bool:
+        return await self._plugin.cancel(handle)
+
+    async def list_completed_files(self, handle: TaskHandle) -> list[Path]:
+        return await self._plugin.completed_path(handle)
+
+    async def get_file_path(
+        self,
+        handle: TaskHandle,
+        remote_filename: str,
+        size: int | None = None,
+    ) -> Path | None:
+        return await self._plugin.get_file_path(handle, remote_filename, size)
+
+    async def diagnose_downloads_mount(self) -> MountDiagnosis:
+        return await self._plugin.diagnose_downloads_mount()

--- a/backend/plugins/builtin/__init__.py
+++ b/backend/plugins/builtin/__init__.py
@@ -1,0 +1,7 @@
+"""Built-in acquisition plugins.
+
+Each subpackage wraps one of the pre-existing download clients (the client code
+itself still lives in ``repositories/``; the plugin delegates - see
+``docs/plugins/MIGRATION.md``). ``PluginManager`` discovers every subpackage
+here automatically.
+"""

--- a/backend/plugins/builtin/soulseek_slskd/__init__.py
+++ b/backend/plugins/builtin/soulseek_slskd/__init__.py
@@ -1,0 +1,3 @@
+"""Soulseek (slskd) built-in acquisition plugin."""
+
+from plugins.builtin.soulseek_slskd.plugin import SoulseekSlskdPlugin  # noqa: F401

--- a/backend/plugins/builtin/soulseek_slskd/plugin.py
+++ b/backend/plugins/builtin/soulseek_slskd/plugin.py
@@ -1,0 +1,205 @@
+"""Soulseek acquisition via a user-supplied slskd instance, as a plugin.
+
+DELEGATES to the pre-existing client code (``repositories/slskd``) through the
+same DI singletons the orchestrator used before the plugin layer existed
+(``get_slskd_repository`` / ``get_slskd_indexer``), resolved lazily per call so
+a settings save (which cache-clears those singletons) is picked up without a
+restart. Behaviour is therefore byte-identical to the pre-plugin wiring.
+
+Settings and the enable flag proxy the legacy ``download_client`` preferences
+section, so the existing ``/download-client/*`` admin routes and the plugin
+settings API read/write the same values.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from plugins.base import (
+    AcquisitionPlugin,
+    Candidate,
+    DownloadTaskStatus,
+    EnqueueRequest,
+    MountDiagnosis,
+    SearchRequest,
+    SettingsField,
+    TaskHandle,
+    TestResult,
+)
+
+
+class SoulseekSlskdPlugin(AcquisitionPlugin):
+    id = "soulseek"
+    name = "Soulseek (slskd)"
+    version = "1.0.0"
+
+    # ------------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _repo():
+        from core.dependencies import get_slskd_repository
+
+        return get_slskd_repository()
+
+    @staticmethod
+    def _indexer():
+        from core.dependencies import get_slskd_indexer
+
+        return get_slskd_indexer()
+
+    @staticmethod
+    def _prefs():
+        from core.dependencies import get_preferences_service
+
+        return get_preferences_service()
+
+    # ---------------------------------------------------------------- lifecycle
+
+    def settings_schema(self) -> list[SettingsField]:
+        return [
+            SettingsField(
+                key="url",
+                type="str",
+                label="slskd URL",
+                help="Base URL of your slskd instance, e.g. http://slskd:5030",
+                default="",
+                required=True,
+            ),
+            SettingsField(
+                key="api_key",
+                type="secret",
+                label="API key",
+                help="slskd API key (Options > Web > Authentication).",
+                default="",
+                required=True,
+            ),
+            SettingsField(
+                key="downloads_subpath",
+                type="str",
+                label="Downloads subfolder",
+                help=(
+                    "Optional subfolder inside the downloads mount where slskd saves "
+                    "completed files, for when the mount points at a parent folder."
+                ),
+                default="",
+            ),
+        ]
+
+    def configure(self, settings: dict[str, Any]) -> None:
+        # Reads the live preferences section on every call; nothing to hold.
+        return None
+
+    async def test_connection(self, settings: dict[str, Any] | None = None) -> TestResult:
+        from core.dependencies import build_slskd_repository
+        from infrastructure.validators import validate_service_url
+        from core.exceptions import ValidationError
+
+        current = self._prefs().get_download_client_settings_raw()
+        values = settings or {"url": current.url, "api_key": current.api_key}
+        url = str(values.get("url") or "")
+        api_key = str(values.get("api_key") or "")
+        try:
+            validate_service_url(url, label="slskd URL")
+        except ValidationError as exc:
+            return TestResult(ok=False, message=str(exc))
+        try:
+            status = await build_slskd_repository(url, api_key).health_check()
+        except Exception as exc:  # noqa: BLE001 - a failed test is a result, not a 500
+            return TestResult(ok=False, message=f"slskd unreachable: {exc}")
+        return TestResult(
+            ok=status.status == "ok",
+            message=status.message or (f"slskd {status.version}" if status.version else ""),
+            version=status.version,
+        )
+
+    # -------------------------------------------------------------- capabilities
+
+    def is_configured(self) -> bool:
+        return self._repo().is_configured()
+
+    async def health_check(self):
+        return await self._repo().health_check()
+
+    async def search(self, request: SearchRequest) -> list[Candidate]:
+        indexer = self._indexer()
+        if request.kind == "track":
+            return await indexer.search_track(
+                request.artist_name,
+                request.track_title or "",
+                request.album_title,
+                request.duration_seconds,
+                timeout=request.timeout,
+            )
+        return await indexer.search_album(
+            request.artist_name,
+            request.album_title or "",
+            request.year,
+            request.track_count,
+            timeout=request.timeout,
+        )
+
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        return await self._repo().enqueue(request)
+
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        return await self._repo().get_status(handle)
+
+    async def cancel(self, handle: TaskHandle) -> bool:
+        return await self._repo().cancel(handle)
+
+    async def completed_path(self, handle: TaskHandle) -> list[Path]:
+        return await self._repo().list_completed_files(handle)
+
+    async def get_file_path(
+        self, handle: TaskHandle, remote_filename: str, size: int | None = None
+    ) -> Path | None:
+        return await self._repo().get_file_path(handle, remote_filename, size)
+
+    async def diagnose_downloads_mount(self) -> MountDiagnosis:
+        return await self._repo().diagnose_downloads_mount()
+
+    # -------------------------------------------------- orchestrator integration
+
+    def get_indexer(self):
+        # The exact pre-plugin object (SlskdIndexer singleton) - lossless wrapping.
+        return self._indexer()
+
+    def get_download_client(self):
+        # The exact pre-plugin object (SlskdRepository singleton) - lossless wrapping.
+        return self._repo()
+
+    # ------------------------------------------------------- built-in overrides
+
+    def enabled_override(self) -> bool | None:
+        return bool(self._prefs().get_download_client_settings().enabled)
+
+    def apply_enabled(self, enabled: bool) -> bool:
+        from core.dependencies.invalidation import clear_soulseek_chain
+
+        prefs = self._prefs()
+        current = prefs.get_download_client_settings_raw()
+        current.enabled = enabled
+        prefs.save_download_client_settings(current)
+        clear_soulseek_chain()
+        return True
+
+    def settings_values(self) -> dict[str, Any] | None:
+        raw = self._prefs().get_download_client_settings_raw()
+        return {
+            "url": raw.url,
+            "api_key": raw.api_key,
+            "downloads_subpath": raw.downloads_subpath,
+        }
+
+    def apply_settings(self, values: dict[str, Any]) -> bool:
+        from core.dependencies.invalidation import clear_soulseek_chain
+
+        prefs = self._prefs()
+        current = prefs.get_download_client_settings_raw()
+        current.url = str(values.get("url", current.url) or "")
+        current.api_key = str(values.get("api_key", current.api_key) or "")
+        current.downloads_subpath = str(
+            values.get("downloads_subpath", current.downloads_subpath) or ""
+        )
+        prefs.save_download_client_settings(current)
+        clear_soulseek_chain()
+        return True

--- a/backend/plugins/builtin/usenet_sabnzbd/__init__.py
+++ b/backend/plugins/builtin/usenet_sabnzbd/__init__.py
@@ -1,0 +1,3 @@
+"""Usenet (SABnzbd + Newznab indexers) built-in acquisition plugin."""
+
+from plugins.builtin.usenet_sabnzbd.plugin import UsenetSabnzbdPlugin  # noqa: F401

--- a/backend/plugins/builtin/usenet_sabnzbd/plugin.py
+++ b/backend/plugins/builtin/usenet_sabnzbd/plugin.py
@@ -1,0 +1,250 @@
+"""Usenet acquisition (SABnzbd download client + Newznab indexer search), as a plugin.
+
+DELEGATES to the pre-existing client code (``repositories/sabnzbd`` and
+``repositories/newznab``) through the same DI singletons the orchestrator used
+before the plugin layer existed (``get_sabnzbd_download_client`` /
+``get_newznab_indexer``), resolved lazily per call so a settings save (which
+cache-clears those singletons) is picked up without a restart. Behaviour is
+therefore byte-identical to the pre-plugin wiring.
+
+The plugin owns the SABnzbd connection settings (proxying the legacy
+``download_clients.sabnzbd`` preferences section). The Newznab indexer LIST
+stays a separate admin surface (``/api/v1/indexers``) - indexers are per-user
+sources, not plugin config - but this plugin's ``search`` capability fans out
+across them, and its readiness (``is_configured``) mirrors the pre-plugin rule:
+SABnzbd reachable AND at least one enabled indexer.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from plugins.base import (
+    AcquisitionPlugin,
+    Candidate,
+    DownloadTaskStatus,
+    EnqueueRequest,
+    MountDiagnosis,
+    SearchRequest,
+    SelectOption,
+    SettingsField,
+    TaskHandle,
+    TestResult,
+)
+
+
+class UsenetSabnzbdPlugin(AcquisitionPlugin):
+    id = "usenet"
+    name = "Usenet (SABnzbd)"
+    version = "1.0.0"
+
+    # ------------------------------------------------------------------ helpers
+
+    @staticmethod
+    def _client():
+        from core.dependencies import get_sabnzbd_download_client
+
+        return get_sabnzbd_download_client()
+
+    @staticmethod
+    def _indexer():
+        from core.dependencies import get_newznab_indexer
+
+        return get_newznab_indexer()
+
+    @staticmethod
+    def _prefs():
+        from core.dependencies import get_preferences_service
+
+        return get_preferences_service()
+
+    # ---------------------------------------------------------------- lifecycle
+
+    def settings_schema(self) -> list[SettingsField]:
+        return [
+            SettingsField(
+                key="url",
+                type="str",
+                label="SABnzbd URL",
+                help="Base URL of your SABnzbd instance, e.g. http://sabnzbd:8080",
+                default="",
+                required=True,
+            ),
+            SettingsField(
+                key="api_key",
+                type="secret",
+                label="API key",
+                help="The FULL SABnzbd API key (the add-only NZB key can't manage the queue).",
+                default="",
+                required=True,
+            ),
+            SettingsField(
+                key="category",
+                type="str",
+                label="Category",
+                help="SABnzbd category new downloads are filed under ('*' = default).",
+                default="*",
+            ),
+            SettingsField(
+                key="priority",
+                type="select",
+                label="Priority",
+                help="Queue priority SABnzbd assigns to DroppedNeedle downloads.",
+                default=0,
+                options=[
+                    SelectOption(value=-1, label="Low"),
+                    SelectOption(value=0, label="Normal"),
+                    SelectOption(value=1, label="High"),
+                    SelectOption(value=2, label="Force"),
+                ],
+            ),
+            SettingsField(
+                key="post_processing",
+                type="select",
+                label="Post-processing",
+                help="How far SABnzbd processes a finished job before hand-off.",
+                default=3,
+                options=[
+                    SelectOption(value=0, label="Skip"),
+                    SelectOption(value=1, label="Repair"),
+                    SelectOption(value=2, label="Repair + Unpack"),
+                    SelectOption(value=3, label="Repair + Unpack + Delete"),
+                ],
+            ),
+            SettingsField(
+                key="downloads_mount",
+                type="str",
+                label="Downloads mount",
+                help="Where DroppedNeedle sees SABnzbd's completed-downloads folder.",
+                default="/sabnzbd-downloads",
+            ),
+        ]
+
+    def configure(self, settings: dict[str, Any]) -> None:
+        # Reads the live preferences section on every call; nothing to hold.
+        return None
+
+    async def test_connection(self, settings: dict[str, Any] | None = None) -> TestResult:
+        from core.dependencies import build_sabnzbd_download_client
+        from core.exceptions import ExternalServiceError
+
+        current = self._prefs().get_sabnzbd_connection_raw()
+        values = settings or {"url": current.url, "api_key": current.api_key}
+        url = str(values.get("url") or "")
+        api_key = str(values.get("api_key") or "")
+        if not url:
+            return TestResult(ok=False, message="SABnzbd URL is required")
+        client = build_sabnzbd_download_client(url, api_key)
+        try:
+            status = await client.health_check()
+        except ExternalServiceError as exc:
+            return TestResult(ok=False, message=str(exc))
+        except Exception as exc:  # noqa: BLE001 - a failed test is a result, not a 500
+            return TestResult(ok=False, message=f"SABnzbd unreachable: {exc}")
+        if status.status != "ok":
+            return TestResult(
+                ok=False, message=status.message or "SABnzbd unreachable", version=status.version
+            )
+        return TestResult(ok=True, message=f"SABnzbd {status.version}", version=status.version)
+
+    # -------------------------------------------------------------- capabilities
+
+    def is_configured(self) -> bool:
+        # Mirrors the pre-plugin readiness rule: SABnzbd configured AND at least
+        # one enabled indexer to search (is_usenet_ready minus the enable flag).
+        return self._client().is_configured() and any(
+            i.enabled for i in self._prefs().get_indexers()
+        )
+
+    async def health_check(self):
+        return await self._client().health_check()
+
+    async def search(self, request: SearchRequest) -> list[Candidate]:
+        indexer = self._indexer()
+        if request.kind == "track":
+            return await indexer.search_track(
+                request.artist_name,
+                request.track_title or "",
+                request.album_title,
+                request.duration_seconds,
+                timeout=request.timeout,
+            )
+        return await indexer.search_album(
+            request.artist_name,
+            request.album_title or "",
+            request.year,
+            request.track_count,
+            timeout=request.timeout,
+        )
+
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        return await self._client().enqueue(request)
+
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        return await self._client().get_status(handle)
+
+    async def cancel(self, handle: TaskHandle) -> bool:
+        return await self._client().cancel(handle)
+
+    async def completed_path(self, handle: TaskHandle) -> list[Path]:
+        return await self._client().list_completed_files(handle)
+
+    async def get_file_path(
+        self, handle: TaskHandle, remote_filename: str, size: int | None = None
+    ) -> Path | None:
+        return await self._client().get_file_path(handle, remote_filename, size)
+
+    async def diagnose_downloads_mount(self) -> MountDiagnosis:
+        return await self._client().diagnose_downloads_mount()
+
+    # -------------------------------------------------- orchestrator integration
+
+    def get_indexer(self):
+        # The exact pre-plugin object (NewznabIndexer singleton) - lossless wrapping.
+        return self._indexer()
+
+    def get_download_client(self):
+        # The exact pre-plugin object (SabnzbdDownloadClient singleton) - lossless wrapping.
+        return self._client()
+
+    # ------------------------------------------------------- built-in overrides
+
+    def enabled_override(self) -> bool | None:
+        return bool(self._prefs().get_sabnzbd_connection().enabled)
+
+    def apply_enabled(self, enabled: bool) -> bool:
+        from core.dependencies.invalidation import clear_usenet_chain
+
+        prefs = self._prefs()
+        current = prefs.get_sabnzbd_connection_raw()
+        current.enabled = enabled
+        prefs.save_sabnzbd_connection(current)
+        clear_usenet_chain()
+        return True
+
+    def settings_values(self) -> dict[str, Any] | None:
+        raw = self._prefs().get_sabnzbd_connection_raw()
+        return {
+            "url": raw.url,
+            "api_key": raw.api_key,
+            "category": raw.category,
+            "priority": raw.priority,
+            "post_processing": raw.post_processing,
+            "downloads_mount": raw.downloads_mount,
+        }
+
+    def apply_settings(self, values: dict[str, Any]) -> bool:
+        from core.dependencies.invalidation import clear_usenet_chain
+
+        prefs = self._prefs()
+        current = prefs.get_sabnzbd_connection_raw()
+        current.url = str(values.get("url", current.url) or "")
+        current.api_key = str(values.get("api_key", current.api_key) or "")
+        current.category = str(values.get("category", current.category) or "*")
+        current.priority = int(values.get("priority", current.priority))
+        current.post_processing = int(values.get("post_processing", current.post_processing))
+        current.downloads_mount = str(
+            values.get("downloads_mount", current.downloads_mount) or ""
+        )
+        prefs.save_sabnzbd_connection(current)
+        clear_usenet_chain()
+        return True

--- a/backend/plugins/manager.py
+++ b/backend/plugins/manager.py
@@ -1,0 +1,501 @@
+"""``PluginManager`` - discovery, validation, quarantine, settings and registry.
+
+Discovery order (first registration of an id wins; later duplicates are
+quarantined):
+
+1. Built-ins: every subpackage of ``plugins/builtin``.
+2. External dir: ``{ROOT_APP_DIR}/plugins`` - single ``.py`` modules and
+   packages (a directory with ``__init__.py``).
+3. Installed distributions exposing the ``droppedneedle.plugins`` entry-point
+   group (each entry point resolves to an ``AcquisitionPlugin`` subclass).
+
+A plugin that raises on import/instantiate/configure, declares an incompatible
+``api_version``, or collides with an already-registered id is QUARANTINED: it
+appears in the registry with ``loaded=False`` and the error message, and the app
+keeps running. Discovery itself never raises.
+
+Per-plugin settings and the enable flag persist through the existing
+``PreferencesService`` config file under the ``plugins.{id}`` namespace
+(``secret`` fields Fernet-encrypted at rest, masked in API responses). Built-in
+plugins proxy both to their pre-existing settings sections via the
+``enabled_override / apply_enabled / settings_values / apply_settings`` hooks,
+so the legacy download-client routes and the plugin API stay in lockstep.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import importlib.util
+import inspect
+import logging
+import pkgutil
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from infrastructure.crypto import decrypt, encrypt
+from plugins.base import (
+    API_VERSION,
+    PLUGIN_SECRET_MASK,
+    AcquisitionPlugin,
+    SettingsField,
+    TestResult,
+)
+
+logger = logging.getLogger(__name__)
+
+ENTRY_POINT_GROUP = "droppedneedle.plugins"
+_CONFIG_KEY = "plugins"
+
+
+@dataclass
+class PluginRecord:
+    """One discovered plugin - loaded or quarantined."""
+
+    id: str
+    name: str = ""
+    version: str = ""
+    source: str = "external"  # "builtin" | "external" | "entry_point"
+    plugin: AcquisitionPlugin | None = None
+    error: str | None = None
+    module: str = ""
+
+    @property
+    def builtin(self) -> bool:
+        return self.source == "builtin"
+
+    @property
+    def loaded(self) -> bool:
+        return self.plugin is not None and self.error is None
+
+
+@dataclass
+class _Discovered:
+    """A candidate plugin class plus where it came from."""
+
+    cls: type
+    source: str
+    module: str
+    fallback_id: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+class PluginManager:
+    def __init__(self, preferences, external_dir: Path | None = None) -> None:
+        self._preferences = preferences
+        self._external_dir = external_dir
+        self._records: dict[str, PluginRecord] = {}
+        self._loaded = False
+
+    # ------------------------------------------------------------------ loading
+
+    def load(self) -> None:
+        """Discover and instantiate every plugin. Idempotent; never raises."""
+        if self._loaded:
+            return
+        self._loaded = True
+        for discovered in self._discover_builtin():
+            self._register(discovered)
+        for discovered in self._discover_external():
+            self._register(discovered)
+        for discovered in self._discover_entry_points():
+            self._register(discovered)
+        loaded = [r.id for r in self._records.values() if r.loaded]
+        broken = [r.id for r in self._records.values() if not r.loaded]
+        logger.info(
+            "plugins.loaded",
+            extra={"loaded": ",".join(loaded), "quarantined": ",".join(broken) or "-"},
+        )
+
+    def _register(self, discovered: _Discovered) -> None:
+        cls = discovered.cls
+        plugin_id = str(getattr(cls, "id", "") or discovered.fallback_id)
+        record = PluginRecord(
+            id=plugin_id or f"unknown:{discovered.module}",
+            name=str(getattr(cls, "name", "") or plugin_id),
+            version=str(getattr(cls, "version", "")),
+            source=discovered.source,
+            module=discovered.module,
+        )
+        if discovered.errors:
+            record.error = "; ".join(discovered.errors)
+        elif not plugin_id:
+            record.error = "plugin class declares no 'id'"
+        elif plugin_id in self._records:
+            record.error = (
+                f"duplicate plugin id {plugin_id!r} (already provided by "
+                f"{self._records[plugin_id].module or self._records[plugin_id].source})"
+            )
+            # keep the FIRST registration; store the duplicate under a synthetic key
+            self._records[f"{plugin_id}!{discovered.module}"] = record
+            logger.error(
+                "plugins.duplicate_id",
+                extra={"plugin": plugin_id, "plugin_module": discovered.module},
+            )
+            return
+        else:
+            declared = getattr(cls, "api_version", None)
+            if declared != API_VERSION:
+                record.error = (
+                    f"plugin targets api_version {declared!r}; this server provides "
+                    f"api_version {API_VERSION}"
+                )
+        if record.error is None:
+            try:
+                record.plugin = cls()
+                record.plugin.configure(self.get_settings_values(record, raw=True))
+            except Exception as exc:  # noqa: BLE001 - a bad plugin must never crash the app
+                record.plugin = None
+                record.error = f"failed to initialise: {exc}"
+                logger.exception("plugins.init_failed", extra={"plugin": record.id})
+        key = record.id
+        if key in self._records:  # collision-safe: never clobber an earlier registration
+            key = f"{key}!{discovered.module}"
+        self._records[key] = record
+        if record.error:
+            logger.error(
+                "plugins.quarantined", extra={"plugin": record.id, "error": record.error}
+            )
+
+    def _discover_builtin(self) -> list[_Discovered]:
+        out: list[_Discovered] = []
+        try:
+            import plugins.builtin as builtin_pkg
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("plugins.builtin_package_broken: %s", exc)
+            return out
+        for info in pkgutil.iter_modules(builtin_pkg.__path__):
+            module_name = f"plugins.builtin.{info.name}"
+            try:
+                module = importlib.import_module(module_name)
+            except Exception as exc:  # noqa: BLE001
+                out.append(
+                    _Discovered(
+                        cls=_BrokenPlugin,
+                        source="builtin",
+                        module=module_name,
+                        fallback_id=info.name,
+                        errors=[f"import failed: {exc}"],
+                    )
+                )
+                logger.exception(
+                    "plugins.builtin_import_failed", extra={"plugin_module": module_name}
+                )
+                continue
+            for cls in self._plugin_classes(module):
+                out.append(_Discovered(cls=cls, source="builtin", module=module_name))
+        return out
+
+    def _discover_external(self) -> list[_Discovered]:
+        out: list[_Discovered] = []
+        root = self._external_dir
+        if root is None or not root.is_dir():
+            return out
+        entries = sorted(root.iterdir(), key=lambda p: p.name.lower())
+        for entry in entries:
+            if entry.name.startswith(("_", ".")):
+                continue
+            is_module = entry.is_file() and entry.suffix == ".py"
+            is_package = entry.is_dir() and (entry / "__init__.py").is_file()
+            if not (is_module or is_package):
+                continue
+            stem = entry.stem if is_module else entry.name
+            module_name = f"droppedneedle_external_plugins.{stem}"
+            target = entry if is_module else entry / "__init__.py"
+            try:
+                spec = importlib.util.spec_from_file_location(
+                    module_name,
+                    target,
+                    submodule_search_locations=[str(entry)] if is_package else None,
+                )
+                if spec is None or spec.loader is None:
+                    raise ImportError(f"cannot build import spec for {entry}")
+                module = importlib.util.module_from_spec(spec)
+                # register before exec so package-relative imports resolve
+                import sys
+
+                sys.modules[module_name] = module
+                spec.loader.exec_module(module)
+            except Exception as exc:  # noqa: BLE001
+                out.append(
+                    _Discovered(
+                        cls=_BrokenPlugin,
+                        source="external",
+                        module=str(entry),
+                        fallback_id=stem,
+                        errors=[f"import failed: {exc}"],
+                    )
+                )
+                logger.exception("plugins.external_import_failed", extra={"path": str(entry)})
+                continue
+            classes = self._plugin_classes(module)
+            if not classes:
+                out.append(
+                    _Discovered(
+                        cls=_BrokenPlugin,
+                        source="external",
+                        module=str(entry),
+                        fallback_id=stem,
+                        errors=["no AcquisitionPlugin subclass found in module"],
+                    )
+                )
+                continue
+            for cls in classes:
+                out.append(_Discovered(cls=cls, source="external", module=str(entry)))
+        return out
+
+    def _discover_entry_points(self) -> list[_Discovered]:
+        out: list[_Discovered] = []
+        try:
+            eps = importlib.metadata.entry_points(group=ENTRY_POINT_GROUP)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("plugins.entry_point_scan_failed: %s", exc)
+            return out
+        for ep in eps:
+            try:
+                cls = ep.load()
+            except Exception as exc:  # noqa: BLE001
+                out.append(
+                    _Discovered(
+                        cls=_BrokenPlugin,
+                        source="entry_point",
+                        module=ep.value,
+                        fallback_id=ep.name,
+                        errors=[f"entry point load failed: {exc}"],
+                    )
+                )
+                logger.exception("plugins.entry_point_load_failed", extra={"entry_point": ep.name})
+                continue
+            if not (inspect.isclass(cls) and issubclass(cls, AcquisitionPlugin)):
+                out.append(
+                    _Discovered(
+                        cls=_BrokenPlugin,
+                        source="entry_point",
+                        module=ep.value,
+                        fallback_id=ep.name,
+                        errors=["entry point does not resolve to an AcquisitionPlugin subclass"],
+                    )
+                )
+                continue
+            out.append(_Discovered(cls=cls, source="entry_point", module=ep.value))
+        return out
+
+    @staticmethod
+    def _plugin_classes(module) -> list[type]:
+        """Concrete ``AcquisitionPlugin`` subclasses DEFINED in *module* (or, for a
+        package, exported by it - re-exports from the package's own submodules count)."""
+        found: list[type] = []
+        for _name, obj in vars(module).items():
+            if (
+                inspect.isclass(obj)
+                and issubclass(obj, AcquisitionPlugin)
+                and obj is not AcquisitionPlugin
+                and not inspect.isabstract(obj)
+                and obj.__module__.startswith(module.__name__.split(".")[0])
+            ):
+                if obj not in found:
+                    found.append(obj)
+        return found
+
+    # ----------------------------------------------------------------- registry
+
+    def list_records(self) -> list[PluginRecord]:
+        self.load()
+        return sorted(self._records.values(), key=lambda r: (not r.builtin, r.id))
+
+    def get_record(self, plugin_id: str) -> PluginRecord | None:
+        self.load()
+        return self._records.get(plugin_id)
+
+    def get_plugin(self, plugin_id: str) -> AcquisitionPlugin | None:
+        """The loaded plugin instance for *plugin_id* regardless of the enable
+        toggle (enablement is enforced by the orchestrator's live flags, exactly
+        as before the plugin layer existed). ``None`` when unknown/quarantined."""
+        record = self.get_record(plugin_id)
+        return record.plugin if record is not None and record.loaded else None
+
+    # --------------------------------------------------------------- enablement
+
+    def is_enabled(self, plugin_id: str) -> bool:
+        record = self.get_record(plugin_id)
+        if record is None or not record.loaded:
+            return False
+        override = record.plugin.enabled_override()
+        if override is not None:
+            return override
+        stored = self._plugin_config(plugin_id).get("enabled")
+        return bool(stored) if stored is not None else True
+
+    def set_enabled(self, plugin_id: str, enabled: bool) -> None:
+        record = self.get_record(plugin_id)
+        if record is None:
+            raise KeyError(plugin_id)
+        if record.loaded and record.plugin.apply_enabled(enabled):
+            return
+        cfg = self._plugin_config(plugin_id)
+        cfg["enabled"] = enabled
+        self._save_plugin_config(plugin_id, cfg)
+
+    # ----------------------------------------------------------------- settings
+
+    def get_settings_schema(self, plugin_id: str) -> list[SettingsField]:
+        record = self.get_record(plugin_id)
+        if record is None or not record.loaded:
+            return []
+        try:
+            return record.plugin.settings_schema()
+        except Exception:  # noqa: BLE001
+            logger.exception("plugins.schema_failed", extra={"plugin": plugin_id})
+            return []
+
+    def get_settings_values(
+        self, record_or_id: PluginRecord | str, *, raw: bool = False
+    ) -> dict[str, Any]:
+        """Current settings values. ``raw=True`` returns secrets decrypted (for
+        ``configure``); ``raw=False`` masks non-empty secrets (for API responses)."""
+        record = (
+            record_or_id
+            if isinstance(record_or_id, PluginRecord)
+            else self.get_record(record_or_id)
+        )
+        if record is None:
+            return {}
+        schema = []
+        values: dict[str, Any] | None = None
+        if record.plugin is not None:
+            try:
+                schema = record.plugin.settings_schema()
+                values = record.plugin.settings_values()
+            except Exception:  # noqa: BLE001
+                logger.exception("plugins.values_failed", extra={"plugin": record.id})
+        plugin_owned = values is not None
+        if values is None:
+            stored = dict(self._plugin_config(record.id).get("settings", {}))
+            values = stored
+        out: dict[str, Any] = {}
+        for descriptor in schema:
+            value = values.get(descriptor.key, descriptor.default)
+            if descriptor.type == "secret" and isinstance(value, str) and value:
+                if plugin_owned:
+                    # plugin returned the secret in the clear
+                    out[descriptor.key] = value if raw else PLUGIN_SECRET_MASK
+                else:
+                    # manager-stored: encrypted at rest
+                    out[descriptor.key] = (
+                        decrypt(value)[0] if raw else PLUGIN_SECRET_MASK
+                    )
+            else:
+                out[descriptor.key] = value
+        return out
+
+    def save_settings(self, plugin_id: str, values: dict[str, Any]) -> None:
+        """Persist and apply a settings mapping. Masked secret sentinels resolve
+        to the currently stored value; unknown keys are dropped."""
+        record = self.get_record(plugin_id)
+        if record is None or not record.loaded:
+            raise KeyError(plugin_id)
+        resolved = self._resolve_values(record, values)
+        if not record.plugin.apply_settings(resolved):
+            stored: dict[str, Any] = {}
+            for descriptor in record.plugin.settings_schema():
+                value = resolved.get(descriptor.key)
+                if descriptor.type == "secret" and isinstance(value, str) and value:
+                    stored[descriptor.key] = encrypt(value)
+                else:
+                    stored[descriptor.key] = value
+            cfg = self._plugin_config(plugin_id)
+            cfg["settings"] = stored
+            self._save_plugin_config(plugin_id, cfg)
+        record.plugin.configure(resolved)
+
+    def _resolve_values(self, record: PluginRecord, values: dict[str, Any]) -> dict[str, Any]:
+        """Coerce a submitted mapping onto the schema: keep known keys, fill
+        missing ones from current values, and swap masked secrets for the stored
+        plaintext."""
+        current = self.get_settings_values(record, raw=True)
+        resolved: dict[str, Any] = dict(current)
+        schema = {d.key: d for d in record.plugin.settings_schema()}
+        for key, value in values.items():
+            descriptor = schema.get(key)
+            if descriptor is None:
+                continue
+            if (
+                descriptor.type == "secret"
+                and isinstance(value, str)
+                and value == PLUGIN_SECRET_MASK
+            ):
+                continue  # keep current
+            if isinstance(value, str):
+                value = value.strip() if descriptor.type in ("secret", "str", "select") else value
+            resolved[key] = value
+        return resolved
+
+    async def test(self, plugin_id: str, values: dict[str, Any] | None = None) -> TestResult:
+        """Run the plugin's connection test - against *values* (masked secrets
+        resolved, nothing persisted) or the current configuration."""
+        record = self.get_record(plugin_id)
+        if record is None:
+            return TestResult(ok=False, message=f"unknown plugin {plugin_id!r}")
+        if not record.loaded:
+            return TestResult(ok=False, message=record.error or "plugin failed to load")
+        try:
+            resolved = self._resolve_values(record, values) if values else None
+            return await record.plugin.test_connection(resolved)
+        except Exception as exc:  # noqa: BLE001 - a broken test must not 500
+            logger.exception("plugins.test_failed", extra={"plugin": plugin_id})
+            return TestResult(ok=False, message=f"test failed: {exc}")
+
+    async def shutdown_all(self) -> None:
+        for record in self._records.values():
+            if record.loaded:
+                try:
+                    await record.plugin.shutdown()
+                except Exception:  # noqa: BLE001
+                    logger.exception("plugins.shutdown_failed", extra={"plugin": record.id})
+
+    # -------------------------------------------------------------- persistence
+
+    def _plugin_config(self, plugin_id: str) -> dict[str, Any]:
+        section = self._preferences.get_plugins_config()
+        return dict(section.get(plugin_id, {}))
+
+    def _save_plugin_config(self, plugin_id: str, cfg: dict[str, Any]) -> None:
+        # raw variant: acquisition settings are typed and pre-encrypted here, so
+        # they must bypass the manifest host's str-coercing save_plugin_config
+        self._preferences.save_plugin_config_raw(plugin_id, cfg)
+
+
+class _BrokenPlugin(AcquisitionPlugin):
+    """Placeholder class for discovery failures - registered so a broken module
+    still shows up (quarantined) in the admin registry. ``_register`` sees the
+    empty id / errors and never instantiates it as a working plugin."""
+
+    id = ""
+    name = ""
+    version = ""
+    api_version = -1  # guarantees quarantine even if something tries to load it
+
+    def settings_schema(self):  # pragma: no cover - never called
+        return []
+
+    def configure(self, settings):  # pragma: no cover - never called
+        return None
+
+    async def test_connection(self, settings=None):  # pragma: no cover - never called
+        return TestResult(ok=False, message="broken plugin")
+
+    async def search(self, request):  # pragma: no cover - never called
+        return []
+
+    async def enqueue(self, request):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    async def get_status(self, handle):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    async def cancel(self, handle):  # pragma: no cover - never called
+        return False
+
+    async def completed_path(self, handle):  # pragma: no cover - never called
+        return []

--- a/backend/services/preferences_service.py
+++ b/backend/services/preferences_service.py
@@ -899,6 +899,31 @@ class PreferencesService:
             logger.error(f"Failed to save plugin config for {plugin_name}: {e}")
             raise ConfigurationError("Failed to save plugin settings")
 
+    # --- Acquisition plugins - per-plugin namespaced config (plugins.{id}) --------
+    # The acquisition ``PluginManager`` owns the shape ({"enabled": bool,
+    # "settings": {...}} with secret values Fernet-encrypted by the manager against
+    # the plugin's typed schema); this layer only persists the namespaced dicts.
+    # Shares the ``plugins`` section with the manifest host's get/save above -
+    # acquisition plugin ids (source ids) and manifest plugin names live side by side.
+
+    def get_plugins_config(self) -> dict:
+        """The whole ``plugins`` section: ``{plugin_id: {...}}``."""
+        section = self._load_config().get("plugins", {})
+        return dict(section) if isinstance(section, dict) else {}
+
+    def save_plugin_config_raw(self, plugin_id: str, cfg: dict) -> None:
+        """Persist one plugin's raw config dict without the manifest host's
+        str-coercion (acquisition plugin settings are typed and pre-encrypted)."""
+        try:
+            config = self._load_config().copy()
+            section = dict(config.get("plugins", {}))
+            section[plugin_id] = cfg
+            config["plugins"] = section
+            self._save_config(config)
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Failed to save plugin config for {plugin_id}: {e}")
+            raise ConfigurationError(f"Failed to save plugin config: {e}")
+
     def _events_section_raw(self) -> EventsSettings:
         config = self._load_config()
         data = config.get("events", {})

--- a/backend/tests/plugins/test_mock_provider_external.py
+++ b/backend/tests/plugins/test_mock_provider_external.py
@@ -1,0 +1,113 @@
+"""Third-party loading proof: the shipped example plugin (docs/plugins/example/
+mock_provider.py) is copied - byte for byte - into a temporary external plugins
+dir, discovered by the manager, and driven through the full acquisition round
+trip (configure -> test -> search -> enqueue -> status -> completed_path ->
+cancel) plus the protocol adapters the orchestrator would consume."""
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from plugins.base import EnqueueRequest, SearchRequest
+from plugins.manager import PluginManager
+from repositories.protocols.download_client import DownloadClientProtocol
+from repositories.protocols.indexer import IndexerProtocol
+
+_EXAMPLE = (
+    Path(__file__).resolve().parents[3] / "docs" / "plugins" / "example" / "mock_provider.py"
+)
+
+
+class _FakePrefs:
+    def __init__(self):
+        self.store: dict[str, dict] = {}
+
+    def get_plugins_config(self) -> dict:
+        return dict(self.store)
+
+    def save_plugin_config_raw(self, plugin_id: str, cfg: dict) -> None:
+        self.store[plugin_id] = cfg
+
+
+@pytest.fixture()
+def manager(tmp_path):
+    ext = tmp_path / "root" / "plugins"
+    ext.mkdir(parents=True)
+    shutil.copy2(_EXAMPLE, ext / "mock_provider.py")
+    return PluginManager(preferences=_FakePrefs(), external_dir=ext)
+
+
+def test_example_plugin_is_discovered(manager):
+    record = manager.get_record("mock_provider")
+    assert record is not None and record.loaded, record.error
+    assert record.source == "external"
+    assert record.name == "Mock Provider"
+    assert manager.is_enabled("mock_provider") is True
+
+
+@pytest.mark.asyncio
+async def test_full_acquisition_round_trip(manager, tmp_path):
+    download_dir = tmp_path / "mock-downloads"
+    manager.save_settings("mock_provider", {"download_dir": str(download_dir)})
+    plugin = manager.get_plugin("mock_provider")
+
+    result = await manager.test("mock_provider")
+    assert result.ok, result.message
+
+    candidates = await plugin.search(
+        SearchRequest(kind="album", artist_name="Artist", album_title="Album", track_count=10)
+    )
+    assert len(candidates) == 3
+    assert all(c.source == "mock_provider" for c in candidates)
+    assert candidates[0].usenet is not None
+    assert "Artist - Album" in candidates[0].usenet.title
+
+    handle = await plugin.enqueue(
+        EnqueueRequest(task_id="t-42", source="mock_provider", job_name="dn-t-42")
+    )
+    assert handle.source == "mock_provider"
+    assert handle.job_name == "dn-t-42"
+
+    status = await plugin.get_status(handle)
+    assert status.status == "completed"
+    assert status.files_completed == status.files_total == 2
+
+    files = await plugin.completed_path(handle)
+    assert len(files) == 2
+    assert all(f.exists() for f in files)
+    assert all(str(f).startswith(str(download_dir)) for f in files)
+
+    assert await plugin.cancel(handle) is True
+    assert all(not f.exists() for f in files)
+
+
+@pytest.mark.asyncio
+async def test_example_plugin_adapters_satisfy_the_protocols(manager, tmp_path):
+    manager.save_settings("mock_provider", {"download_dir": str(tmp_path / "dl")})
+    plugin = manager.get_plugin("mock_provider")
+
+    indexer = plugin.get_indexer()
+    client = plugin.get_download_client()
+    assert isinstance(indexer, IndexerProtocol)
+    assert isinstance(client, DownloadClientProtocol)
+
+    results = await indexer.search_album("A", "B")
+    assert results and results[0].source == "mock_provider"
+
+    handle = await client.enqueue(
+        EnqueueRequest(task_id="t-1", source="mock_provider", job_name="dn-t-1")
+    )
+    files = await client.list_completed_files(handle)
+    assert files and all(f.exists() for f in files)
+    assert (await client.get_status(handle)).progress_percent == 100.0
+    assert (await client.health_check()).status == "ok"
+    assert await client.cancel(handle) is True
+
+
+def test_secret_field_round_trip(manager):
+    from plugins.base import PLUGIN_SECRET_MASK
+
+    manager.save_settings("mock_provider", {"api_token": "tok-123"})
+    assert manager.get_settings_values("mock_provider")["api_token"] == PLUGIN_SECRET_MASK
+    assert manager.get_settings_values("mock_provider", raw=True)["api_token"] == "tok-123"

--- a/backend/tests/plugins/test_plugin_base.py
+++ b/backend/tests/plugins/test_plugin_base.py
@@ -1,0 +1,144 @@
+"""Plugin adapter conformance: the generic ``PluginIndexerAdapter`` /
+``PluginDownloadClientAdapter`` satisfy ``IndexerProtocol`` /
+``DownloadClientProtocol`` at name, signature AND async-ness level (the same
+contract the slskd/SABnzbd implementations are held to), so a third-party
+plugin's search/acquire sides plug into the orchestrator with zero
+``services/native`` changes."""
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+from plugins.base import (
+    AcquisitionPlugin,
+    Candidate,
+    DownloadTaskStatus,
+    EnqueueRequest,
+    PluginDownloadClientAdapter,
+    PluginIndexerAdapter,
+    SearchRequest,
+    TaskHandle,
+    UsenetRelease,
+)
+from plugins.base import TestResult as PluginTestResult  # aliased: pytest must not collect it
+from repositories.protocols.download_client import DownloadClientProtocol
+from repositories.protocols.indexer import IndexerProtocol
+
+_CLIENT_METHODS = (
+    "is_configured",
+    "health_check",
+    "enqueue",
+    "get_status",
+    "cancel",
+    "list_completed_files",
+    "get_file_path",
+    "diagnose_downloads_mount",
+)
+
+_INDEXER_METHODS = (
+    "is_configured",
+    "health_check",
+    "search_album",
+    "search_track",
+)
+
+
+class _MinimalPlugin(AcquisitionPlugin):
+    id = "minimal"
+    name = "Minimal"
+    version = "0.1.0"
+
+    def settings_schema(self):
+        return []
+
+    def configure(self, settings):
+        return None
+
+    async def test_connection(self, settings=None):
+        return PluginTestResult(ok=True, message="ok", version="0.1.0")
+
+    async def search(self, request: SearchRequest) -> list[Candidate]:
+        return [
+            Candidate(
+                source=self.id,
+                usenet=UsenetRelease(
+                    indexer_id=self.id,
+                    indexer_name=self.name,
+                    guid="g",
+                    title=f"{request.artist_name} - {request.album_title or request.track_title}",
+                    nzb_url="mock://g",
+                ),
+            )
+        ]
+
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        return TaskHandle(source=self.id, job_name=request.job_name or request.task_id)
+
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        return DownloadTaskStatus(task_id="", status="completed", progress_percent=100.0)
+
+    async def cancel(self, handle: TaskHandle) -> bool:
+        return True
+
+    async def completed_path(self, handle: TaskHandle) -> list[Path]:
+        return [Path("/mock") / handle.job_name]
+
+
+def test_download_client_adapter_conforms():
+    adapter = PluginDownloadClientAdapter(_MinimalPlugin())
+
+    assert isinstance(adapter, DownloadClientProtocol)
+    assert adapter.client_name == "minimal"
+
+    for name in _CLIENT_METHODS:
+        proto_fn = getattr(DownloadClientProtocol, name)
+        impl_fn = getattr(type(adapter), name)
+        assert inspect.signature(impl_fn) == inspect.signature(proto_fn), name
+        assert inspect.iscoroutinefunction(impl_fn) == inspect.iscoroutinefunction(
+            proto_fn
+        ), name
+
+
+def test_indexer_adapter_conforms():
+    adapter = PluginIndexerAdapter(_MinimalPlugin())
+
+    assert isinstance(adapter, IndexerProtocol)
+    assert adapter.indexer_name == "minimal"
+
+    for name in _INDEXER_METHODS:
+        proto_fn = getattr(IndexerProtocol, name)
+        impl_fn = getattr(type(adapter), name)
+        assert inspect.signature(impl_fn) == inspect.signature(proto_fn), name
+        assert inspect.iscoroutinefunction(impl_fn) == inspect.iscoroutinefunction(
+            proto_fn
+        ), name
+
+
+@pytest.mark.asyncio
+async def test_adapters_delegate_round_trip():
+    plugin = _MinimalPlugin()
+    indexer = plugin.get_indexer()
+    client = plugin.get_download_client()
+
+    results = await indexer.search_album("Artist", "Album", 2020, 10)
+    assert len(results) == 1
+    assert results[0].source == "minimal"
+    assert results[0].usenet.title == "Artist - Album"
+
+    results = await indexer.search_track("Artist", "Track")
+    assert results[0].usenet.title == "Artist - Track"
+
+    handle = await client.enqueue(
+        EnqueueRequest(task_id="t1", source="minimal", job_name="job-1")
+    )
+    assert handle.job_name == "job-1"
+    status = await client.get_status(handle)
+    assert status.status == "completed"
+    files = await client.list_completed_files(handle)
+    assert files == [Path("/mock/job-1")]
+    assert await client.get_file_path(handle, "x") is None
+    assert (await client.diagnose_downloads_mount()).supported is False
+    health = await client.health_check()
+    assert health.status == "ok"
+    assert await client.cancel(handle) is True

--- a/backend/tests/plugins/test_plugin_manager.py
+++ b/backend/tests/plugins/test_plugin_manager.py
@@ -1,0 +1,312 @@
+"""PluginManager: built-in registration, external discovery (single .py module and
+package), entry-point discovery, api_version rejection, quarantine of broken
+modules, duplicate-id handling, enable/disable + settings persistence with
+secret masking."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from plugins.base import API_VERSION, PLUGIN_SECRET_MASK
+from plugins.manager import PluginManager
+
+_GOOD_PLUGIN = textwrap.dedent(
+    '''
+    from plugins.base import AcquisitionPlugin, SettingsField, TestResult
+
+
+    class GoodPlugin(AcquisitionPlugin):
+        id = "good_plugin"
+        name = "Good Plugin"
+        version = "2.3.4"
+
+        def settings_schema(self):
+            return [
+                SettingsField(key="endpoint", type="str", label="Endpoint", default="http://x"),
+                SettingsField(key="token", type="secret", label="Token", default=""),
+                SettingsField(key="limit", type="int", label="Limit", default=5),
+                SettingsField(key="fast", type="bool", label="Fast", default=True),
+            ]
+
+        def configure(self, settings):
+            self.applied = dict(settings)
+
+        async def test_connection(self, settings=None):
+            values = settings or getattr(self, "applied", {})
+            return TestResult(ok=bool(values.get("endpoint")), message="tested", version="2.3.4")
+
+        async def search(self, request):
+            return []
+
+        async def enqueue(self, request):
+            raise NotImplementedError
+
+        async def get_status(self, handle):
+            raise NotImplementedError
+
+        async def cancel(self, handle):
+            return True
+
+        async def completed_path(self, handle):
+            return []
+    '''
+)
+
+
+class _FakePrefs:
+    """Dict-backed stand-in for the two PreferencesService plugin methods."""
+
+    def __init__(self):
+        self.store: dict[str, dict] = {}
+
+    def get_plugins_config(self) -> dict:
+        return dict(self.store)
+
+    def save_plugin_config_raw(self, plugin_id: str, cfg: dict) -> None:
+        self.store[plugin_id] = cfg
+
+
+def _manager(tmp_path: Path) -> PluginManager:
+    return PluginManager(preferences=_FakePrefs(), external_dir=tmp_path / "plugins")
+
+
+def _external_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "plugins"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+# ------------------------------------------------------------- built-ins
+
+
+def test_builtins_are_registered(tmp_path):
+    manager = _manager(tmp_path)
+    records = {r.id: r for r in manager.list_records()}
+    assert "soulseek" in records and records["soulseek"].builtin
+    assert "usenet" in records and records["usenet"].builtin
+    assert records["soulseek"].loaded and records["usenet"].loaded
+    assert manager.get_plugin("soulseek") is not None
+    assert manager.get_plugin("usenet") is not None
+
+
+# ------------------------------------------------------- external discovery
+
+
+def test_external_single_module_loads(tmp_path):
+    (_external_dir(tmp_path) / "good_plugin.py").write_text(_GOOD_PLUGIN, encoding="utf-8")
+    manager = _manager(tmp_path)
+    record = manager.get_record("good_plugin")
+    assert record is not None and record.loaded
+    assert record.version == "2.3.4"
+    assert not record.builtin
+    # configure ran at load with schema defaults
+    assert manager.get_plugin("good_plugin").applied["endpoint"] == "http://x"
+    assert manager.get_plugin("good_plugin").applied["limit"] == 5
+
+
+def test_external_package_loads(tmp_path):
+    pkg = _external_dir(tmp_path) / "pkg_plugin"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text(
+        _GOOD_PLUGIN.replace("good_plugin", "pkg_plugin").replace("GoodPlugin", "PkgPlugin"),
+        encoding="utf-8",
+    )
+    manager = _manager(tmp_path)
+    record = manager.get_record("pkg_plugin")
+    assert record is not None and record.loaded
+
+
+def test_broken_external_module_is_quarantined_not_fatal(tmp_path):
+    ext = _external_dir(tmp_path)
+    (ext / "broken.py").write_text("raise RuntimeError('boom on import')", encoding="utf-8")
+    (ext / "good_plugin.py").write_text(_GOOD_PLUGIN, encoding="utf-8")
+    manager = _manager(tmp_path)
+    # the good one still loads; the broken one is quarantined with its error
+    assert manager.get_plugin("good_plugin") is not None
+    broken = manager.get_record("broken")
+    assert broken is not None and not broken.loaded
+    assert "boom on import" in (broken.error or "")
+
+
+def test_module_without_plugin_class_is_quarantined(tmp_path):
+    (_external_dir(tmp_path) / "empty.py").write_text("X = 1\n", encoding="utf-8")
+    manager = _manager(tmp_path)
+    record = manager.get_record("empty")
+    assert record is not None and not record.loaded
+    assert "no AcquisitionPlugin subclass" in (record.error or "")
+
+
+def test_wrong_api_version_is_rejected(tmp_path):
+    bad = _GOOD_PLUGIN.replace(
+        'version = "2.3.4"', f'version = "2.3.4"\n    api_version = {API_VERSION + 1}'
+    ).replace("good_plugin", "future_plugin")
+    (_external_dir(tmp_path) / "future_plugin.py").write_text(bad, encoding="utf-8")
+    manager = _manager(tmp_path)
+    record = manager.get_record("future_plugin")
+    assert record is not None and not record.loaded
+    assert f"api_version {API_VERSION + 1}" in (record.error or "")
+    assert manager.get_plugin("future_plugin") is None
+
+
+def test_duplicate_id_keeps_first_and_quarantines_second(tmp_path):
+    ext = _external_dir(tmp_path)
+    dup = _GOOD_PLUGIN.replace("good_plugin", "soulseek")  # collides with the built-in
+    (ext / "soulseek_clone.py").write_text(dup, encoding="utf-8")
+    manager = _manager(tmp_path)
+    record = manager.get_record("soulseek")
+    assert record is not None and record.builtin  # the FIRST registration won
+    duplicates = [r for r in manager.list_records() if "duplicate plugin id" in (r.error or "")]
+    assert len(duplicates) == 1
+
+
+def test_plugin_raising_in_init_is_quarantined(tmp_path):
+    src = _GOOD_PLUGIN.replace("good_plugin", "init_boom") + textwrap.dedent(
+        """
+        class InitBoom(GoodPlugin):
+            id = "boom_plugin"
+
+            def __init__(self):
+                raise RuntimeError("boom in init")
+        """
+    )
+    (_external_dir(tmp_path) / "init_boom.py").write_text(src, encoding="utf-8")
+    manager = _manager(tmp_path)
+    record = manager.get_record("boom_plugin")
+    assert record is not None and not record.loaded
+    assert "boom in init" in (record.error or "")
+    # the sibling class in the same module still loads
+    assert manager.get_plugin("init_boom") is not None
+
+
+# --------------------------------------------------------- entry points
+
+
+def test_entry_point_discovery(tmp_path, monkeypatch):
+    import importlib.metadata
+
+    from plugins.base import AcquisitionPlugin, TestResult
+
+    class EpPlugin(AcquisitionPlugin):
+        id = "ep_plugin"
+        name = "EP Plugin"
+        version = "0.1.0"
+
+        def settings_schema(self):
+            return []
+
+        def configure(self, settings):
+            return None
+
+        async def test_connection(self, settings=None):
+            return TestResult(ok=True)
+
+        async def search(self, request):
+            return []
+
+        async def enqueue(self, request):
+            raise NotImplementedError
+
+        async def get_status(self, handle):
+            raise NotImplementedError
+
+        async def cancel(self, handle):
+            return True
+
+        async def completed_path(self, handle):
+            return []
+
+    class _FakeEp:
+        name = "ep_plugin"
+        value = "some_dist:EpPlugin"
+
+        @staticmethod
+        def load():
+            return EpPlugin
+
+    real_entry_points = importlib.metadata.entry_points
+
+    def fake_entry_points(**kwargs):
+        if kwargs.get("group") == "droppedneedle.plugins":
+            return [_FakeEp()]
+        return real_entry_points(**kwargs)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    manager = _manager(tmp_path)
+    record = manager.get_record("ep_plugin")
+    assert record is not None and record.loaded and record.source == "entry_point"
+
+
+# --------------------------------------------- enablement + settings persistence
+
+
+def test_external_enable_disable_persists(tmp_path):
+    (_external_dir(tmp_path) / "good_plugin.py").write_text(_GOOD_PLUGIN, encoding="utf-8")
+    prefs = _FakePrefs()
+    manager = PluginManager(preferences=prefs, external_dir=tmp_path / "plugins")
+    assert manager.is_enabled("good_plugin") is True  # default on
+    manager.set_enabled("good_plugin", False)
+    assert manager.is_enabled("good_plugin") is False
+    assert prefs.store["good_plugin"]["enabled"] is False
+    # a fresh manager over the same store sees the persisted flag
+    manager2 = PluginManager(preferences=prefs, external_dir=tmp_path / "plugins")
+    assert manager2.is_enabled("good_plugin") is False
+
+
+def test_settings_roundtrip_masks_and_preserves_secret(tmp_path):
+    (_external_dir(tmp_path) / "good_plugin.py").write_text(_GOOD_PLUGIN, encoding="utf-8")
+    prefs = _FakePrefs()
+    manager = PluginManager(preferences=prefs, external_dir=tmp_path / "plugins")
+
+    manager.save_settings(
+        "good_plugin",
+        {"endpoint": "http://real", "token": "s3cret", "limit": 9, "fast": False},
+    )
+    plugin = manager.get_plugin("good_plugin")
+    assert plugin.applied == {
+        "endpoint": "http://real",
+        "token": "s3cret",
+        "limit": 9,
+        "fast": False,
+    }
+    # at rest the secret is encrypted, never plaintext
+    assert prefs.store["good_plugin"]["settings"]["token"] != "s3cret"
+
+    masked = manager.get_settings_values("good_plugin")
+    assert masked["token"] == PLUGIN_SECRET_MASK
+    assert masked["endpoint"] == "http://real"
+
+    # saving the mask back preserves the stored secret
+    manager.save_settings("good_plugin", {"endpoint": "http://real2", "token": PLUGIN_SECRET_MASK})
+    assert plugin.applied["token"] == "s3cret"
+    assert plugin.applied["endpoint"] == "http://real2"
+    # unchanged keys survive a partial save
+    assert plugin.applied["limit"] == 9
+
+    raw = manager.get_settings_values("good_plugin", raw=True)
+    assert raw["token"] == "s3cret"
+
+
+@pytest.mark.asyncio
+async def test_test_connection_uses_submitted_values_without_saving(tmp_path):
+    (_external_dir(tmp_path) / "good_plugin.py").write_text(_GOOD_PLUGIN, encoding="utf-8")
+    prefs = _FakePrefs()
+    manager = PluginManager(preferences=prefs, external_dir=tmp_path / "plugins")
+    result = await manager.test("good_plugin", {"endpoint": ""})
+    assert result.ok is False
+    result = await manager.test("good_plugin", {"endpoint": "http://y"})
+    assert result.ok is True and result.version == "2.3.4"
+    # nothing persisted by testing
+    assert "settings" not in prefs.store.get("good_plugin", {})
+
+
+@pytest.mark.asyncio
+async def test_test_unknown_plugin_is_a_result_not_an_error(tmp_path):
+    manager = _manager(tmp_path)
+    result = await manager.test("nope")
+    assert result.ok is False and "unknown plugin" in result.message
+
+
+def test_missing_external_dir_is_fine(tmp_path):
+    manager = PluginManager(preferences=_FakePrefs(), external_dir=tmp_path / "does-not-exist")
+    assert manager.get_plugin("soulseek") is not None

--- a/backend/tests/plugins/test_plugin_routes.py
+++ b/backend/tests/plugins/test_plugin_routes.py
@@ -1,0 +1,195 @@
+"""Admin plugin API routes: admin gating, list shape, enable/disable, settings
+GET/PUT with masked secrets, and the test endpoint."""
+
+import textwrap
+
+from fastapi import FastAPI, HTTPException
+
+from api.v1.routes import plugins as plugins_routes
+from core.dependencies import get_plugin_manager
+from middleware import _get_current_admin
+from plugins.base import API_VERSION, PLUGIN_SECRET_MASK
+from plugins.manager import PluginManager
+from tests.helpers import build_test_client, mock_admin_user
+
+_EXTERNAL_PLUGIN = textwrap.dedent(
+    '''
+    from plugins.base import AcquisitionPlugin, SettingsField, TestResult
+
+
+    class RoutePlugin(AcquisitionPlugin):
+        id = "route_plugin"
+        name = "Route Plugin"
+        version = "1.1.0"
+
+        def settings_schema(self):
+            return [
+                SettingsField(key="endpoint", type="str", label="Endpoint", default=""),
+                SettingsField(key="token", type="secret", label="Token", default=""),
+            ]
+
+        def configure(self, settings):
+            self.applied = dict(settings)
+
+        async def test_connection(self, settings=None):
+            values = settings or getattr(self, "applied", {})
+            if not values.get("endpoint"):
+                return TestResult(ok=False, message="endpoint required")
+            return TestResult(ok=True, message="reachable", version="9.9")
+
+        async def search(self, request):
+            return []
+
+        async def enqueue(self, request):
+            raise NotImplementedError
+
+        async def get_status(self, handle):
+            raise NotImplementedError
+
+        async def cancel(self, handle):
+            return True
+
+        async def completed_path(self, handle):
+            return []
+    '''
+)
+
+
+class _FakePrefs:
+    def __init__(self):
+        self.store: dict[str, dict] = {}
+
+    def get_plugins_config(self) -> dict:
+        return dict(self.store)
+
+    def save_plugin_config_raw(self, plugin_id: str, cfg: dict) -> None:
+        self.store[plugin_id] = cfg
+
+
+def _manager(tmp_path) -> PluginManager:
+    ext = tmp_path / "plugins"
+    ext.mkdir(parents=True, exist_ok=True)
+    (ext / "route_plugin.py").write_text(_EXTERNAL_PLUGIN, encoding="utf-8")
+    (ext / "broken.py").write_text("raise RuntimeError('kaput')", encoding="utf-8")
+    return PluginManager(preferences=_FakePrefs(), external_dir=ext)
+
+
+def _app(manager) -> FastAPI:
+    app = FastAPI()
+    app.include_router(plugins_routes.router)
+    app.dependency_overrides[get_plugin_manager] = lambda: manager
+    return app
+
+
+def _deny_admin():
+    raise HTTPException(status_code=403, detail="admin only")
+
+
+def _admin_client(tmp_path):
+    manager = _manager(tmp_path)
+    app = _app(manager)
+    app.dependency_overrides[_get_current_admin] = mock_admin_user
+    return build_test_client(app), manager
+
+
+def test_list_requires_admin(tmp_path):
+    app = _app(_manager(tmp_path))
+    app.dependency_overrides[_get_current_admin] = _deny_admin
+    assert build_test_client(app).get("/plugins").status_code == 403
+
+
+def test_list_shape_builtins_external_and_quarantined(tmp_path):
+    client, _ = _admin_client(tmp_path)
+    resp = client.get("/plugins")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["api_version"] == API_VERSION
+    by_id = {p["id"]: p for p in body["plugins"]}
+
+    assert by_id["soulseek"]["builtin"] is True
+    assert by_id["soulseek"]["loaded"] is True
+    assert by_id["usenet"]["builtin"] is True
+
+    ext = by_id["route_plugin"]
+    assert ext["builtin"] is False
+    assert ext["loaded"] is True
+    assert ext["version"] == "1.1.0"
+    assert ext["enabled"] is True
+
+    broken = next(p for p in body["plugins"] if "kaput" in (p["error"] or ""))
+    assert broken["loaded"] is False
+    assert broken["enabled"] is False
+
+
+def test_enable_disable_roundtrip(tmp_path):
+    client, manager = _admin_client(tmp_path)
+    resp = client.post("/plugins/route_plugin/disable")
+    assert resp.status_code == 200
+    assert resp.json() == {"id": "route_plugin", "enabled": False}
+    assert manager.is_enabled("route_plugin") is False
+    resp = client.post("/plugins/route_plugin/enable")
+    assert resp.json()["enabled"] is True
+
+
+def test_enable_unknown_404_and_broken_409(tmp_path):
+    client, _ = _admin_client(tmp_path)
+    assert client.post("/plugins/nope/enable").status_code == 404
+    assert client.post("/plugins/broken/enable").status_code == 409
+
+
+def test_settings_get_put_masks_secret(tmp_path):
+    client, manager = _admin_client(tmp_path)
+
+    resp = client.get("/plugins/route_plugin/settings")
+    assert resp.status_code == 200
+    body = resp.json()
+    keys = [f["key"] for f in body["schema"]]
+    assert keys == ["endpoint", "token"]
+    assert body["values"]["token"] == ""
+
+    resp = client.put(
+        "/plugins/route_plugin/settings",
+        json={"values": {"endpoint": "http://z", "token": "hush"}},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["values"]["token"] == PLUGIN_SECRET_MASK
+    assert resp.json()["values"]["endpoint"] == "http://z"
+    assert manager.get_plugin("route_plugin").applied["token"] == "hush"
+
+    # PUTting the mask back preserves the real secret
+    resp = client.put(
+        "/plugins/route_plugin/settings",
+        json={"values": {"endpoint": "http://z2", "token": PLUGIN_SECRET_MASK}},
+    )
+    assert resp.status_code == 200
+    assert manager.get_plugin("route_plugin").applied["token"] == "hush"
+    assert manager.get_plugin("route_plugin").applied["endpoint"] == "http://z2"
+
+
+def test_settings_non_admin_forbidden(tmp_path):
+    app = _app(_manager(tmp_path))
+    app.dependency_overrides[_get_current_admin] = _deny_admin
+    client = build_test_client(app)
+    assert client.get("/plugins/route_plugin/settings").status_code == 403
+    assert client.put("/plugins/route_plugin/settings", json={"values": {}}).status_code == 403
+    assert client.post("/plugins/route_plugin/test", json={}).status_code == 403
+    assert client.post("/plugins/route_plugin/enable").status_code == 403
+
+
+def test_test_endpoint_uses_submitted_values(tmp_path):
+    client, _ = _admin_client(tmp_path)
+    resp = client.post("/plugins/route_plugin/test", json={"values": {"endpoint": ""}})
+    assert resp.status_code == 200
+    # empty submitted endpoint -> falls back to stored (also empty) -> invalid
+    assert resp.json()["valid"] is False
+
+    resp = client.post("/plugins/route_plugin/test", json={"values": {"endpoint": "http://up"}})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is True
+    assert body["version"] == "9.9"
+
+
+def test_test_endpoint_unknown_plugin_404(tmp_path):
+    client, _ = _admin_client(tmp_path)
+    assert client.post("/plugins/nope/test", json={}).status_code == 404

--- a/backend/tests/plugins/test_registry_equivalence.py
+++ b/backend/tests/plugins/test_registry_equivalence.py
@@ -1,0 +1,84 @@
+"""Orchestrator-via-registry equivalence: the plugin layer must be a lossless
+wrapper. The built-in plugins hand the orchestrator the EXACT same singleton
+objects the pre-plugin providers built (SlskdRepository / SlskdIndexer /
+SabnzbdDownloadClient / NewznabIndexer), so download behaviour is byte-identical
+- identity assertions prove it, and would fail on any 'helpful' re-wrapping."""
+
+import pytest
+
+from core.dependencies import (
+    get_newznab_indexer,
+    get_plugin_manager,
+    get_sabnzbd_download_client,
+    get_slskd_indexer,
+    get_slskd_repository,
+)
+from core.dependencies._registry import clear_all_singletons
+
+
+@pytest.fixture(autouse=True)
+def _fresh_singletons():
+    clear_all_singletons()
+    yield
+    clear_all_singletons()
+
+
+def test_builtin_plugins_expose_the_exact_core_singletons():
+    manager = get_plugin_manager()
+
+    soulseek = manager.get_plugin("soulseek")
+    assert soulseek is not None
+    assert soulseek.get_download_client() is get_slskd_repository()
+    assert soulseek.get_indexer() is get_slskd_indexer()
+
+    usenet = manager.get_plugin("usenet")
+    assert usenet is not None
+    assert usenet.get_download_client() is get_sabnzbd_download_client()
+    assert usenet.get_indexer() is get_newznab_indexer()
+
+
+def test_orchestrator_resolves_clients_through_the_registry():
+    from core.dependencies.service_providers import get_download_orchestrator
+
+    orchestrator = get_download_orchestrator()
+    assert orchestrator._client is get_slskd_repository()
+    # the usenet strategy holds the registry-resolved SABnzbd client
+    assert orchestrator._strategies["usenet"]._client is get_sabnzbd_download_client()
+    assert orchestrator._strategies["soulseek"]._indexer is get_slskd_indexer()
+    assert orchestrator._strategies["usenet"]._indexer is get_newznab_indexer()
+
+
+def test_download_service_resolves_clients_through_the_registry():
+    from core.dependencies.service_providers import get_download_service
+
+    service = get_download_service()
+    assert service._client is get_slskd_repository()
+    assert service._indexer is get_slskd_indexer()
+    assert service._usenet_indexer is get_newznab_indexer()
+
+
+def test_rebuild_after_cache_clear_tracks_fresh_singletons():
+    """A settings save cache-clears the slskd chain and rebuilds the orchestrator;
+    the plugin must hand the REBUILT singleton to the new orchestrator, never a
+    stale captured instance."""
+    from core.dependencies.invalidation import clear_soulseek_chain
+    from core.dependencies.service_providers import get_download_orchestrator
+
+    first_repo = get_slskd_repository()
+    first_orch = get_download_orchestrator()
+    assert first_orch._client is first_repo
+
+    clear_soulseek_chain()
+
+    second_repo = get_slskd_repository()
+    second_orch = get_download_orchestrator()
+    assert second_repo is not first_repo
+    assert second_orch is not first_orch
+    assert second_orch._client is second_repo
+
+
+def test_get_download_client_for_source_routes_via_registry():
+    from core.dependencies import get_download_client_for_source
+
+    assert get_download_client_for_source("soulseek") is get_slskd_repository()
+    assert get_download_client_for_source("usenet") is get_sabnzbd_download_client()

--- a/docs/plugins/AUTHORING.md
+++ b/docs/plugins/AUTHORING.md
@@ -1,0 +1,248 @@
+# Authoring an Acquisition Plugin
+
+This guide takes you from empty file to a distributed plugin. It assumes you
+are a competent Python developer; it does **not** assume you know this
+codebase. Read [README.md](README.md) first for the scope boundary — your
+plugin ends where the finished files sit on disk; the core import pipeline
+takes it from there.
+
+## 0. Ground rules
+
+* **You are async code on the app's event loop.** Never block. Use
+  `httpx.AsyncClient`, `asyncio.to_thread` for file I/O bursts, etc.
+* **Never crash the host.** Raise freely inside your methods — the orchestrator
+  treats a raising source as a failed source — but your module import,
+  `__init__` and `configure` must be cheap and safe. A plugin that raises on
+  load is quarantined (visible in Settings → Plugins with the error) and the
+  app keeps running without it.
+* **Ship no sources.** DroppedNeedle's legality boundary: the user supplies
+  every endpoint. Do not hard-code indexer/tracker URLs or credentials;
+  everything reachable must come from your settings schema.
+* **Secrets go in `secret` fields.** The manager encrypts them at rest and
+  masks them in API responses. Never log them.
+
+## 1. Scaffold
+
+Create `my_provider.py` (a single module is a complete plugin):
+
+```python
+from pathlib import Path
+from typing import Any
+
+from plugins.base import (
+    AcquisitionPlugin, Candidate, DownloadTaskStatus, EnqueueRequest,
+    SearchRequest, SettingsField, TaskHandle, TestResult, UsenetRelease,
+)
+
+
+class MyProviderPlugin(AcquisitionPlugin):
+    id = "my_provider"          # stable, lowercase, [a-z0-9_]; doubles as the source id
+    name = "My Provider"        # what admins see
+    version = "1.0.0"           # your release version (semver recommended)
+    # api_version defaults to the version of plugins.base you imported at dev
+    # time; PIN IT explicitly when distributing (see §7).
+
+    def settings_schema(self): ...
+    def configure(self, settings): ...
+    async def test_connection(self, settings=None): ...
+    async def search(self, request): ...
+    async def enqueue(self, request): ...
+    async def get_status(self, handle): ...
+    async def cancel(self, handle): ...
+    async def completed_path(self, handle): ...
+```
+
+Drop it into `{ROOT_APP_DIR}/plugins/` and restart. It appears on
+*Settings → Plugins*. A package works exactly the same way: a directory with an
+`__init__.py` that defines (or re-exports) your plugin class.
+
+The fastest way to see all of this working end-to-end is the shipped example:
+[example/mock_provider.py](example/mock_provider.py).
+
+## 2. Settings schema
+
+Describe your configuration as typed field descriptors; the admin UI renders
+the form, and the manager persists/encrypts values for you:
+
+```python
+def settings_schema(self):
+    return [
+        SettingsField(key="url", type="str", label="Server URL",
+                      help="e.g. http://myclient:1234", required=True, default=""),
+        SettingsField(key="api_key", type="secret", label="API key", default=""),
+        SettingsField(key="max_results", type="int", label="Max results", default=25),
+        SettingsField(key="prefer_lossless", type="bool", label="Prefer lossless", default=True),
+        SettingsField(key="mode", type="select", label="Mode", default="fast",
+                      options=[SelectOption(value="fast", label="Fast"),
+                               SelectOption(value="thorough", label="Thorough")]),
+    ]
+```
+
+Field types: `str`, `int`, `bool`, `select` (with `options`), `secret`
+(rendered as a password input with show/hide; encrypted at rest; masked as
+`plugin****` on read — when you receive the mask back you never will: the
+manager resolves it to the stored plaintext before calling you).
+
+`configure(settings)` is called once after load (with persisted values, secrets
+decrypted, missing keys filled from your declared defaults) and again after
+every save. Store the values on `self`; do **not** open connections here.
+
+## 3. `test_connection`
+
+```python
+async def test_connection(self, settings=None):
+    values = settings or self._current_values
+    try:
+        version = await self._ping(values["url"], values["api_key"])
+    except Exception as exc:
+        return TestResult(ok=False, message=f"unreachable: {exc}")
+    return TestResult(ok=True, message=f"connected", version=version)
+```
+
+`settings` is `None` when the admin tests the *saved* config, and a full values
+mapping when they hit **Test** with unsaved form edits — test what you're
+given, persist nothing. Return `TestResult`; never raise (a raise is caught and
+reported as a generic failure, which is a worse message than yours).
+
+## 4. Implementing the capabilities
+
+### `search(request) -> list[Candidate]`
+
+`SearchRequest.kind` is `"album"` or `"track"`; honour `request.timeout`
+(seconds). Return candidates *tagged with your plugin id* in `source`, in one
+of the two archetypal shapes:
+
+```python
+async def search(self, request):
+    rows = await self._api_search(f"{request.artist_name} {request.album_title}")
+    return [
+        Candidate(source=self.id, usenet=UsenetRelease(
+            indexer_id=self.id, indexer_name=self.name,
+            guid=row["id"], title=row["title"],
+            nzb_url=row["download_url"], size_bytes=row["bytes"],
+        ))
+        for row in rows
+    ]
+```
+
+Use the release shape (`usenet=UsenetRelease(...)`) for "one downloadable
+archive per result" networks; use the per-file shape
+(`soulseek=DownloadSearchResult(...)`) for peer-to-peer, per-file networks.
+Return `[]` for "nothing found" — that is a result, not an error.
+
+### `enqueue(request) -> TaskHandle`
+
+`EnqueueRequest` carries `task_id` plus the fields of the candidate that was
+picked (`files` for per-file sources; `nzb_url`/`job_name`/`category` for
+release sources). Start the download in your client and return a `TaskHandle`
+holding whatever *you* need to find the job again — the core persists the
+handle verbatim and hands it back to every later call. `job_name`
+(`droppedneedle-{task_id}`) is the crash-safe correlation key: prefer honouring
+it so a job can be found even if the app dies before your client returns an id.
+
+### `get_status(handle) -> DownloadTaskStatus`
+
+Polled every couple of seconds while the task runs. Fill in what you know:
+`status` (`"queued" | "downloading" | "completed" | "failed"`), byte/file
+counters, `progress_percent`, `error`. Two fields materially affect the
+watchdogs: `has_active_transfer` (distinguishes an actively-moving transfer
+from one parked in a remote queue) and `succeeded_filenames` (lets the core
+import the finished subset of a partially-failed job).
+
+### `completed_path(handle) -> list[Path]`
+
+The hand-off. Return the on-disk paths of the finished job's audio files, in a
+location the DroppedNeedle process can read (for containerised setups that
+means a shared mount — document what your users must mount). The core moves
+the files; you should not delete them yourself on success.
+
+### `cancel(handle) -> bool`
+
+Cancel the job if still running AND/OR clean up its transfer records. Called
+both for user cancellation and post-import cleanup. Idempotent; `True` on
+success.
+
+### Optional overrides
+
+* `get_file_path(handle, remote_filename, size)` — resolve one remote filename
+  to its local path, if your client's layout allows it.
+* `diagnose_downloads_mount()` — cross-check your client's completed downloads
+  against the mount, to catch misconfigured paths proactively.
+* `health_check()` — liveness (defaults to deriving from `test_connection`).
+* `is_configured()` — "has enough config to try at all" (defaults to `True`).
+* `shutdown()` — close clients on app exit.
+
+## 5. Testing locally
+
+* **Unit-test against the ABC directly** — everything is plain Python:
+
+  ```python
+  plugin = MyProviderPlugin()
+  plugin.configure({"url": "http://x", "api_key": "k"})
+  candidates = await plugin.search(SearchRequest(kind="album",
+      artist_name="Artist", album_title="Album"))
+  ```
+
+* **Load-test through the manager** the way the app does (this is exactly what
+  `backend/tests/plugins/test_mock_provider_external.py` does with the example
+  plugin — copy that file as your starting point):
+
+  ```python
+  from plugins.manager import PluginManager
+  manager = PluginManager(preferences=fake_prefs, external_dir=dir_with_your_py)
+  assert manager.get_record("my_provider").loaded
+  ```
+
+* **Live**: copy your file into `{ROOT_APP_DIR}/plugins/`, restart, open
+  *Settings → Plugins*, fill the form, hit **Test**. Discovery/quarantine
+  problems are logged under the `plugins.*` log events.
+
+## 6. Packaging & distribution
+
+Two options:
+
+1. **Drop-in** (simplest): distribute the `.py` file (or package folder);
+   operators copy it into `{ROOT_APP_DIR}/plugins/`.
+2. **pip package with an entry point** (versioned installs, dependencies):
+
+   ```toml
+   # pyproject.toml of your distribution
+   [project]
+   name = "droppedneedle-my-provider"
+   version = "1.0.0"
+
+   [project.entry-points."droppedneedle.plugins"]
+   my_provider = "droppedneedle_my_provider:MyProviderPlugin"
+   ```
+
+   Installed into the app's environment, the manager discovers it via the
+   `droppedneedle.plugins` entry-point group — no file copying.
+
+If your module fails to import because of a missing dependency, you're
+quarantined with that ImportError; prefer the pip route when you have deps.
+
+## 7. Versioning & `api_version` policy
+
+* `version` is **yours** — release however you like (semver recommended).
+* `api_version` is the **contract version** of `plugins.base` you wrote
+  against. The server refuses (quarantines) any plugin whose `api_version`
+  differs from its own `plugins.base.API_VERSION` — there is no silent
+  best-effort compatibility. The policy:
+  * The API version bumps **only on breaking changes** to the base class,
+    the exchange structs, or the manager's calling conventions.
+  * Purely additive changes (new optional fields with defaults, new optional
+    hooks) do **not** bump it.
+  * When distributing, pin it explicitly (`api_version = 1`) so a future
+    server rejects you with a clear message instead of failing mid-download.
+
+## 8. Error-handling rules
+
+| Where                    | Rule                                                              |
+| ------------------------ | ----------------------------------------------------------------- |
+| module import / `__init__` / `configure` | Must not raise for bad *values* — you'll be quarantined. Validate lazily. |
+| `test_connection`        | Never raise; return `TestResult(ok=False, message=...)`.          |
+| `search`                 | `[]` means "nothing found". Raise (or let httpx raise) only for real faults — the orchestrator fails over to the next source. |
+| `enqueue`                | Raise on failure — the orchestrator counts it as a failed attempt and retries/fails over per its policy. |
+| `get_status`             | Prefer returning `status="failed"` + `error` for job-level failures; raise only for transport faults. |
+| `cancel` / `shutdown`    | Best-effort; swallow your own cleanup errors.                     |
+| messages                 | Error strings you return may be shown to users verbatim: be specific, actionable, and never include secrets. |

--- a/docs/plugins/INTERFACE.md
+++ b/docs/plugins/INTERFACE.md
@@ -1,0 +1,273 @@
+# Plugin Interface Reference
+
+Authoritative reference for `plugins.base` (the plugin contract) and
+`plugins.manager` (the host side). Everything a plugin imports comes from
+`plugins.base`; the exchange structs are re-exports of the orchestrator's own
+protocol types (`repositories/protocols/`), so they are identical to what the
+core exchanges with the built-in clients.
+
+```python
+from plugins.base import (
+    API_VERSION, PLUGIN_SECRET_MASK,
+    AcquisitionPlugin,
+    SettingsField, SelectOption, TestResult, SearchRequest,
+    Candidate, DownloadSearchResult, UsenetRelease,
+    EnqueueRequest, DownloadFileRef, TaskHandle,
+    DownloadTaskStatus, MountDiagnosis,
+    PluginIndexerAdapter, PluginDownloadClientAdapter,
+)
+```
+
+## Module constants
+
+| Name                  | Type  | Meaning                                                       |
+| --------------------- | ----- | ------------------------------------------------------------- |
+| `API_VERSION`         | `int` | The plugin-contract version this server implements (currently `1`). |
+| `PLUGIN_SECRET_MASK`  | `str` | `"plugin****"` — what a stored non-empty `secret` value reads as in API responses. |
+
+---
+
+## class `AcquisitionPlugin` (ABC)
+
+### Identity (class attributes — override all three)
+
+```python
+id: ClassVar[str] = ""            # stable machine id; doubles as the source id ('soulseek', 'usenet', ...)
+name: ClassVar[str] = ""          # human-readable display name
+version: ClassVar[str] = "0.0.0"  # the plugin's own release version
+api_version: ClassVar[int] = API_VERSION  # contract version; mismatch => quarantined
+```
+
+### Lifecycle
+
+```python
+def settings_schema(self) -> list[SettingsField]            # abstract
+def configure(self, settings: dict[str, Any]) -> None       # abstract
+async def test_connection(self, settings: dict | None = None) -> TestResult  # abstract
+async def shutdown(self) -> None                            # default: no-op
+```
+
+* `configure` — called after load with persisted values (secrets decrypted,
+  missing keys defaulted from the schema) and again after every settings save.
+  Must be cheap, no I/O, and must not raise for bad values.
+* `test_connection(None)` tests the saved config; a mapping tests those values
+  *without persisting them*.
+
+### Capabilities
+
+```python
+def is_configured(self) -> bool                                   # default: True
+async def health_check(self) -> ServiceStatus                     # default: derived from test_connection
+async def search(self, request: SearchRequest) -> list[Candidate] # abstract
+async def enqueue(self, request: EnqueueRequest) -> TaskHandle    # abstract
+async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus  # abstract
+async def cancel(self, handle: TaskHandle) -> bool                # abstract
+async def completed_path(self, handle: TaskHandle) -> list[Path]  # abstract
+async def get_file_path(self, handle, remote_filename: str, size: int | None = None) -> Path | None  # default: None
+async def diagnose_downloads_mount(self) -> MountDiagnosis        # default: supported=False
+```
+
+### Orchestrator integration (rarely overridden)
+
+```python
+def get_indexer(self)          # -> IndexerProtocol; default: PluginIndexerAdapter(self)
+def get_download_client(self)  # -> DownloadClientProtocol; default: PluginDownloadClientAdapter(self)
+```
+
+The download orchestrator consumes plugins through these two protocol views.
+The default adapters wrap your `search`/`enqueue`/`get_status`/`cancel`/
+`completed_path` methods; the built-in plugins override them to return the
+pre-existing client singletons.
+
+### Built-in persistence hooks (third-party plugins never override)
+
+```python
+def enabled_override(self) -> bool | None   # None => manager persists the enable flag
+def apply_enabled(self, enabled: bool) -> bool   # True => plugin persisted it itself
+def settings_values(self) -> dict | None    # None => manager owns settings storage
+def apply_settings(self, values: dict) -> bool   # True => plugin persisted them itself
+```
+
+---
+
+## Settings types
+
+### `SettingsField`
+
+| Field      | Type                                    | Notes                                          |
+| ---------- | --------------------------------------- | ---------------------------------------------- |
+| `key`      | `str`                                   | Settings-dict key.                             |
+| `type`     | `"str" \| "int" \| "bool" \| "select" \| "secret"` | Drives the rendered control + secret handling. |
+| `label`    | `str`                                   | Form label.                                    |
+| `help`     | `str`                                   | Helper text under the control.                 |
+| `default`  | `str \| int \| float \| bool \| None`   | Used when no value is stored.                  |
+| `required` | `bool`                                  | UI hint (marked in the form).                  |
+| `options`  | `list[SelectOption]`                    | For `select` only.                             |
+
+### `SelectOption`
+
+| Field   | Type         | Notes                       |
+| ------- | ------------ | --------------------------- |
+| `value` | `str \| int` | What gets stored.           |
+| `label` | `str`        | What the admin sees.        |
+
+### `TestResult`
+
+| Field     | Type          | Notes                                          |
+| --------- | ------------- | ---------------------------------------------- |
+| `ok`      | `bool`        | Overall verdict.                               |
+| `message` | `str`         | Shown verbatim in the admin UI.                |
+| `version` | `str \| None` | Backing service version, when known.           |
+
+---
+
+## Search types
+
+### `SearchRequest`
+
+| Field              | Type                      | Notes                                    |
+| ------------------ | ------------------------- | ---------------------------------------- |
+| `kind`             | `"album" \| "track"`      | Selects which of the fields below apply. |
+| `artist_name`      | `str`                     | Always set.                              |
+| `album_title`      | `str \| None`             | Album searches; optional context on track searches. |
+| `track_title`      | `str \| None`             | Track searches.                          |
+| `year`             | `int \| None`             | Album searches.                          |
+| `track_count`      | `int \| None`             | Album searches (expected tracklist size).|
+| `duration_seconds` | `int \| None`             | Track searches.                          |
+| `timeout`          | `float` (default `30.0`)  | Soft budget in seconds — honour it.      |
+
+### `Candidate` (= `IndexerResult`)
+
+A tagged union: exactly one of `soulseek` / `usenet` is set.
+
+| Field      | Type                            | Notes                                     |
+| ---------- | ------------------------------- | ----------------------------------------- |
+| `source`   | `str`                           | Your plugin `id`.                         |
+| `soulseek` | `DownloadSearchResult \| None`  | Per-file, peer-to-peer archetype.         |
+| `usenet`   | `UsenetRelease \| None`         | Release/archive archetype.                |
+
+### `DownloadSearchResult` (per-file archetype)
+
+| Field              | Type            | Notes                                  |
+| ------------------ | --------------- | -------------------------------------- |
+| `username`         | `str`           | Peer/owner of the file.                |
+| `filename`         | `str`           | Full remote path of the file.          |
+| `parent_directory` | `str`           | Remote folder (release grouping key).  |
+| `size`             | `int`           | Bytes.                                 |
+| `extension`        | `str`           | e.g. `"flac"`.                         |
+| `bitrate`          | `int \| None`   | kbps.                                  |
+| `bit_depth`        | `int \| None`   |                                        |
+| `sample_rate`      | `int \| None`   | Hz.                                    |
+| `duration`         | `float \| None` | Seconds.                               |
+| `has_free_slot`    | `bool`          | Peer can start immediately.            |
+| `upload_speed`     | `int`           | Peer's advertised speed.               |
+
+### `UsenetRelease` (release archetype)
+
+| Field          | Type            | Notes                                             |
+| -------------- | --------------- | ------------------------------------------------- |
+| `indexer_id`   | `str`           | Your plugin id (or per-indexer id if you fan out).|
+| `indexer_name` | `str`           | Display name.                                     |
+| `guid`         | `str`           | Stable identity of the release at the indexer.    |
+| `title`        | `str`           | Release title (scored against artist/album).      |
+| `nzb_url`      | `str`           | Fetch URL handed back to you in `EnqueueRequest`. |
+| `size_bytes`   | `int`           |                                                   |
+| `category_ids` | `list[int]`     | Newznab-style categories (3000 = audio).          |
+| `grabs`        | `int \| None`   | Optional popularity signal.                       |
+| `files`        | `int \| None`   | Optional file count.                              |
+| `usenet_date`  | `float \| None` | Unix timestamp of the post.                       |
+| `password`     | `int`           | Non-zero = password-protected (rejected pre-grab).|
+
+---
+
+## Acquire/track/locate types
+
+### `EnqueueRequest`
+
+| Field             | Type                     | Notes                                                        |
+| ----------------- | ------------------------ | ------------------------------------------------------------ |
+| `task_id`         | `str`                    | DroppedNeedle's download-task id.                             |
+| `source`          | `str`                    | Your plugin id.                                               |
+| `files`           | `list[DownloadFileRef]`  | Per-file sources: the files to fetch.                         |
+| `nzb_url`         | `str \| None`            | Release sources: the candidate's fetch URL.                   |
+| `job_name`        | `str \| None`            | `droppedneedle-{task_id}` — crash-safe correlation key; honour it. |
+| `category`        | `str \| None`            | Client-side category, from plugin settings.                   |
+| `priority`        | `int \| None`            |                                                              |
+| `post_processing` | `int \| None`            |                                                              |
+
+`DownloadFileRef`: `username: str`, `filename: str`, `size: int`.
+
+### `TaskHandle`
+
+Persisted verbatim by the core and handed back to every later call — put
+whatever you need in it to find the job again.
+
+| Field       | Type        | Notes                                             |
+| ----------- | ----------- | ------------------------------------------------- |
+| `source`    | `str`       | Your plugin id.                                   |
+| `username`  | `str`       | Per-file sources: the peer.                       |
+| `filenames` | `list[str]` | Per-file sources: the remote filenames.           |
+| `job_name`  | `str`       | Pre-enqueue correlation key (survives crashes).   |
+| `nzo_id`    | `str`       | Client-assigned job id, once known.               |
+
+### `DownloadTaskStatus`
+
+| Field                 | Type          | Notes                                                            |
+| --------------------- | ------------- | ---------------------------------------------------------------- |
+| `task_id`             | `str`         | May be left `""` — the orchestrator correlates by handle.         |
+| `status`              | `str`         | `"queued" \| "downloading" \| "completed" \| "failed"`.           |
+| `files_total`         | `int`         |                                                                  |
+| `files_completed`     | `int`         |                                                                  |
+| `files_failed`        | `int`         |                                                                  |
+| `bytes_total`         | `int`         |                                                                  |
+| `bytes_downloaded`    | `int`         |                                                                  |
+| `progress_percent`    | `float`       | 0–100.                                                           |
+| `error`               | `str \| None` | Job-level failure message (may be shown to users).               |
+| `succeeded_filenames` | `list[str]`   | Finished subset — lets the core import a partially-failed job.    |
+| `has_active_transfer` | `bool`        | Actively moving bytes vs parked in a remote queue (stall watchdog). |
+| `matched_transfers`   | `int`         | 0 = the enqueue produced no transfer record (fail over fast).     |
+
+### `MountDiagnosis`
+
+| Field                   | Type          | Notes                                              |
+| ----------------------- | ------------- | -------------------------------------------------- |
+| `supported`             | `bool`        | `False` = the plugin can't introspect (default).   |
+| `completed_downloads`   | `int`         | Finished jobs known to the client.                 |
+| `mount_has_files`       | `bool`        | The configured mount contains anything at all.     |
+| `resolvable_downloads`  | `int`         | Of a sample, how many resolve under the mount.     |
+| `sampled_downloads`     | `int`         | Sample size.                                       |
+| `client_downloads_dir`  | `str \| None` | The client's own downloads dir, in its namespace.  |
+
+---
+
+## Adapters
+
+`PluginIndexerAdapter(plugin)` and `PluginDownloadClientAdapter(plugin)` are
+signature-exact implementations of the core's `IndexerProtocol` and
+`DownloadClientProtocol` over a plugin instance (contract-tested in
+`backend/tests/plugins/test_plugin_base.py`). You get them for free via
+`get_indexer()` / `get_download_client()`.
+
+---
+
+## class `PluginManager` (host side — you don't implement this)
+
+| Member | Purpose |
+| ------ | ------- |
+| `load()` | Discover + register everything; idempotent; never raises. |
+| `list_records() -> list[PluginRecord]` | Registry, built-ins first. |
+| `get_record(id) -> PluginRecord \| None` | One record, loaded or quarantined. |
+| `get_plugin(id) -> AcquisitionPlugin \| None` | Loaded instance (regardless of the enable flag). |
+| `is_enabled(id)` / `set_enabled(id, bool)` | Enable flag, persisted. |
+| `get_settings_schema(id)` | The plugin's schema (empty when quarantined). |
+| `get_settings_values(id, raw=False)` | Values; `raw=False` masks secrets. |
+| `save_settings(id, values)` | Resolve masks, persist (encrypting secrets), re-`configure`. |
+| `test(id, values=None)` | Run `test_connection`, exceptions turned into `TestResult(ok=False)`. |
+| `shutdown_all()` | Best-effort `shutdown()` for every loaded plugin. |
+
+`PluginRecord`: `id`, `name`, `version`, `source` (`"builtin" | "external" |
+"entry_point"`), `plugin` (instance or `None`), `error` (`str | None`), plus
+derived `builtin` and `loaded`.
+
+Discovery constants: external dir `{ROOT_APP_DIR}/plugins`; entry-point group
+`droppedneedle.plugins`.

--- a/docs/plugins/MIGRATION.md
+++ b/docs/plugins/MIGRATION.md
@@ -1,0 +1,86 @@
+# Migration: slskd and SABnzbd as Plugins
+
+## What changed (this release)
+
+Soulseek (slskd) and Usenet (SABnzbd + Newznab) support became the first two
+**built-in acquisition plugins** — `plugins/builtin/soulseek_slskd` and
+`plugins/builtin/usenet_sabnzbd`. The refactor is a *wrap, not a rewrite*:
+
+* **The client code did not move.** `repositories/slskd/*`,
+  `repositories/sabnzbd/*` and `repositories/newznab/*` are unchanged; the
+  plugins delegate to the exact same DI singletons
+  (`get_slskd_repository()`, `get_slskd_indexer()`,
+  `get_sabnzbd_download_client()`, `get_newznab_indexer()`), resolved lazily
+  per call so settings saves still rebuild them.
+* **The orchestrator now resolves its per-source providers through the plugin
+  registry** (`PluginManager`), keyed by the same source ids as before —
+  `soulseek` and `usenet`. Because the built-in plugins hand back the identical
+  singleton objects, download behaviour is byte-identical (the test suite
+  asserts object identity in `tests/plugins/test_registry_equivalence.py`).
+* **Settings stayed where they were.** The plugins proxy the pre-existing
+  preference sections (`download_client` for slskd,
+  `download_clients.sabnzbd` for SABnzbd), so:
+  * the existing admin routes (`/api/v1/download-client/*`,
+    `/api/v1/download-clients/*`) keep working unchanged;
+  * the new plugin settings API (`/api/v1/plugins/{id}/settings`) reads and
+    writes the *same* values — the two surfaces cannot drift;
+  * the plugin enable toggles ARE the existing slskd/SABnzbd enable flags.
+* **Nothing about your config file changes.** No migration step runs; a
+  pre-plugin config is a post-plugin config.
+
+## What operators see today
+
+* A new **Settings → Plugins** page listing Soulseek and Usenet (with a
+  *built-in* badge) plus any third-party plugins you drop into
+  `{ROOT_APP_DIR}/plugins/`.
+* The existing slskd / SABnzbd / Indexers settings pages continue to work and
+  stay the richer surface (mount diagnostics, category discovery, etc.). The
+  plugin page is an alternative view over the same connection settings.
+* Newznab **indexers remain their own admin surface** (`/api/v1/indexers`).
+  They are user-supplied sources, not plugin configuration; the Usenet plugin's
+  search fans out across whatever indexers you have configured, exactly as
+  before.
+
+## What "removal from core" will mean (future release)
+
+The plan of record is to remove the slskd and SABnzbd client code from the
+core distribution and ship them as standalone plugins (drop-in or pip-installed
+via the `droppedneedle.plugins` entry-point group). When that happens:
+
+* **Your configuration carries over.** The plugins read the same preference
+  sections; connection settings, categories, mounts and enable flags survive.
+* **Install becomes explicit.** A core-only install will acquire nothing until
+  you install at least one acquisition plugin. Operators upgrading across the
+  removal release will need to install the plugin(s) matching the sources they
+  use — release notes will call this out loudly, and the upgrade path is
+  expected to bundle-or-prompt rather than silently strip working sources.
+* **The import pipeline stays core.** Identification, quality verification,
+  library placement and registration are unaffected — plugins end at "the
+  finished files are here".
+* **In-flight downloads:** the download manifest persists the client-agnostic
+  `TaskHandle`, so a resumed download only needs a plugin that answers the same
+  source id (`soulseek`/`usenet`). Upgrading with an empty queue is still the
+  recommended, boring path.
+* **API stability:** the admin plugin API (`/api/v1/plugins*`) and the
+  `plugins.base` contract (`api_version`) are the compatibility surface. The
+  legacy per-client routes (`/api/v1/download-client*`) become part of the
+  plugins' own surface and will follow the plugins out of core.
+
+## For developers
+
+The pre-plugin protocol seam (`repositories/protocols/download_client.py` and
+`indexer.py`) is unchanged and remains the orchestrator's language. The plugin
+layer sits on top of it:
+
+```
+DownloadOrchestrator
+   └── source id ──> PluginManager registry ──> AcquisitionPlugin
+                                                    ├── get_indexer()          -> IndexerProtocol
+                                                    └── get_download_client()  -> DownloadClientProtocol
+```
+
+If you maintain code that imported `get_slskd_repository` and friends
+directly: those providers still exist and still return the live singletons,
+but new code should resolve per-source clients via
+`core.dependencies.get_download_client_for_source(source)` or the manager, so
+it keeps working when the built-ins move out of core.

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -1,0 +1,136 @@
+# DroppedNeedle Acquisition Plugins
+
+DroppedNeedle acquires music through **acquisition plugins**. A plugin owns one
+*source*: it searches its network for release candidates, enqueues downloads
+with an external client, reports progress, and tells the core where the
+finished files landed. Everything after that hand-off — identifying the audio,
+matching it to MusicBrainz, moving it into the library, registering it — is the
+**core import pipeline** and is deliberately *not* pluggable.
+
+Soulseek (via [slskd](https://github.com/slskd/slskd)) and Usenet (via
+SABnzbd + your Newznab indexers) are the first two plugins. They ship built-in
+today, but they are ordinary plugins wired through the same registry a
+third-party plugin uses — the long-term plan is to move them out of core
+entirely and distribute them as standalone plugins (see
+[MIGRATION.md](MIGRATION.md)).
+
+## Why plugins?
+
+* **DroppedNeedle ships no sources.** The user supplies every source the app
+  can reach. Plugins make that boundary structural: a source is a unit of code
+  the *operator* chooses to install and configure, not something the core
+  bundles.
+* **The acquisition surface is naturally pluggable.** The download orchestrator
+  already speaks two small protocols — search (`IndexerProtocol`) and
+  acquire/track/locate (`DownloadClientProtocol`) — and never imports a client
+  directly. A plugin is simply a named, versioned, self-describing provider of
+  those two capabilities plus a settings form.
+* **Slimmer core.** When slskd and SABnzbd move out, operators who only use one
+  network run none of the other's code.
+
+## What a plugin is
+
+A Python class extending `plugins.base.AcquisitionPlugin`, discovered from one
+of three places:
+
+1. **Built-in**: a subpackage of `backend/plugins/builtin/` (ships with the app).
+2. **External dir**: a single `.py` module or a package directory dropped into
+   `{ROOT_APP_DIR}/plugins/` (for a stock Docker install: `/app/plugins/`).
+3. **Entry points**: any installed distribution exposing the
+   `droppedneedle.plugins` entry-point group.
+
+The `PluginManager` validates each plugin's declared `api_version` against the
+server's `plugins.base.API_VERSION`, and **quarantines** anything that fails —
+bad import, wrong api_version, duplicate id, exception during init. A
+quarantined plugin shows up in *Settings → Plugins* with its error; the app
+never crashes because of a plugin.
+
+## Lifecycle
+
+```
+              +--------------------------------------------------------------+
+              |                      app startup                             |
+              +--------------------------------------------------------------+
+                                        |
+                                        v
+   +--------------------- PluginManager.load() ---------------------------+
+   |  discover: builtin pkgs  ->  {ROOT_APP_DIR}/plugins  ->  entry points |
+   |  validate: id present? api_version == server? id unique?              |
+   |     ok --> instantiate --> configure(stored settings) --> REGISTERED  |
+   |     fail -----------------------------------------------> QUARANTINED |
+   +-----------------------------------------------------------------------+
+                                        |
+                                        v
+   +-----------------------------------------------------------------------+
+   |                          serving requests                             |
+   |                                                                       |
+   |   orchestrator --- search(request) ----------> list[Candidate]        |
+   |   orchestrator --- enqueue(request) ---------> TaskHandle             |
+   |   orchestrator --- get_status(handle) --24/7-> DownloadTaskStatus     |
+   |   orchestrator --- completed_path(handle) ---> [files on disk]        |
+   |                        |                                              |
+   |                        v                                              |
+   |            core import pipeline (NOT pluggable):                      |
+   |            verify -> identify -> move into library -> register        |
+   |                                                                       |
+   |   orchestrator --- cancel(handle) -----------> stop / clean up        |
+   |                                                                       |
+   |   admin UI ---- settings_schema() / configure() / test_connection()   |
+   |   admin UI ---- enable / disable (persisted)                          |
+   +-----------------------------------------------------------------------+
+                                        |
+                                        v
+   +-----------------------------------------------------------------------+
+   |                   app shutdown: shutdown() per plugin                  |
+   +-----------------------------------------------------------------------+
+```
+
+## The exchange types are the orchestrator's own
+
+The request/candidate/progress structs in `plugins.base` are not a new schema —
+they are re-exports of the exact structs the download orchestrator already
+exchanged with the slskd and SABnzbd clients (`repositories/protocols/`). That
+is what makes wrapping the two built-in clients lossless, and it means a
+candidate can take one of two archetypal shapes:
+
+* **per-file, peer-to-peer** (`Candidate.soulseek`, a `DownloadSearchResult`):
+  a specific file on a specific peer, with audio attributes.
+* **release-shaped** (`Candidate.usenet`, a `UsenetRelease`): one downloadable
+  archive/release with a title, a fetch URL, and a size.
+
+Pick whichever fits your network. See [INTERFACE.md](INTERFACE.md) for every
+field and [AUTHORING.md](AUTHORING.md) for the step-by-step guide.
+
+## Admin API
+
+All admin-gated, under `/api/v1/plugins`:
+
+| Method | Path                          | What                                              |
+| ------ | ----------------------------- | ------------------------------------------------- |
+| GET    | `/plugins`                    | Registry: id/name/version/builtin/enabled/loaded/error |
+| POST   | `/plugins/{id}/enable`        | Enable (persisted)                                |
+| POST   | `/plugins/{id}/disable`       | Disable (persisted)                               |
+| GET    | `/plugins/{id}/settings`      | Settings schema + current values (secrets masked) |
+| PUT    | `/plugins/{id}/settings`      | Save values (masked secret = keep stored)         |
+| POST   | `/plugins/{id}/test`          | Connection test (optional body values, unsaved)   |
+
+The *Settings → Plugins* page in the web UI is built on these endpoints and
+renders each plugin's form directly from its `settings_schema()`.
+
+## Settings & secrets
+
+Per-plugin settings persist in the app config under the `plugins.{id}`
+namespace. Fields declared `secret` in the schema are Fernet-encrypted at rest,
+masked (`plugin****`) in every API response, and preserved when the mask is
+saved back — the same pattern every core settings section uses. The two
+built-in plugins proxy their pre-existing settings sections instead, so the
+legacy download-client routes and the plugin API always agree.
+
+## Files in this folder
+
+* [AUTHORING.md](AUTHORING.md) — write, test, package and distribute a plugin.
+* [INTERFACE.md](INTERFACE.md) — full reference of the base class and every type.
+* [MIGRATION.md](MIGRATION.md) — how slskd/SABnzbd became plugins and what their
+  future removal from core means for operators.
+* [example/mock_provider.py](example/mock_provider.py) — a complete, runnable
+  example plugin (also exercised by the backend test suite).

--- a/docs/plugins/example/mock_provider.py
+++ b/docs/plugins/example/mock_provider.py
@@ -1,0 +1,181 @@
+"""mock_provider - a complete, runnable example acquisition plugin.
+
+Install by copying this single file into ``{ROOT_APP_DIR}/plugins/`` and
+restarting DroppedNeedle; it appears on the Settings > Plugins page. It fakes a
+source: ``search`` fabricates release candidates, ``enqueue`` "downloads" by
+writing small placeholder files into a local directory, ``get_status`` reports
+them complete, and ``completed_path`` hands the files to the caller.
+
+It exists to (a) document every extension point with working code and (b) prove
+third-party loading end-to-end - the backend test suite copies this exact file
+into a temporary external plugins dir and drives the full round-trip against it.
+
+NOTE: candidates fabricated here are release-shaped (the ``usenet`` archetype).
+A real plugin returns real results from its network; see docs/plugins/AUTHORING.md.
+"""
+
+import asyncio
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from plugins.base import (
+    AcquisitionPlugin,
+    Candidate,
+    DownloadTaskStatus,
+    EnqueueRequest,
+    SearchRequest,
+    SelectOption,
+    SettingsField,
+    TaskHandle,
+    TestResult,
+    UsenetRelease,
+)
+
+
+class MockProviderPlugin(AcquisitionPlugin):
+    # -- identity ------------------------------------------------------------
+    id = "mock_provider"
+    name = "Mock Provider"
+    version = "1.0.0"
+    # api_version defaults to plugins.base.API_VERSION; pin it explicitly when
+    # distributing, so an incompatible server quarantines you with a clear error.
+
+    def __init__(self) -> None:
+        self._download_dir = Path(tempfile.gettempdir()) / "droppedneedle-mock-provider"
+        self._latency = 0.0
+        self._label = "Mock"
+        self._jobs: dict[str, list[Path]] = {}
+
+    # -- lifecycle -------------------------------------------------------------
+
+    def settings_schema(self) -> list[SettingsField]:
+        return [
+            SettingsField(
+                key="download_dir",
+                type="str",
+                label="Download directory",
+                help="Where fake downloads are written.",
+                default=str(Path(tempfile.gettempdir()) / "droppedneedle-mock-provider"),
+                required=True,
+            ),
+            SettingsField(
+                key="api_token",
+                type="secret",
+                label="API token",
+                help="Demonstrates a secret field: encrypted at rest, masked in the UI.",
+                default="",
+            ),
+            SettingsField(
+                key="latency",
+                type="select",
+                label="Simulated latency",
+                help="Seconds each fake operation sleeps.",
+                default=0,
+                options=[
+                    SelectOption(value=0, label="None"),
+                    SelectOption(value=1, label="1 second"),
+                    SelectOption(value=3, label="3 seconds"),
+                ],
+            ),
+            SettingsField(
+                key="verbose",
+                type="bool",
+                label="Verbose titles",
+                default=False,
+            ),
+            SettingsField(
+                key="result_count",
+                type="int",
+                label="Results per search",
+                default=3,
+            ),
+        ]
+
+    def configure(self, settings: dict[str, Any]) -> None:
+        if settings.get("download_dir"):
+            self._download_dir = Path(str(settings["download_dir"]))
+        self._latency = float(settings.get("latency") or 0)
+        self._result_count = int(settings.get("result_count") or 3)
+        self._verbose = bool(settings.get("verbose", False))
+
+    async def test_connection(self, settings: dict[str, Any] | None = None) -> TestResult:
+        directory = Path(str((settings or {}).get("download_dir") or self._download_dir))
+        try:
+            directory.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            return TestResult(ok=False, message=f"cannot create download dir: {exc}")
+        return TestResult(ok=True, message=f"mock provider ready at {directory}", version=self.version)
+
+    # -- capabilities ------------------------------------------------------------
+
+    def is_configured(self) -> bool:
+        return True
+
+    async def search(self, request: SearchRequest) -> list[Candidate]:
+        await asyncio.sleep(self._latency)
+        what = request.album_title if request.kind == "album" else request.track_title
+        out: list[Candidate] = []
+        for i in range(getattr(self, "_result_count", 3)):
+            title = f"{request.artist_name} - {what} [mock {i + 1}]"
+            if getattr(self, "_verbose", False):
+                title += f" ({time.strftime('%Y-%m-%d')})"
+            out.append(
+                Candidate(
+                    source=self.id,
+                    usenet=UsenetRelease(
+                        indexer_id=self.id,
+                        indexer_name=self.name,
+                        guid=f"mock-{abs(hash(title))}",
+                        title=title,
+                        nzb_url=f"mock://release/{i + 1}",
+                        size_bytes=(i + 1) * 25_000_000,
+                        category_ids=[3000],
+                    ),
+                )
+            )
+        return out
+
+    async def enqueue(self, request: EnqueueRequest) -> TaskHandle:
+        await asyncio.sleep(self._latency)
+        job_name = request.job_name or f"mock-{request.task_id}"
+        job_dir = self._download_dir / job_name
+        job_dir.mkdir(parents=True, exist_ok=True)
+        files: list[Path] = []
+        for i in range(1, 3):
+            path = job_dir / f"{i:02d} - mock track.mp3"
+            path.write_bytes(b"ID3mock-audio-payload")
+            files.append(path)
+        self._jobs[job_name] = files
+        return TaskHandle(source=self.id, job_name=job_name, nzo_id=job_name)
+
+    async def get_status(self, handle: TaskHandle) -> DownloadTaskStatus:
+        files = self._jobs.get(handle.job_name, [])
+        size = sum(f.stat().st_size for f in files if f.exists())
+        return DownloadTaskStatus(
+            task_id="",
+            status="completed" if files else "failed",
+            files_total=len(files),
+            files_completed=len(files),
+            bytes_total=size,
+            bytes_downloaded=size,
+            progress_percent=100.0 if files else 0.0,
+            succeeded_filenames=[f.name for f in files],
+            error=None if files else "unknown mock job",
+        )
+
+    async def cancel(self, handle: TaskHandle) -> bool:
+        files = self._jobs.pop(handle.job_name, [])
+        for f in files:
+            try:
+                f.unlink(missing_ok=True)
+            except OSError:
+                pass
+        return True
+
+    async def completed_path(self, handle: TaskHandle) -> list[Path]:
+        return list(self._jobs.get(handle.job_name, []))
+
+    async def shutdown(self) -> None:
+        self._jobs.clear()

--- a/frontend/src/lib/components/settings/SettingsPlugins.svelte
+++ b/frontend/src/lib/components/settings/SettingsPlugins.svelte
@@ -1,219 +1,422 @@
 <script lang="ts">
-	import { Blocks, CircleAlert, ExternalLink, Github, Trash2 } from 'lucide-svelte';
-	import { getPluginsQuery } from '$lib/queries/plugins/PluginQueries.svelte';
 	import {
-		installPluginMutation,
-		uninstallPluginMutation,
-		updatePluginMutation
-	} from '$lib/queries/plugins/PluginMutations.svelte';
-	import type { PluginInfo } from '$lib/queries/plugins/types';
+		ChevronDown,
+		CircleCheck,
+		CircleX,
+		FolderOpen,
+		Package,
+		Puzzle,
+		TriangleAlert
+	} from 'lucide-svelte';
+
+	import {
+		getPluginSettingsQuery,
+		getPluginsQuery,
+		savePluginSettingsMutation,
+		testPluginMutation,
+		togglePluginMutation
+	} from '$lib/queries/plugins/PluginQueries.svelte';
+	import { toastStore } from '$lib/stores/toast';
+	import type {
+		PluginInfo,
+		PluginSettingsField,
+		PluginSettingsValue,
+		PluginTestResult
+	} from '$lib/types';
 
 	const pluginsQuery = getPluginsQuery();
-	const update = updatePluginMutation();
-	const install = installPluginMutation();
-	const uninstall = uninstallPluginMutation();
+	const toggle = togglePluginMutation();
+	const save = savePluginSettingsMutation();
+	const test = testPluginMutation();
+
 	const plugins = $derived(pluginsQuery.data?.plugins ?? []);
+	const apiVersion = $derived(pluginsQuery.data?.api_version ?? 1);
 
-	let repoUrl = $state('');
-	let confirmingRemoval = $state<string | null>(null);
+	let openId = $state<string | null>(null);
+	let draft = $state<Record<string, PluginSettingsValue>>({});
+	let revealed = $state<Record<string, boolean>>({});
+	let testResults = $state<Record<string, PluginTestResult>>({});
 
-	function submitInstall(event: SubmitEvent) {
-		event.preventDefault();
-		const url = repoUrl.trim();
-		if (!url || install.isPending) return;
-		install.mutate(url, { onSuccess: () => (repoUrl = '') });
-	}
-
-	// local draft per plugin so typing doesn't fight the query cache; seeded in
-	// an effect (never during render - that would be a state_unsafe_mutation)
-	let drafts = $state<Record<string, { enabled: boolean; settings: Record<string, string> }>>({});
+	// settings for the expanded card only; the query re-runs when openId changes
+	const settingsQuery = getPluginSettingsQuery(() => openId ?? '');
+	const schema = $derived(
+		openId && settingsQuery.data?.id === openId ? settingsQuery.data.schema : []
+	);
 
 	$effect(() => {
-		for (const plugin of plugins) {
-			if (!drafts[plugin.name]) {
-				drafts[plugin.name] = {
-					enabled: plugin.enabled,
-					settings: { ...plugin.settings_values }
-				};
-			}
+		// seed the form once the expanded plugin's stored values arrive
+		if (openId && settingsQuery.data?.id === openId) {
+			draft = { ...settingsQuery.data.values };
 		}
 	});
 
-	function save(plugin: PluginInfo) {
-		const draft = drafts[plugin.name];
-		if (!draft) return;
-		update.mutate({ name: plugin.name, enabled: draft.enabled, settings: draft.settings });
+	function toggleOpen(plugin: PluginInfo) {
+		if (!plugin.loaded) return;
+		if (openId === plugin.id) {
+			openId = null;
+			return;
+		}
+		openId = plugin.id;
+		draft = {};
+		revealed = {};
+	}
+
+	async function setEnabled(plugin: PluginInfo, enabled: boolean) {
+		try {
+			await toggle.mutateAsync({ id: plugin.id, enabled });
+		} catch {
+			toastStore.show({
+				message: `Could not ${enabled ? 'enable' : 'disable'} ${plugin.name}`,
+				type: 'error'
+			});
+		}
+	}
+
+	async function saveDraft(plugin: PluginInfo) {
+		try {
+			await save.mutateAsync({ id: plugin.id, values: draft });
+			toastStore.show({ message: `${plugin.name} settings saved`, type: 'success' });
+		} catch {
+			toastStore.show({ message: `Could not save ${plugin.name} settings`, type: 'error' });
+		}
+	}
+
+	async function runTest(plugin: PluginInfo) {
+		try {
+			const result = await test.mutateAsync({ id: plugin.id, values: draft });
+			testResults = { ...testResults, [plugin.id]: result };
+		} catch {
+			testResults = {
+				...testResults,
+				[plugin.id]: { valid: false, message: "Couldn't finish the connection test" }
+			};
+		}
+	}
+
+	function fieldId(pluginId: string, key: string): string {
+		return `plugin-${pluginId}-${key}`;
+	}
+
+	function stringValue(key: string): string {
+		const v = draft[key];
+		return v === null || v === undefined ? '' : String(v);
+	}
+
+	function setNumber(key: string, raw: string) {
+		draft = { ...draft, [key]: raw === '' ? null : Number(raw) };
+	}
+
+	function setSelect(field: PluginSettingsField, raw: string) {
+		// preserve the option's own type (number vs string)
+		const match = field.options.find((o) => String(o.value) === raw);
+		draft = { ...draft, [field.key]: match ? match.value : raw };
+	}
+
+	function sourceLabel(plugin: PluginInfo): string {
+		if (plugin.builtin) return 'built-in';
+		return plugin.source === 'entry_point' ? 'installed package' : 'external';
 	}
 </script>
 
-<div class="card bg-base-200">
-	<div class="card-body">
-		<div class="flex items-center gap-2">
-			<Blocks class="h-5 w-5 text-primary" aria-hidden="true" />
-			<h2 class="card-title">Plugins</h2>
-			<span class="badge badge-warning badge-sm">experimental</span>
+<section class="space-y-4">
+	<header class="space-y-1">
+		<h2 class="text-lg font-semibold">Plugins</h2>
+		<p class="max-w-prose text-sm text-base-content/70">
+			Acquisition plugins are the sources DroppedNeedle can download music through. Soulseek and
+			Usenet ship built in; drop third-party plugins into the server's <code
+				class="rounded bg-base-300/60 px-1.5 py-0.5 font-mono text-xs">plugins/</code
+			> folder and restart to add more.
+		</p>
+	</header>
+
+	{#if pluginsQuery.isLoading}
+		<div class="flex justify-center rounded-2xl border border-base-content/8 bg-base-200/50 p-10">
+			<span class="loading loading-spinner loading-md text-base-content/40"></span>
 		</div>
-		<p class="text-sm text-base-content/60">
-			Third-party extensions loaded from the <code>plugins/</code> folder in your data directory. A plugin
-			runs with the server's full privileges - only enable code you trust. See PLUGINS.md in the repository
-			for the API.
-		</p>
-
-		<form class="mt-2 flex flex-wrap items-end gap-2" onsubmit={submitInstall}>
-			<div class="form-control min-w-0 flex-1">
-				<label class="label py-1" for="plugin-repo-url">
-					<span class="label-text text-sm">Install from GitHub</span>
-				</label>
-				<label class="input input-bordered input-sm flex w-full items-center gap-2">
-					<Github class="h-4 w-4 shrink-0 opacity-50" aria-hidden="true" />
-					<input
-						id="plugin-repo-url"
-						type="url"
-						class="grow"
-						placeholder="https://github.com/owner/repo"
-						bind:value={repoUrl}
-						disabled={install.isPending}
-					/>
-				</label>
+	{:else if plugins.length === 0}
+		<div
+			class="flex flex-col items-center rounded-box border border-dashed border-base-300 bg-base-200/40 p-10 text-center"
+		>
+			<div class="grid size-14 place-items-center rounded-2xl bg-base-300/60">
+				<Puzzle class="size-7 text-accent" aria-hidden="true" />
 			</div>
-			<button
-				class="btn btn-primary btn-sm"
-				type="submit"
-				disabled={install.isPending || !repoUrl.trim()}
-			>
-				{install.isPending ? 'Installing…' : 'Install'}
-			</button>
-		</form>
-		<p class="text-xs text-base-content/45">
-			Downloads the repository into your plugins folder. Nothing runs until you enable it - read the
-			code first.
-		</p>
-
-		{#if pluginsQuery.isLoading}
-			<div class="skeleton h-20 w-full rounded-xl"></div>
-		{:else if plugins.length === 0}
-			<p class="py-4 text-sm text-base-content/50">
-				No plugins yet. Install one above, or drop a folder into <code>plugins/</code> and reload.
+			<p class="mt-4 font-semibold">No plugins found</p>
+			<p class="mx-auto mt-1 max-w-md text-sm text-base-content/70">
+				That shouldn't happen — the built-in Soulseek and Usenet plugins load automatically. Check
+				the server logs for <code class="font-mono text-xs">plugins.*</code> events.
 			</p>
-		{:else}
-			<div class="space-y-4 pt-2">
-				{#each plugins as plugin (plugin.name)}
-					{@const draft = drafts[plugin.name]}
-					{#if draft}
-						<div class="rounded-2xl border border-base-content/10 bg-base-100/60 p-4">
-							<div class="flex flex-wrap items-start justify-between gap-3">
-								<div class="min-w-0">
-									<div class="flex items-center gap-2">
-										<h3 class="font-semibold">{plugin.display_name}</h3>
-										<span class="text-xs text-base-content/40">v{plugin.version}</span>
-										{#if plugin.homepage}
-											<a
-												href={plugin.homepage}
-												target="_blank"
-												rel="noopener noreferrer"
-												class="text-base-content/40 hover:text-primary"
-												aria-label="Plugin homepage"
-											>
-												<ExternalLink class="h-3.5 w-3.5" aria-hidden="true" />
-											</a>
-										{/if}
-									</div>
-									{#if plugin.description}
-										<p class="mt-0.5 text-xs text-base-content/55">{plugin.description}</p>
-									{/if}
-									<div class="mt-1.5 flex flex-wrap gap-1">
-										{#each plugin.capabilities as capability (capability)}
-											<span
-												class="badge badge-sm {plugin.active_capabilities.includes(capability)
-													? 'badge-primary badge-outline'
-													: 'badge-ghost'}"
-											>
-												{capability}
-											</span>
-										{/each}
-									</div>
-								</div>
-								<label class="flex cursor-pointer items-center gap-2">
-									<span class="text-xs text-base-content/60">Enabled</span>
-									<input
-										type="checkbox"
-										class="toggle toggle-primary toggle-sm"
-										bind:checked={draft.enabled}
-									/>
-								</label>
-							</div>
-
-							{#if plugin.error}
-								<div
-									class="mt-2 flex items-center gap-2 rounded-lg bg-error/10 px-3 py-2 text-xs text-error"
+		</div>
+	{:else}
+		<ul class="space-y-3">
+			{#each plugins as plugin (plugin.id)}
+				{@const isOpen = openId === plugin.id}
+				{@const result = testResults[plugin.id]}
+				<li
+					class="plugin-card overflow-hidden rounded-2xl border border-base-content/8 bg-base-200/50"
+					class:is-active={plugin.loaded && plugin.enabled}
+					class:is-broken={!plugin.loaded}
+				>
+					<div class="flex flex-wrap items-center gap-4 p-5">
+						<div
+							class="grid size-12 place-items-center rounded-2xl border border-base-content/8 bg-base-300/60"
+						>
+							{#if !plugin.loaded}
+								<TriangleAlert class="size-6 text-error" aria-hidden="true" />
+							{:else if plugin.builtin}
+								<Puzzle class="size-6 text-accent" aria-hidden="true" />
+							{:else if plugin.source === 'entry_point'}
+								<Package class="size-6 text-accent" aria-hidden="true" />
+							{:else}
+								<FolderOpen class="size-6 text-accent" aria-hidden="true" />
+							{/if}
+						</div>
+						<button
+							type="button"
+							class="min-w-0 flex-1 text-left"
+							onclick={() => toggleOpen(plugin)}
+							aria-expanded={isOpen}
+							disabled={!plugin.loaded}
+						>
+							<div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+								<h3 class="font-display text-lg font-bold tracking-tight">{plugin.name}</h3>
+								<span
+									class="font-mono text-[0.68rem] font-bold uppercase tracking-[0.2em] text-base-content/50"
+									>{sourceLabel(plugin)}</span
 								>
-									<CircleAlert class="h-4 w-4 shrink-0" aria-hidden="true" />
-									{plugin.error}
-								</div>
-							{/if}
-
-							{#if plugin.settings_fields.length}
-								<div class="mt-3 grid gap-3 sm:grid-cols-2">
-									{#each plugin.settings_fields as field (field.key)}
-										<div class="form-control">
-											<label class="label py-1" for="plugin-{plugin.name}-{field.key}">
-												<span class="label-text text-sm">{field.label}</span>
-											</label>
-											<input
-												id="plugin-{plugin.name}-{field.key}"
-												type={field.secret ? 'password' : 'text'}
-												class="input input-bordered input-sm w-full"
-												bind:value={draft.settings[field.key]}
-											/>
-											{#if field.help}
-												<p class="mt-1 text-xs text-base-content/45">{field.help}</p>
-											{/if}
-										</div>
-									{/each}
-								</div>
-							{/if}
-
-							<div class="mt-3 flex items-center justify-end gap-2">
-								{#if confirmingRemoval === plugin.name}
-									<span class="text-xs text-base-content/60">Remove this plugin?</span>
-									<button
-										class="btn btn-ghost btn-xs"
-										onclick={() => (confirmingRemoval = null)}
-										disabled={uninstall.isPending}
+								{#if plugin.version}
+									<span class="badge badge-ghost badge-sm font-mono tabular-nums"
+										>v{plugin.version}</span
 									>
-										Cancel
-									</button>
-									<button
-										class="btn btn-error btn-xs"
-										onclick={() => {
-											uninstall.mutate(plugin.name);
-											confirmingRemoval = null;
-										}}
-										disabled={uninstall.isPending}
-									>
-										Remove
-									</button>
-								{:else}
-									<button
-										class="btn btn-ghost btn-xs text-base-content/50 hover:text-error"
-										onclick={() => (confirmingRemoval = plugin.name)}
-										aria-label="Remove {plugin.display_name}"
-									>
-										<Trash2 class="h-3.5 w-3.5" aria-hidden="true" />
-									</button>
-									<button
-										class="btn btn-primary btn-xs"
-										onclick={() => save(plugin)}
-										disabled={update.isPending}
-									>
-										{update.isPending ? 'Saving…' : 'Save'}
-									</button>
 								{/if}
 							</div>
+							<div class="flex items-center gap-2 text-sm text-base-content/70">
+								{#if !plugin.loaded}
+									<span class="truncate text-error" title={plugin.error ?? undefined}>
+										Failed to load — {plugin.error}
+									</span>
+								{:else}
+									<span
+										class="orb"
+										class:is-connected={plugin.enabled}
+										role="status"
+										aria-label={plugin.enabled ? 'Enabled' : 'Disabled'}
+									></span>
+									<span class="truncate">
+										{plugin.enabled ? 'Enabled' : 'Disabled'} · source id
+										<code class="font-mono text-xs">{plugin.id}</code>
+									</span>
+								{/if}
+							</div>
+						</button>
+						{#if plugin.loaded}
+							<label class="flex cursor-pointer items-center gap-2">
+								<span class="text-sm font-medium">{plugin.enabled ? 'Enabled' : 'Disabled'}</span>
+								<input
+									type="checkbox"
+									class="toggle toggle-accent"
+									checked={plugin.enabled}
+									disabled={toggle.isPending}
+									onchange={() => setEnabled(plugin, !plugin.enabled)}
+									aria-label={plugin.enabled ? `Disable ${plugin.name}` : `Enable ${plugin.name}`}
+								/>
+							</label>
+							<button
+								type="button"
+								class="btn btn-ghost btn-sm btn-square"
+								onclick={() => toggleOpen(plugin)}
+								aria-label={isOpen ? 'Collapse' : 'Expand'}
+							>
+								<ChevronDown
+									class={isOpen
+										? 'size-5 rotate-180 transition-transform'
+										: 'size-5 transition-transform'}
+									aria-hidden="true"
+								/>
+							</button>
+						{/if}
+					</div>
+
+					{#if isOpen && plugin.loaded}
+						<div class="space-y-4 border-t border-base-content/8 p-5">
+							{#if settingsQuery.isLoading}
+								<div class="flex justify-center p-4">
+									<span class="loading loading-spinner loading-sm text-base-content/40"></span>
+								</div>
+							{:else if schema.length === 0}
+								<p class="text-sm text-base-content/50">This plugin has no settings.</p>
+							{:else}
+								<div class="space-y-3">
+									{#each schema as field (field.key)}
+										{@const id = fieldId(plugin.id, field.key)}
+										{#if field.type === 'bool'}
+											<label class="flex cursor-pointer items-center justify-between gap-4">
+												<span class="min-w-0">
+													<span class="block text-sm font-medium">
+														{field.label || field.key}
+														{#if field.required}<span class="text-error">*</span>{/if}
+													</span>
+													{#if field.help}
+														<span class="block text-xs text-base-content/50">{field.help}</span>
+													{/if}
+												</span>
+												<input
+													type="checkbox"
+													class="toggle toggle-accent"
+													checked={Boolean(draft[field.key])}
+													onchange={(e) =>
+														(draft = { ...draft, [field.key]: e.currentTarget.checked })}
+												/>
+											</label>
+										{:else}
+											<div class="form-control">
+												<label class="label" for={id}>
+													<span class="label-text">
+														{field.label || field.key}
+														{#if field.required}<span class="text-error">*</span>{/if}
+													</span>
+												</label>
+												{#if field.type === 'select'}
+													<select
+														{id}
+														class="select select-bordered select-sm w-full"
+														value={stringValue(field.key)}
+														onchange={(e) => setSelect(field, e.currentTarget.value)}
+													>
+														{#each field.options as option (option.value)}
+															<option value={String(option.value)}>
+																{option.label || String(option.value)}
+															</option>
+														{/each}
+													</select>
+												{:else if field.type === 'int'}
+													<input
+														{id}
+														type="number"
+														class="input input-bordered input-sm w-full tabular-nums"
+														value={stringValue(field.key)}
+														oninput={(e) => setNumber(field.key, e.currentTarget.value)}
+													/>
+												{:else if field.type === 'secret'}
+													<div class="join w-full">
+														<input
+															{id}
+															type={revealed[field.key] ? 'text' : 'password'}
+															class="input input-bordered input-sm join-item flex-1 font-mono text-sm"
+															value={stringValue(field.key)}
+															oninput={(e) =>
+																(draft = { ...draft, [field.key]: e.currentTarget.value })}
+														/>
+														<button
+															type="button"
+															class="btn btn-sm join-item"
+															onclick={() =>
+																(revealed = { ...revealed, [field.key]: !revealed[field.key] })}
+														>
+															{revealed[field.key] ? 'Hide' : 'Show'}
+														</button>
+													</div>
+												{:else}
+													<input
+														{id}
+														type="text"
+														class="input input-bordered input-sm w-full"
+														value={stringValue(field.key)}
+														oninput={(e) =>
+															(draft = { ...draft, [field.key]: e.currentTarget.value })}
+													/>
+												{/if}
+												{#if field.help}
+													<span class="mt-1 text-xs text-base-content/50">{field.help}</span>
+												{/if}
+											</div>
+										{/if}
+									{/each}
+								</div>
+
+								<div class="flex flex-wrap items-center gap-3 pt-1">
+									<button
+										type="button"
+										class="btn btn-sm"
+										onclick={() => runTest(plugin)}
+										disabled={test.isPending}
+									>
+										{test.isPending ? 'Testing…' : 'Test'}
+									</button>
+									{#if result}
+										<span
+											class="flex min-w-0 items-center gap-1.5 text-sm"
+											class:text-success={result.valid}
+											class:text-error={!result.valid}
+										>
+											{#if result.valid}
+												<CircleCheck class="size-4 shrink-0" aria-hidden="true" />
+											{:else}
+												<CircleX class="size-4 shrink-0" aria-hidden="true" />
+											{/if}
+											<span class="truncate">{result.message}</span>
+										</span>
+									{/if}
+									<div class="flex-1"></div>
+									<button
+										type="button"
+										class="btn btn-primary btn-sm"
+										onclick={() => saveDraft(plugin)}
+										disabled={save.isPending}
+									>
+										{save.isPending ? 'Saving…' : 'Save'}
+									</button>
+								</div>
+							{/if}
 						</div>
 					{/if}
-				{/each}
-			</div>
-		{/if}
-	</div>
-</div>
+				</li>
+			{/each}
+		</ul>
+		<p class="font-mono text-[0.68rem] uppercase tracking-[0.2em] text-base-content/35">
+			plugin api v{apiVersion}
+		</p>
+	{/if}
+</section>
+
+<style>
+	.plugin-card {
+		transition:
+			box-shadow 0.4s ease,
+			border-color 0.4s ease;
+	}
+	.plugin-card.is-active {
+		border-color: oklch(from var(--color-accent) l c h / 0.55);
+		box-shadow:
+			0 0 0 1px oklch(from var(--color-accent) l c h / 0.3),
+			0 0 44px oklch(from var(--color-accent) l c h / 0.18);
+	}
+	.plugin-card.is-broken {
+		border-color: oklch(from var(--color-error) l c h / 0.4);
+	}
+	.orb {
+		display: inline-block;
+		width: 0.7rem;
+		height: 0.7rem;
+		border-radius: 9999px;
+		background: oklch(from var(--color-base-content) l c h / 0.3);
+		transition: background 0.3s ease;
+	}
+	.orb.is-connected {
+		background: var(--color-accent);
+		animation: orb-pulse 2.4s ease-in-out infinite;
+	}
+	@keyframes orb-pulse {
+		0%,
+		100% {
+			box-shadow: 0 0 5px oklch(from var(--color-accent) l c h / 0.5);
+		}
+		50% {
+			box-shadow: 0 0 14px oklch(from var(--color-accent) l c h / 0.95);
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.orb.is-connected {
+			animation: none;
+		}
+	}
+</style>

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -381,6 +381,12 @@ export const API = {
 	},
 	plugins: {
 		list: () => '/api/v1/plugins',
+		enable: (id: string) => `/api/v1/plugins/${id}/enable`,
+		disable: (id: string) => `/api/v1/plugins/${id}/disable`,
+		settings: (id: string) => `/api/v1/plugins/${id}/settings`,
+		test: (id: string) => `/api/v1/plugins/${id}/test`,
+		// manifest plugin API (PLUGINS.md, api_version 0) routes - kept so the
+		// existing manifest UI/queries type-check while the two APIs are reconciled
 		install: () => '/api/v1/plugins/install',
 		update: (name: string) => `/api/v1/plugins/${name}`,
 		uninstall: (name: string) => `/api/v1/plugins/${name}`

--- a/frontend/src/lib/queries/plugins/PluginQueries.svelte.ts
+++ b/frontend/src/lib/queries/plugins/PluginQueries.svelte.ts
@@ -1,17 +1,75 @@
-import { createQuery } from '@tanstack/svelte-query';
+import { createMutation, createQuery, queryOptions } from '@tanstack/svelte-query';
 
 import { api } from '$lib/api/client';
-import { API } from '$lib/constants';
+import { API, CACHE_TTL } from '$lib/constants';
+import { invalidateQueriesWithPersister } from '$lib/queries/QueryClient';
+import type {
+	PluginListResponse,
+	PluginSettingsResponse,
+	PluginSettingsValue,
+	PluginTestResult,
+	PluginToggleResponse
+} from '$lib/types';
 
-import { PluginQueryKeyFactory } from './PluginQueryKeyFactory';
-import type { PluginListResponse } from './types';
+export const PluginQueryKeyFactory = {
+	all: ['plugins'] as const,
+	list: () => [...PluginQueryKeyFactory.all, 'list'] as const,
+	settings: (id: string) => [...PluginQueryKeyFactory.all, 'settings', id] as const
+};
 
-type Getter<T> = () => T;
-
-// Admin-only: the Settings -> Plugins roster.
-export const getPluginsQuery = (getEnabled: Getter<boolean> = () => true) =>
-	createQuery(() => ({
+const getPluginsQueryOptions = () =>
+	queryOptions({
+		staleTime: CACHE_TTL.LIBRARY_NATIVE,
 		queryKey: PluginQueryKeyFactory.list(),
-		queryFn: ({ signal }) => api.global.get<PluginListResponse>(API.plugins.list(), { signal }),
-		enabled: getEnabled()
+		queryFn: ({ signal }) => api.global.get<PluginListResponse>(API.plugins.list(), { signal })
+	});
+
+export const getPluginsQuery = () => createQuery(() => getPluginsQueryOptions());
+
+const getPluginSettingsQueryOptions = (id: string) =>
+	queryOptions({
+		staleTime: CACHE_TTL.LIBRARY_NATIVE,
+		queryKey: PluginQueryKeyFactory.settings(id),
+		queryFn: ({ signal }) =>
+			api.global.get<PluginSettingsResponse>(API.plugins.settings(id), { signal })
+	});
+
+export const getPluginSettingsQuery = (id: () => string) =>
+	createQuery(() => getPluginSettingsQueryOptions(id()));
+
+async function invalidatePlugins(id?: string) {
+	await invalidateQueriesWithPersister({ queryKey: PluginQueryKeyFactory.list() });
+	if (id) {
+		await invalidateQueriesWithPersister({ queryKey: PluginQueryKeyFactory.settings(id) });
+	}
+}
+
+export function togglePluginMutation() {
+	return createMutation(() => ({
+		mutationFn: ({ id, enabled }: { id: string; enabled: boolean }) =>
+			api.global.post<PluginToggleResponse>(
+				enabled ? API.plugins.enable(id) : API.plugins.disable(id),
+				{}
+			),
+		onSuccess: (_data: PluginToggleResponse, vars: { id: string; enabled: boolean }) =>
+			invalidatePlugins(vars.id)
 	}));
+}
+
+export function savePluginSettingsMutation() {
+	return createMutation(() => ({
+		mutationFn: ({ id, values }: { id: string; values: Record<string, PluginSettingsValue> }) =>
+			api.global.put<PluginSettingsResponse>(API.plugins.settings(id), { values }),
+		onSuccess: (
+			_data: PluginSettingsResponse,
+			vars: { id: string; values: Record<string, PluginSettingsValue> }
+		) => invalidatePlugins(vars.id)
+	}));
+}
+
+export function testPluginMutation() {
+	return createMutation(() => ({
+		mutationFn: ({ id, values }: { id: string; values?: Record<string, PluginSettingsValue> }) =>
+			api.global.post<PluginTestResult>(API.plugins.test(id), { values: values ?? {} })
+	}));
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1770,6 +1770,58 @@ export interface OperationResult {
 	message?: string | null;
 }
 
+// Acquisition plugins (hand-mirrors backend api/v1/schemas/plugins.py)
+export interface PluginInfo {
+	id: string;
+	name: string;
+	version: string;
+	builtin: boolean;
+	enabled: boolean;
+	loaded: boolean;
+	error?: string | null;
+	source: string;
+	api_version?: number | null;
+}
+
+export interface PluginListResponse {
+	plugins: PluginInfo[];
+	api_version: number;
+}
+
+export type PluginSettingsValue = string | number | boolean | null;
+
+export interface PluginSelectOption {
+	value: string | number;
+	label: string;
+}
+
+export interface PluginSettingsField {
+	key: string;
+	type: 'str' | 'int' | 'bool' | 'select' | 'secret';
+	label: string;
+	help: string;
+	default: PluginSettingsValue;
+	required: boolean;
+	options: PluginSelectOption[];
+}
+
+export interface PluginSettingsResponse {
+	id: string;
+	schema: PluginSettingsField[];
+	values: Record<string, PluginSettingsValue>;
+}
+
+export interface PluginToggleResponse {
+	id: string;
+	enabled: boolean;
+}
+
+export interface PluginTestResult {
+	valid: boolean;
+	message: string;
+	version?: string | null;
+}
+
 export interface SabnzbdConnectionSettings {
 	enabled: boolean;
 	client_type: string;


### PR DESCRIPTION
> **DRAFT - needs maintainer reconciliation.** Upstream already ships a different, experimental **manifest-based** plugin API (`PLUGINS.md`, `api_version 0`, `infrastructure/plugins/host.py`, install-from-GitHub, `plugin.toml`) and deliberately dropped the `audio_source` capability in c6936a0. This PR was developed in parallel and offers a **typed `AcquisitionPlugin` ABC** with a settings-encrypted management UI as a candidate evolution of the acquisition seam specifically. The two systems overlap on `/api/v1/plugins`, `SettingsPlugins.svelte`, and `PluginQueries.svelte.ts` - this draft **replaces those three surfaces** with the acquisition variants (disclosed conflicts below) while leaving the manifest host itself (used by Get-It and scrobbler capabilities) untouched. Happy to re-cut this either as a capability inside the manifest system or as a separate route namespace - maintainer call.

## What

An acquisition plugin layer that turns the slskd/SABnzbd integrations into instances of a typed plugin interface:

- `backend/plugins/base.py`: `AcquisitionPlugin` ABC - identity, typed settings schema (`str`/`int`/`bool`/`select`/`secret` fields), `get_indexer()` / `get_download_client()` factories, `test_connection()`, lifecycle hooks, `API_VERSION`
- `backend/plugins/manager.py`: discovery (built-ins + `{ROOT_APP_DIR}/plugins` + the `droppedneedle.plugins` entry-point group), quarantine-on-error registry, per-plugin namespaced config with manager-side Fernet encryption of secret fields
- `backend/plugins/builtin/`: slskd and SABnzbd wrappers that return the exact same DI singletons the orchestrator used before - behavior is provably unchanged (see `test_registry_equivalence.py`)
- The acquisition seam: `_resolve_acquisition_providers()` in `service_providers.py` resolves (indexer, client) pairs through the registry; `get_download_client_for_source` consults the registry first (source ids ARE plugin ids)
- `core/dependencies/invalidation.py`: the soulseek/usenet singleton cache-clear chains extracted from the two settings routes so the plugin settings API reuses the identical lists
- Admin API (`/api/v1/plugins`: list/enable/disable/settings/test) + `SettingsPlugins.svelte` schema-driven UI
- `docs/plugins/`: AUTHORING / INTERFACE / MIGRATION guides + a runnable `example/mock_provider.py`

## Known conflicts with the manifest system (all deliberate, all up for discussion)

1. `api/v1/routes/plugins.py` + `api/v1/schemas/plugins.py` are replaced; the manifest API's install/update/uninstall routes are removed in this draft (their frontend constants are kept so the untouched manifest queries still type-check).
2. `SettingsPlugins.svelte` / `PluginQueries.svelte.ts` are replaced with the acquisition management UI.
3. `PreferencesService` gains `get_plugins_config()` / `save_plugin_config_raw()` alongside the manifest host's `get_plugin_config()` / `save_plugin_config()`; both share the `plugins` config section (acquisition ids `soulseek`/`usenet` vs manifest plugin names).
4. This design intentionally allows third-party *acquisition* plugins, which upstream dropped as a capability - that is the core policy question this draft raises.

## How tested

`backend/tests/plugins` - **34 passed** (Windows, Python 3.13): base contract, manager discovery/quarantine/encryption, route auth + masking, external mock provider end-to-end, and registry equivalence (orchestrator receives identical singletons pre/post plugin layer). Frontend: `pnpm check` - 0 errors, 0 warnings.
