### PR TITLE
feat: support serving under a reverse-proxy base path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ COPY frontend/pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store pnpm install --frozen-lockfile
 
 COPY frontend/ .
-RUN pnpm run build
+# SvelteKit bakes paths.base at build time; the entrypoint rewrites this placeholder
+# to the runtime BASE_PATH so one image serves any subpath.
+RUN BASE_PATH=/__DN_BASE_PATH__ pnpm run build
 
 FROM python:3.13.5-slim AS python-deps
 

--- a/README.md
+++ b/README.md
@@ -620,6 +620,8 @@ DroppedNeedle stores its config in `config/config.json` inside the mapped config
 | `PORT` | `8688` | Port the application listens on |
 | `TZ` | `Etc/UTC` | Container timezone |
 | `SLSKD_DOWNLOADS_PATH` | `/data/downloads/slskd` | Exact in-container path to slskd's completed downloads. The Compose example overrides this with `/data/slskd/complete`; keep either path inside the library's common-parent mount for fast moves. |
+| `TRUSTED_PROXY_IPS` | `*` | Comma-separated IPs/CIDRs trusted for `X-Forwarded-*` headers. Restrict to your proxy's IP in production. |
+| `BASE_PATH` | *(empty)* | Subpath to serve under behind a reverse proxy, e.g. `/droppedneedle`. Empty serves at the domain root. See [Serving Under a Subpath](#serving-under-a-subpath). |
 
 Run `id` on your host to find your PUID and PGID values.
 
@@ -635,6 +637,21 @@ and another trusted service share a group and both must modify the same media. A
 it makes new files writable by every local account allowed by the underlying filesystem.
 A move or metadata-preserving copy can retain a source file's existing mode, so `UMASK`
 is not a way to override permissions supplied by a download client.
+
+### Serving Under a Subpath
+
+By default DroppedNeedle is served at the root of its domain (`https://music.example.com/`).
+To serve it under a subpath instead (`https://example.com/droppedneedle/`), set `BASE_PATH`
+to that subpath and configure your reverse proxy to forward it **with the prefix stripped**.
+The single prebuilt image handles any subpath at runtime; no rebuild is needed. Example nginx:
+
+```nginx
+location /droppedneedle/ {
+    proxy_pass http://droppedneedle:8688/;  # trailing slash strips the prefix
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
 
 ### In-App Settings
 

--- a/backend/api/v1/routes/auth.py
+++ b/backend/api/v1/routes/auth.py
@@ -490,7 +490,9 @@ async def oidc_callback(
         raise HTTPException(status_code = status.HTTP_401_UNAUTHORIZED, detail = "OIDC authentication failed")
     except ExternalServiceError:
         raise HTTPException(status_code = status.HTTP_503_SERVICE_UNAVAILABLE, detail = "OIDC provider unavailable")
-    return responses.RedirectResponse(url = f"/auth/callback?code={exchange_code}")
+    return responses.RedirectResponse(
+        request.url_for("serve_spa_routes", full_path="auth/callback").include_query_params(code=exchange_code)
+    )
 
 
 @router.post("/oidc/exchange", response_model = AuthResponse)

--- a/backend/api/v1/routes/me_connections.py
+++ b/backend/api/v1/routes/me_connections.py
@@ -311,7 +311,7 @@ async def spotify_auth_url(
         raise HTTPException(status_code=400, detail="Spotify is not configured by the administrator")
     state = secrets.token_urlsafe(32)
     await auth_store.store_spotify_state(state, current_user.id)
-    redirect_uri = str(request.base_url).rstrip("/") + "/api/v1/me/connections/spotify/auth/callback"
+    redirect_uri = str(request.url_for("spotify_auth_callback"))
     auth_url = "https://accounts.spotify.com/authorize?" + urlencode({
         "client_id": settings.client_id,
         "response_type": "code",
@@ -332,15 +332,16 @@ async def spotify_auth_callback(
     state: str | None = None,
     error: str | None = None,
 ) -> fastapi_responses.RedirectResponse:
+    profile = request.url_for("serve_spa_routes", full_path="profile")
     if error or not code or not state:
-        return fastapi_responses.RedirectResponse("/profile?spotify=error")
+        return fastapi_responses.RedirectResponse(profile.include_query_params(spotify="error"))
 
     user_id = await auth_store.consume_spotify_state(state)
     if not user_id:
-        return fastapi_responses.RedirectResponse("/profile?spotify=error&reason=state")
+        return fastapi_responses.RedirectResponse(profile.include_query_params(spotify="error", reason="state"))
 
     settings = preferences_service.get_spotify_settings_raw()
-    redirect_uri = str(request.base_url).rstrip("/") + "/api/v1/me/connections/spotify/auth/callback"
+    redirect_uri = str(request.url_for("spotify_auth_callback"))
     basic = base64.b64encode(f"{settings.client_id}:{settings.client_secret}".encode()).decode()
 
     try:
@@ -352,7 +353,7 @@ async def spotify_auth_callback(
             )
             if token_resp.status_code != 200:
                 logger.warning(f"Spotify token exchange failed: status={token_resp.status_code}")
-                return fastapi_responses.RedirectResponse("/profile?spotify=error&reason=token")
+                return fastapi_responses.RedirectResponse(profile.include_query_params(spotify="error", reason="token"))
             token_data = token_resp.json()
 
             me_resp = await client.get(
@@ -361,7 +362,7 @@ async def spotify_auth_callback(
             )
     except Exception:  # noqa: BLE001
         logger.exception("Spotify OAuth callback failed")
-        return fastapi_responses.RedirectResponse("/profile?spotify=error&reason=network")
+        return fastapi_responses.RedirectResponse(profile.include_query_params(spotify="error", reason="network"))
 
     spotify_user = me_resp.json() if me_resp.status_code == 200 else {}
     expires_at = (
@@ -375,7 +376,7 @@ async def spotify_auth_callback(
         "username": spotify_user.get("display_name") or spotify_user.get("id") or "Spotify",
         "spotify_user_id": spotify_user.get("id", ""),
     })
-    return fastapi_responses.RedirectResponse("/profile?spotify=connected")
+    return fastapi_responses.RedirectResponse(profile.include_query_params(spotify="connected"))
 
 
 @router.put("/connections/navidrome", response_model=ConnectionStatus)

--- a/backend/api/v1/routes/settings.py
+++ b/backend/api/v1/routes/settings.py
@@ -653,10 +653,7 @@ class SpotifyRedirectUriResponse(AppStruct):
     dependencies=[Depends(_admin_guard)],
 )
 async def get_spotify_redirect_uri(request: Request) -> SpotifyRedirectUriResponse:
-    redirect_uri = (
-        str(request.base_url).rstrip("/")
-        + "/api/v1/me/connections/spotify/auth/callback"
-    )
+    redirect_uri = str(request.url_for("spotify_auth_callback"))
     return SpotifyRedirectUriResponse(redirect_uri=redirect_uri)
 
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -72,6 +72,11 @@ class Settings(BaseSettings):
     port: int = Field(default=8688)
     debug: bool = Field(default=False)
     log_level: str = Field(default="INFO")
+
+    base_path: str = Field(
+        default="",
+        description="Subpath the app is served under behind a reverse proxy (e.g. '/droppedneedle'). Empty (default) serves at the domain root. The proxy must forward the subpath stripped of this prefix. Must match the BASE_PATH the frontend was built/rewritten with.",
+    )
     
     cache_ttl_default: int = Field(default=60)
     cache_ttl_artist: int = Field(default=3600)
@@ -109,6 +114,14 @@ class Settings(BaseSettings):
     audiodb_premium: bool = Field(default=False, description="Set to true if using a premium AudioDB API key")
     instance_id: str = Field(default="", description="Auto-generated per-instance UUID for User-Agent differentiation")
     
+    @field_validator("base_path")
+    @classmethod
+    def validate_base_path(cls, v: str) -> str:
+        stripped = v.strip().rstrip("/")
+        if not stripped:
+            return ""
+        return stripped if stripped.startswith("/") else f"/{stripped}"
+
     @field_validator("log_level")
     @classmethod
     def validate_log_level(cls, v: str) -> str:

--- a/backend/main.py
+++ b/backend/main.py
@@ -783,6 +783,7 @@ app = FastAPI(
     openapi_url="/api/v1/openapi.json",
     lifespan=lifespan,
     default_response_class=MsgSpecJSONResponse,
+    root_path=get_settings().base_path,
 )
 
 app.add_exception_handler(ClientDisconnectedError, client_disconnected_handler)

--- a/backend/tests/test_base_path.py
+++ b/backend/tests/test_base_path.py
@@ -1,0 +1,102 @@
+"""BASE_PATH / reverse-proxy subpath support: config normalization + base-aware redirects.
+
+The subpath is carried by FastAPI's ``root_path`` (set from ``base_path``); browser-facing
+redirects to SPA routes are generated via ``request.url_for`` so they inherit the prefix.
+"""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import AsyncMock, MagicMock
+
+from core.config import Settings
+
+
+class TestBasePathNormalization:
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("", ""),
+            ("/droppedneedle", "/droppedneedle"),
+            ("droppedneedle", "/droppedneedle"),
+            ("/dn/", "/dn"),
+            ("/a/b/", "/a/b"),
+            ("   ", ""),
+            ("/x///", "/x"),
+        ],
+    )
+    def test_normalizes(self, raw: str, expected: str) -> None:
+        assert Settings(base_path=raw).base_path == expected
+
+    def test_default_is_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BASE_PATH", raising=False)
+        assert Settings().base_path == ""
+
+
+def _spa_app(base_path: str) -> FastAPI:
+    """Minimal app exercising the base-aware redirect handlers.
+
+    Includes the SPA catch-all so ``url_for('serve_spa_routes', ...)`` resolves, and
+    overrides the callbacks' dependencies (unused on the redirect paths under test).
+    """
+    from api.v1.routes.auth import router as auth_router
+    from api.v1.routes.me_connections import router as me_router
+    from core.dependencies import (
+        get_auth_store,
+        get_preferences_service,
+        get_user_connections_store,
+    )
+    from core.dependencies.auth_providers import get_oidc_user_auth_service
+
+    app = FastAPI(root_path=base_path)
+    app.include_router(auth_router)
+    app.include_router(me_router)
+
+    @app.get("/{full_path:path}")
+    async def serve_spa_routes(full_path: str):
+        return {}
+
+    auth_store = AsyncMock()
+    auth_store.consume_spotify_state = AsyncMock(return_value=None)
+    oidc = AsyncMock()
+    oidc.handle_callback = AsyncMock(return_value="exch-123")
+
+    app.dependency_overrides[get_auth_store] = lambda: auth_store
+    app.dependency_overrides[get_user_connections_store] = lambda: AsyncMock()
+    app.dependency_overrides[get_preferences_service] = lambda: MagicMock()
+    app.dependency_overrides[get_oidc_user_auth_service] = lambda: oidc
+    return app
+
+
+@pytest.mark.parametrize("base_path", ["", "/droppedneedle"])
+def test_spotify_callback_redirect_carries_base_path(base_path: str) -> None:
+    client = TestClient(_spa_app(base_path), raise_server_exceptions=False)
+    resp = client.get(
+        "/me/connections/spotify/auth/callback?error=denied", follow_redirects=False
+    )
+    assert resp.status_code == 307
+    assert resp.headers["location"] == f"http://testserver{base_path}/profile?spotify=error"
+
+
+@pytest.mark.parametrize("base_path", ["", "/droppedneedle"])
+def test_spotify_callback_invalid_state_redirect_carries_base_path(base_path: str) -> None:
+    client = TestClient(_spa_app(base_path), raise_server_exceptions=False)
+    resp = client.get(
+        "/me/connections/spotify/auth/callback?code=c&state=s", follow_redirects=False
+    )
+    assert resp.status_code == 307
+    location = resp.headers["location"]
+    assert location.startswith(f"http://testserver{base_path}/profile")
+    assert "spotify=error" in location
+    assert "reason=state" in location
+
+
+@pytest.mark.parametrize("base_path", ["", "/droppedneedle"])
+def test_oidc_callback_redirect_carries_base_path(base_path: str) -> None:
+    client = TestClient(_spa_app(base_path), raise_server_exceptions=False)
+    resp = client.get("/auth/oidc/callback?code=c&state=s", follow_redirects=False)
+    assert resp.status_code == 307
+    assert (
+        resp.headers["location"]
+        == f"http://testserver{base_path}/auth/callback?code=exch-123"
+    )

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -18,6 +18,7 @@ services:
       - TZ=Etc/UTC           # e.g. America/New_York, Europe/London
       - SLSKD_DOWNLOADS_PATH=/data/slskd/complete  # path inside the common media mount below
       # - TRUSTED_PROXY_IPS=172.17.0.1  # your reverse proxy's IP; defaults to * (fine for single-host)
+      # - BASE_PATH=/droppedneedle  # serve under a reverse-proxy subpath; the proxy must forward it stripped. Omit to serve at the root.
     ports:
       - "8688:8688"          # host:container
     volumes:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,6 +27,24 @@ PGID=${PGID:-1000}
 case "$PUID" in ''|*[!0-9]*) echo "[init] FATAL: PUID='$PUID' is not a valid numeric UID."; exit 1;; esac
 case "$PGID" in ''|*[!0-9]*) echo "[init] FATAL: PGID='$PGID' is not a valid numeric GID."; exit 1;; esac
 
+# Rewrite the frontend's build-time base-path placeholder (baked by the Dockerfile) to
+# the runtime BASE_PATH, so one image serves any reverse-proxy subpath. Empty = root.
+apply_base_path() {
+    _static="/app/static"
+    [ -d "$_static" ] || return 0
+    _base=$(printf '%s' "${BASE_PATH:-}" | sed 's#/*$##')
+    case "$_base" in ""|/*) ;; *) _base="/$_base" ;; esac
+    _files=$(grep -rlF '/__DN_BASE_PATH__' "$_static" 2>/dev/null || true)
+    [ -n "$_files" ] || return 0
+    printf '%s\n' "$_files" | while IFS= read -r _f; do
+        if ! sed -i "s#/__DN_BASE_PATH__#${_base}#g" "$_f" 2>/dev/null; then
+            echo "[init] WARNING: could not rewrite '$_f' for BASE_PATH (not writable?); frontend may be broken."
+        fi
+    done
+    echo "[init] Serving frontend under base path '${_base:-/}'."
+}
+apply_base_path || true
+
 check_writable() {
     _dir="$1"
     _identity="$2"

--- a/frontend/src/lib/api/api-utils.spec.ts
+++ b/frontend/src/lib/api/api-utils.spec.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// `base` (from $app/paths) and PUBLIC_API_URL are resolved at module load, so each case
+// re-mocks and re-imports to exercise a different reverse-proxy base path.
+async function loadGetApiUrl(base: string, env: Record<string, string> = {}) {
+	vi.doMock('$app/paths', () => ({ base }));
+	vi.doMock('$env/dynamic/public', () => ({ env }));
+	return (await import('./api-utils')).getApiUrl;
+}
+
+describe('getApiUrl', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('returns root-absolute API paths unchanged when no base path is set', async () => {
+		const getApiUrl = await loadGetApiUrl('');
+		expect(getApiUrl('/api/v1/covers/x')).toBe('/api/v1/covers/x');
+	});
+
+	it('prefixes API paths with the base path when set', async () => {
+		const getApiUrl = await loadGetApiUrl('/droppedneedle');
+		expect(getApiUrl('/api/v1/covers/x')).toBe('/droppedneedle/api/v1/covers/x');
+	});
+
+	it('composes the PUBLIC_API_URL dev override with the base path', async () => {
+		const getApiUrl = await loadGetApiUrl('/dn', { PUBLIC_API_URL: 'http://api.test/' });
+		expect(getApiUrl('/api/v1/covers/x')).toBe('http://api.test/dn/api/v1/covers/x');
+	});
+
+	it('leaves non-absolute input untouched', async () => {
+		const getApiUrl = await loadGetApiUrl('/dn');
+		expect(getApiUrl('already/relative')).toBe('already/relative');
+	});
+});

--- a/frontend/src/lib/api/api-utils.ts
+++ b/frontend/src/lib/api/api-utils.ts
@@ -1,12 +1,14 @@
 import { env } from '$env/dynamic/public';
+import { base } from '$app/paths';
 
 /**
- * Normalizes an API path by prepending the PUBLIC_API_URL if it's set.
- * Useful for <img> src tags, Background image URLs, and other places where
- * the API client isn't automatically resolving the absolute URL.
+ * Normalizes an API path by prepending the reverse-proxy base path (and the
+ * PUBLIC_API_URL dev override, if set). Useful for <img> src tags, EventSource
+ * URLs, and other places where the API client isn't automatically resolving the
+ * absolute URL. `base` is empty by default, so root-hosted deploys are unaffected.
  *
  * @param path The API path (e.g., '/api/v1/covers/...')
- * @returns The fully qualified API URL or the original path if PUBLIC_API_URL is unset.
+ * @returns The fully qualified API URL, or a base-prefixed path.
  */
 export function getApiUrl(path: string): string {
 	if (!path.startsWith('/')) {
@@ -15,8 +17,8 @@ export function getApiUrl(path: string): string {
 
 	if (env.PUBLIC_API_URL) {
 		const baseUrl = env.PUBLIC_API_URL.replace(/\/$/, '');
-		return `${baseUrl}${path}`;
+		return `${baseUrl}${base}${path}`;
 	}
 
-	return path;
+	return `${base}${path}`;
 }

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,5 +1,6 @@
 import { pageFetch } from '$lib/utils/navigationAbort';
 import { getApiUrl } from '$lib/api/api-utils';
+import { resolve } from '$app/paths';
 import { browser } from '$app/environment';
 import { authStore } from '$lib/stores/authStore.svelte';
 
@@ -66,7 +67,7 @@ async function handleResponse<T = void>(res: Response): Promise<T> {
 		// Session expired mid-use: hard redirect so layout re-initialises cleanly
 		if (res.status === 401 && browser && authStore.isAuthenticated) {
 			authStore.clear();
-			window.location.href = '/login';
+			window.location.href = resolve('/login');
 			throw new SessionExpiredError();
 		}
 

--- a/frontend/src/lib/components/AuthenticatedAppShell.svelte
+++ b/frontend/src/lib/components/AuthenticatedAppShell.svelte
@@ -326,13 +326,13 @@
 
 	function handleSearch() {
 		if (query.trim()) {
-			goto(`/search?q=${encodeURIComponent(query)}`);
+			goto(resolve(`/search?q=${encodeURIComponent(query)}`));
 		}
 	}
 
 	function handleModalSearch() {
 		if (modalQuery.trim()) {
-			goto(`/search?q=${encodeURIComponent(modalQuery)}`);
+			goto(resolve(`/search?q=${encodeURIComponent(modalQuery)}`));
 			const modal = document.getElementById('search_modal') as HTMLDialogElement;
 			if (modal) modal.close();
 			modalQuery = '';
@@ -381,7 +381,7 @@
 			class="droppedneedle-topbar navbar bg-base-100/95 backdrop-blur shadow-sm sticky top-0 z-50"
 		>
 			<div class="navbar-start w-auto">
-				<a href="/" class="btn btn-ghost px-2 max-xs:hidden sm:px-4" aria-label="Home">
+				<a href={resolve('/')} class="btn btn-ghost px-2 max-xs:hidden sm:px-4" aria-label="Home">
 					<img src="/logo_wide.png" alt="DroppedNeedle" class="h-8 hidden sm:block" />
 					<img src="/logo_icon.png" alt="DroppedNeedle" class="h-8 block sm:hidden" />
 				</a>
@@ -398,7 +398,7 @@
 			</div>
 			<div class="navbar-end w-auto pr-1 sm:pr-2">
 				<ServiceHealthIndicator />
-				<a href="/profile" class="btn btn-ghost btn-circle btn-md" aria-label="Profile">
+				<a href={resolve('/profile')} class="btn btn-ghost btn-circle btn-md" aria-label="Profile">
 					{#if authStore.user?.avatar_url}
 						<img
 							src={authStore.user.avatar_url}
@@ -444,7 +444,11 @@
 				<div class="divider my-0"></div>
 
 				<li>
-					<a href="/" class="is-drawer-close:tooltip is-drawer-close:tooltip-right" data-tip="Home">
+					<a
+						href={resolve('/')}
+						class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
+						data-tip="Home"
+					>
 						<House class="h-6 w-6" />
 						<span class="is-drawer-close:hidden">Home</span>
 					</a>
@@ -452,7 +456,7 @@
 
 				<li>
 					<a
-						href="/discover"
+						href={resolve('/discover')}
 						class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 						data-tip="Discover"
 					>
@@ -463,7 +467,7 @@
 
 				<li>
 					<a
-						href="/library"
+						href={resolve('/library')}
 						class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 						class:menu-active={isLibraryNavActive()}
 						aria-current={isLibraryNavActive() ? 'page' : undefined}
@@ -484,7 +488,7 @@
 
 				<li>
 					<a
-						href="/downloads"
+						href={resolve('/downloads')}
 						class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 						data-tip="Downloads"
 					>
@@ -498,7 +502,7 @@
 
 				<li>
 					<a
-						href="/following"
+						href={resolve('/following')}
 						class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 						class:menu-active={isNavActive('/following')}
 						aria-current={isNavActive('/following') ? 'page' : undefined}
@@ -517,7 +521,7 @@
 				{#if downloadClientConfigured}
 					<li>
 						<a
-							href="/playlists"
+							href={resolve('/playlists')}
 							class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 							class:menu-active={isNavActive('/playlists')}
 							aria-current={isNavActive('/playlists') ? 'page' : undefined}
@@ -538,7 +542,7 @@
 				{#if downloadClientConfigured}
 					<li>
 						<a
-							href="/requests"
+							href={resolve('/requests')}
 							class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 							data-tip="Requests"
 						>
@@ -557,7 +561,7 @@
 					</li>
 					<li>
 						<a
-							href="/library/management"
+							href={resolve('/library/management')}
 							class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 							class:menu-active={isNavActive('/library/management')}
 							aria-current={isNavActive('/library/management') ? 'page' : undefined}
@@ -577,7 +581,7 @@
 					</li>
 					<li>
 						<a
-							href="/requests?tab=approvals"
+							href={resolve('/requests?tab=approvals')}
 							class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 							data-tip="Approvals"
 						>
@@ -597,7 +601,7 @@
 						data-tip={versionUpdateAvailable ? 'Settings - update available' : 'Settings'}
 					>
 						<a
-							href={versionUpdateAvailable ? '/settings?tab=about' : '/settings'}
+							href={versionUpdateAvailable ? resolve('/settings?tab=about') : resolve('/settings')}
 							class="btn btn-ghost btn-circle relative"
 							aria-label={versionUpdateAvailable ? 'Settings - update available' : 'Settings'}
 						>
@@ -636,7 +640,7 @@
 
 <nav class="droppedneedle-bottom-nav md:hidden" aria-label="Primary navigation">
 	<a
-		href="/"
+		href={resolve('/')}
 		class="droppedneedle-bottom-nav__item"
 		class:active={currentPath === '/'}
 		aria-current={currentPath === '/' ? 'page' : undefined}
@@ -645,7 +649,7 @@
 		<span>Home</span>
 	</a>
 	<a
-		href="/discover"
+		href={resolve('/discover')}
 		class="droppedneedle-bottom-nav__item"
 		class:active={isNavActive('/discover')}
 		aria-current={isNavActive('/discover') ? 'page' : undefined}
@@ -664,7 +668,7 @@
 		<span>Search</span>
 	</button>
 	<a
-		href="/library"
+		href={resolve('/library')}
 		class="droppedneedle-bottom-nav__item"
 		class:active={isNavActive('/library')}
 		aria-current={isNavActive('/library') ? 'page' : undefined}
@@ -676,7 +680,7 @@
 		{/if}
 	</a>
 	<a
-		href={versionUpdateAvailable ? '/settings?tab=about' : '/settings'}
+		href={versionUpdateAvailable ? resolve('/settings?tab=about') : resolve('/settings')}
 		class="droppedneedle-bottom-nav__item"
 		class:active={isNavActive('/settings')}
 		aria-current={isNavActive('/settings') ? 'page' : undefined}

--- a/frontend/src/lib/components/AuthenticatedAppShell.svelte
+++ b/frontend/src/lib/components/AuthenticatedAppShell.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { stripBase } from '$lib/utils/basePath';
 	import '../../app.css';
 	import { browser } from '$app/environment';
 	import { goto, beforeNavigate, afterNavigate } from '$app/navigation';
-	import { resolve } from '$app/paths';
+	import { base, resolve } from '$app/paths';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { logout } from '$lib/utils/logout';
 	import { migratePageSourceKeys } from '$lib/stores/musicSource';
@@ -118,7 +119,7 @@
 
 	afterNavigate(() => {
 		if (browser) {
-			currentPath = window.location.pathname;
+			currentPath = stripBase(window.location.pathname);
 		}
 		navigationProgress.finish();
 	});
@@ -153,7 +154,7 @@
 		};
 
 		if (browser) {
-			currentPath = window.location.pathname;
+			currentPath = stripBase(window.location.pathname);
 		}
 		document.addEventListener('keydown', handleGlobalKeydown);
 	});
@@ -382,8 +383,8 @@
 		>
 			<div class="navbar-start w-auto">
 				<a href={resolve('/')} class="btn btn-ghost px-2 max-xs:hidden sm:px-4" aria-label="Home">
-					<img src="/logo_wide.png" alt="DroppedNeedle" class="h-8 hidden sm:block" />
-					<img src="/logo_icon.png" alt="DroppedNeedle" class="h-8 block sm:hidden" />
+					<img src="{base}/logo_wide.png" alt="DroppedNeedle" class="h-8 hidden sm:block" />
+					<img src="{base}/logo_icon.png" alt="DroppedNeedle" class="h-8 block sm:hidden" />
 				</a>
 			</div>
 			<div class="navbar-center min-w-0 grow justify-center px-1 sm:px-4">

--- a/frontend/src/lib/components/DiscoveryAlbumCarousel.svelte
+++ b/frontend/src/lib/components/DiscoveryAlbumCarousel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { DiscoveryAlbum, Album } from '$lib/types';
 	import HorizontalCarousel from './HorizontalCarousel.svelte';
 	import CarouselSkeleton from './CarouselSkeleton.svelte';
@@ -41,7 +42,7 @@
 	{:else if !configured}
 		<div class="bg-base-200 rounded-lg p-6 text-center">
 			<p class="text-base-content/70">Connect a music service to see recommendations</p>
-			<a href="/profile#scrobbling" class="btn btn-primary btn-sm mt-3">Configure</a>
+			<a href={resolve('/profile#scrobbling')} class="btn btn-primary btn-sm mt-3">Configure</a>
 		</div>
 	{:else if albums.length === 0}
 		<div class="bg-base-200 rounded-lg p-6 text-center">

--- a/frontend/src/lib/components/Footer.svelte
+++ b/frontend/src/lib/components/Footer.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base } from '$app/paths';
 	import { Github } from 'lucide-svelte';
 	import { getVersionQuery } from '$lib/queries/VersionQuery.svelte';
 
@@ -18,7 +19,7 @@
 <footer class="ms-footer grain" aria-label="Site footer">
 	<div class="ms-footer__inner">
 		<div class="ms-footer__brand">
-			<img src="/logo_wide_white.png" alt="DroppedNeedle" class="ms-footer__logo" />
+			<img src="{base}/logo_wide_white.png" alt="DroppedNeedle" class="ms-footer__logo" />
 		</div>
 
 		<div class="ms-footer__rule" aria-hidden="true"></div>

--- a/frontend/src/lib/components/GenreGrid.svelte
+++ b/frontend/src/lib/components/GenreGrid.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import GenreArtwork from '$lib/components/GenreArtwork.svelte';
 	import type { GenreArtwork as GenreArtworkModel } from '$lib/types';
 	import { getGenreGradient } from '$lib/utils/genreGradient';
@@ -25,7 +26,7 @@
 	<div class="grid grid-cols-2 gap-2.5 sm:grid-cols-3 sm:gap-3 md:grid-cols-4 lg:grid-cols-5">
 		{#each genres.slice(0, 20) as genre (genre.name)}
 			<a
-				href="/genre?name={encodeURIComponent(genre.name)}"
+				href={resolve(`/genre?name=${encodeURIComponent(genre.name)}`)}
 				class="genre-tile group relative isolate overflow-hidden rounded-xl text-white shadow-md transition-all duration-300 hover:shadow-xl hover:ring-2 hover:ring-white/20 active:scale-[0.97] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary"
 			>
 				<div class="aspect-16/10"></div>

--- a/frontend/src/lib/components/GenrePills.svelte
+++ b/frontend/src/lib/components/GenrePills.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Globe, Shuffle } from 'lucide-svelte';
 
 	interface Props {
@@ -58,7 +59,7 @@
 	<div class="flex flex-wrap gap-3">
 		{#each genres.slice(0, MAX_PILLS) as genre (genre.name)}
 			<a
-				href="/genre?name={encodeURIComponent(genre.name)}"
+				href={resolve(`/genre?name=${encodeURIComponent(genre.name)}`)}
 				class="genre-pill group relative inline-flex items-center gap-1.5 rounded-full bg-gradient-to-r px-4 py-2 text-sm font-medium text-white shadow-lg ring-1 ring-inset ring-white/15 transition-all duration-300 motion-safe:hover:scale-105 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 sm:px-5 sm:py-2.5 {getGenreColor(
 					genre.name
 				)}"

--- a/frontend/src/lib/components/HomeEntryCards.svelte
+++ b/frontend/src/lib/components/HomeEntryCards.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Headphones, ArrowRight, Sparkles, AlertTriangle } from 'lucide-svelte';
 	import type { ComponentType } from 'svelte';
 	import { fromStore } from 'svelte/store';
@@ -215,7 +216,7 @@
 		<div class="flex flex-col">
 			<DropImportZone className="flex-1 [&>button]:h-full" />
 			<a
-				href="/downloads?tab=import"
+				href={resolve('/downloads?tab=import')}
 				class="mt-2 self-end text-xs font-semibold text-primary hover:underline"
 			>
 				View import history

--- a/frontend/src/lib/components/HomeSection.svelte
+++ b/frontend/src/lib/components/HomeSection.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type {
 		HomeSection as HomeSectionType,
 		HomeArtist,
@@ -51,7 +52,7 @@
 	function handleAlbumSearch(album: HomeAlbum) {
 		const query = [album.artist_name, album.name].filter(Boolean).join(' ').trim();
 		if (query) {
-			goto(`/search/albums?q=${encodeURIComponent(query)}`);
+			goto(resolve(`/search/albums?q=${encodeURIComponent(query)}`));
 		}
 	}
 
@@ -61,7 +62,7 @@
 			.join(' ')
 			.trim();
 		if (query) {
-			goto(`/search/albums?q=${encodeURIComponent(query)}`);
+			goto(resolve(`/search/albums?q=${encodeURIComponent(query)}`));
 		}
 	}
 
@@ -129,7 +130,7 @@
 				</div>
 				<p class="text-base-content/70 text-sm">{section.fallback_message}</p>
 				{#if section.connect_service}
-					<a href="/settings" class="btn btn-primary btn-sm mt-2">
+					<a href={resolve('/settings')} class="btn btn-primary btn-sm mt-2">
 						Connect {section.connect_service === 'listenbrainz'
 							? 'ListenBrainz'
 							: section.connect_service === 'lastfm'

--- a/frontend/src/lib/components/LastFmInfoCard.svelte
+++ b/frontend/src/lib/components/LastFmInfoCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { ChevronUp, ChevronDown, ExternalLink, Users, Headphones } from 'lucide-svelte';
 	import { formatListenCount } from '$lib/utils/formatting';
 	import { onMount } from 'svelte';
@@ -135,7 +136,7 @@
 			<div class="flex flex-wrap gap-2">
 				{#each tags.slice(0, 10) as tag (tag.name)}
 					<a
-						href="/genre?name={encodeURIComponent(tag.name)}"
+						href={resolve(`/genre?name=${encodeURIComponent(tag.name)}`)}
 						class="badge badge-outline badge-sm cursor-pointer hover:badge-primary transition-colors"
 					>
 						{tag.name}

--- a/frontend/src/lib/components/LibraryPage.svelte
+++ b/frontend/src/lib/components/LibraryPage.svelte
@@ -2,6 +2,7 @@
 	lang="ts"
 	generics="TAlbum extends JellyfinAlbumSummary | LocalAlbumSummary | NavidromeAlbumSummary | PlexAlbumSummary"
 >
+	import { resolve } from '$app/paths';
 	import type { Snippet } from 'svelte';
 	import type { LibraryController } from '$lib/utils/libraryController.svelte';
 	import type {
@@ -180,7 +181,7 @@
 			<div class="flex flex-col gap-1">
 				<span>{ctrl.fetchError}</span>
 				{#if ctrl.fetchErrorCode === 'CIRCUIT_BREAKER_OPEN' || /connection|DNS|not configured/i.test(ctrl.fetchError)}
-					<a href="/settings" class="link link-primary text-sm">Open settings</a>
+					<a href={resolve('/settings')} class="link link-primary text-sm">Open settings</a>
 				{/if}
 			</div>
 			<button class="btn btn-sm btn-ghost" onclick={() => ctrl.fetchAlbums(true)}>Retry</button>

--- a/frontend/src/lib/components/Player.svelte
+++ b/frontend/src/lib/components/Player.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { playerStore } from '$lib/stores/player.svelte';
 	import { deckFocus } from '$lib/stores/deckFocus.svelte';
 	import { eqStore } from '$lib/stores/eq.svelte';
@@ -148,16 +149,18 @@
 						<p class="text-sm font-semibold truncate">{playerStore.nowPlaying.trackName}</p>
 						<p class="text-xs opacity-60 truncate">
 							{#if isAlbumLinkable(playerStore.nowPlaying.albumId)}
-								<a href="/album/{playerStore.nowPlaying.albumId}" class="hover:underline"
-									>{playerStore.nowPlaying.albumName}</a
+								<a
+									href={resolve(`/album/${playerStore.nowPlaying.albumId}`)}
+									class="hover:underline">{playerStore.nowPlaying.albumName}</a
 								>
 							{:else}
 								{playerStore.nowPlaying.albumName}
 							{/if}
 							-
 							{#if playerStore.nowPlaying.artistId}
-								<a href="/artist/{playerStore.nowPlaying.artistId}" class="hover:underline"
-									>{playerStore.nowPlaying.artistName}</a
+								<a
+									href={resolve(`/artist/${playerStore.nowPlaying.artistId}`)}
+									class="hover:underline">{playerStore.nowPlaying.artistName}</a
 								>
 							{:else}
 								{playerStore.nowPlaying.artistName}
@@ -166,8 +169,9 @@
 					{:else}
 						<p class="text-sm font-semibold truncate">
 							{#if isAlbumLinkable(playerStore.nowPlaying.albumId)}
-								<a href="/album/{playerStore.nowPlaying.albumId}" class="hover:underline"
-									>{playerStore.nowPlaying.albumName}</a
+								<a
+									href={resolve(`/album/${playerStore.nowPlaying.albumId}`)}
+									class="hover:underline">{playerStore.nowPlaying.albumName}</a
 								>
 							{:else}
 								{playerStore.nowPlaying.albumName}
@@ -175,8 +179,9 @@
 						</p>
 						<p class="text-xs opacity-60 truncate">
 							{#if playerStore.nowPlaying.artistId}
-								<a href="/artist/{playerStore.nowPlaying.artistId}" class="hover:underline"
-									>{playerStore.nowPlaying.artistName}</a
+								<a
+									href={resolve(`/artist/${playerStore.nowPlaying.artistId}`)}
+									class="hover:underline">{playerStore.nowPlaying.artistName}</a
 								>
 							{:else}
 								{playerStore.nowPlaying.artistName}

--- a/frontend/src/lib/components/PlaylistCard.svelte
+++ b/frontend/src/lib/components/PlaylistCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onDestroy } from 'svelte';
 	import type { PlaylistSummary } from '$lib/api/playlists';
 	import { fetchPlaylist, deletePlaylist, isRedactedPlaylist } from '$lib/api/playlists';
@@ -151,7 +152,7 @@
 		: 'oklch(from var(--color-primary) l c h / 0.15)'}
 >
 	<a
-		href="/playlists/{playlist.id}"
+		href={resolve(`/playlists/${playlist.id}`)}
 		class="block relative z-0 transition-transform active:scale-95 focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 rounded-t-box"
 		aria-label="Open {playlist.name}"
 	>

--- a/frontend/src/lib/components/PlaylistImportBanner.svelte
+++ b/frontend/src/lib/components/PlaylistImportBanner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { SourcePlaylistSummary } from '$lib/types';
 	import type { Snippet } from 'svelte';
 	import {
@@ -158,7 +159,7 @@
 						</a>
 					{/if}
 					{#if (!hasError && (accountMode === 'shared' || totalCount === 0)) || relinkRequired}
-						<a class="btn btn-ghost btn-sm gap-2" href="/profile#media-accounts">
+						<a class="btn btn-ghost btn-sm gap-2" href={resolve('/profile#media-accounts')}>
 							<Link2 class="h-4 w-4" />
 							{relinkRequired
 								? `Reconnect ${sourceLabel}`

--- a/frontend/src/lib/components/RequestCard.svelte
+++ b/frontend/src/lib/components/RequestCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { albumHref, artistHref } from '$lib/utils/entityRoutes';
 	import AlbumImage from './AlbumImage.svelte';
 	import DeleteAlbumModal from './DeleteAlbumModal.svelte';
@@ -282,7 +283,7 @@
 
 			{#if !isActive && watchState}
 				<a
-					href="/requests?tab=wanted"
+					href={resolve('/requests?tab=wanted')}
 					class="badge badge-sm badge-outline gap-1 border-info/30 text-info/80 hover:bg-info/10"
 					title={watchState === 'retrying'
 						? 'Auto-retrying - see the Wanted tab'

--- a/frontend/src/lib/components/SidebarServiceHint.svelte
+++ b/frontend/src/lib/components/SidebarServiceHint.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Plus } from 'lucide-svelte';
 	import type { Snippet } from 'svelte';
 
@@ -13,7 +14,7 @@
 
 <li class="opacity-30 hover:opacity-70 transition-opacity duration-200">
 	<a
-		href="/settings?tab={settingsTab}"
+		href={resolve(`/settings?tab=${settingsTab}`)}
 		class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 		data-tip="Connect {label}"
 	>

--- a/frontend/src/lib/components/SidebarServices.svelte
+++ b/frontend/src/lib/components/SidebarServices.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { fromStore } from 'svelte/store';
 	import { Headphones, Disc3 } from 'lucide-svelte';
 	import { integrationStore } from '$lib/stores/integration';
@@ -47,7 +48,7 @@
 	{#if integrations.current.youtube}
 		<li>
 			<a
-				href="/library/youtube"
+				href={resolve('/library/youtube')}
 				class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 				data-tip="YouTube"
 			>
@@ -66,7 +67,7 @@
 	{#if integrations.current.jellyfin}
 		<li>
 			<a
-				href="/library/jellyfin"
+				href={resolve('/library/jellyfin')}
 				class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 				data-tip="Jellyfin"
 			>
@@ -96,7 +97,7 @@
 	{#if integrations.current.navidrome}
 		<li>
 			<a
-				href="/library/navidrome"
+				href={resolve('/library/navidrome')}
 				class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 				data-tip="Navidrome"
 			>
@@ -126,7 +127,7 @@
 	{#if integrations.current.plex}
 		<li>
 			<a
-				href="/library/plex"
+				href={resolve('/library/plex')}
 				class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 				data-tip="Plex"
 			>
@@ -156,7 +157,7 @@
 	{#if integrations.current.localfiles}
 		<li>
 			<a
-				href="/library/local"
+				href={resolve('/library/local')}
 				class="is-drawer-close:tooltip is-drawer-close:tooltip-right"
 				data-tip="Local Files"
 			>

--- a/frontend/src/lib/components/SimilarArtistsCarousel.svelte
+++ b/frontend/src/lib/components/SimilarArtistsCarousel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Check } from 'lucide-svelte';
 	import type { SimilarArtist } from '$lib/types';
 	import HorizontalCarousel from './HorizontalCarousel.svelte';
@@ -24,7 +25,7 @@
 	{:else if !configured}
 		<div class="bg-base-200 rounded-lg p-6 text-center">
 			<p class="text-base-content/70">Connect a music service to see similar artists</p>
-			<a href="/profile#scrobbling" class="btn btn-primary btn-sm mt-3">Configure</a>
+			<a href={resolve('/profile#scrobbling')} class="btn btn-primary btn-sm mt-3">Configure</a>
 		</div>
 	{:else if artists.length === 0}
 		<div class="bg-base-200 rounded-lg p-6 text-center">

--- a/frontend/src/lib/components/SourceAlbumModal.svelte
+++ b/frontend/src/lib/components/SourceAlbumModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Shuffle, Play, X, ListPlus, ListStart, ListMusic, Info, Download } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { API } from '$lib/constants';
@@ -201,10 +202,10 @@
 		if (mbid) {
 			const target = mbid;
 			handleClose();
-			goto(`/album/${target}`);
+			goto(resolve(`/album/${target}`));
 		} else if (albumName) {
 			handleClose();
-			goto(`/search?q=${encodeURIComponent(albumName)}`);
+			goto(resolve(`/search?q=${encodeURIComponent(albumName)}`));
 		}
 	}
 
@@ -212,7 +213,7 @@
 		if (!canNavigateArtist || !artistMbid) return;
 		const target = artistMbid;
 		handleClose();
-		goto(`/artist/${target}`);
+		goto(resolve(`/artist/${target}`));
 	}
 
 	async function launchInstantMix() {

--- a/frontend/src/lib/components/SourcePlaylistDetail.svelte
+++ b/frontend/src/lib/components/SourcePlaylistDetail.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { ApiError } from '$lib/api/client';
 	import BackButton from '$lib/components/BackButton.svelte';
 	import { createSourcePlaylistImportMutation } from '$lib/queries/source-playlists/SourcePlaylistMutations.svelte';
@@ -83,7 +84,7 @@
 						: "Couldn't load this playlist."}
 			</span>
 			{#if relinkRequired}
-				<a class="btn btn-primary btn-sm" href="/profile#media-accounts">Reconnect</a>
+				<a class="btn btn-primary btn-sm" href={resolve('/profile#media-accounts')}>Reconnect</a>
 			{:else if notFound}
 				<a class="btn btn-primary btn-sm" href={backFallback}>Back to playlists</a>
 			{:else}
@@ -136,7 +137,7 @@
 				{#if importRelinkRequired}
 					<p class="text-sm text-error">
 						Reconnect the linked account to continue.
-						<a class="link font-medium" href="/profile#media-accounts">Reconnect</a>
+						<a class="link font-medium" href={resolve('/profile#media-accounts')}>Reconnect</a>
 					</p>
 				{/if}
 			</div>

--- a/frontend/src/lib/components/SourcePlaylistList.svelte
+++ b/frontend/src/lib/components/SourcePlaylistList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
+	import { resolve } from '$app/paths';
 	import { ApiError } from '$lib/api/client';
 	import BackButton from '$lib/components/BackButton.svelte';
 	import SourcePlaylistCard from '$lib/components/SourcePlaylistCard.svelte';
@@ -11,7 +12,10 @@
 		source: SourcePlaylistSource;
 		sourceLabel: string;
 		backFallback: string;
-		playlistBaseHref: string;
+		playlistBaseHref:
+			| '/library/jellyfin/playlists'
+			| '/library/navidrome/playlists'
+			| '/library/plex/playlists';
 		icon: Snippet;
 	}
 
@@ -64,7 +68,7 @@
 			</p>
 			<div class="mt-4 flex flex-wrap justify-center gap-2">
 				{#if relinkRequired}
-					<a class="btn btn-primary btn-sm gap-2" href="/profile#media-accounts">
+					<a class="btn btn-primary btn-sm gap-2" href={resolve('/profile#media-accounts')}>
 						<Link2 class="h-4 w-4" />
 						Reconnect account
 					</a>
@@ -86,7 +90,7 @@
 			</p>
 			<div class="mt-4 flex flex-wrap justify-center gap-2">
 				{#if collection}
-					<a class="btn btn-primary btn-sm gap-2" href="/profile#media-accounts">
+					<a class="btn btn-primary btn-sm gap-2" href={resolve('/profile#media-accounts')}>
 						<Link2 class="h-4 w-4" />
 						{collection.account_mode === 'shared' ? 'Link your account' : 'Manage account'}
 					</a>
@@ -100,7 +104,7 @@
 	{:else}
 		<div class="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
 			{#each playlists as playlist (playlist.id)}
-				<SourcePlaylistCard {playlist} href="{playlistBaseHref}/{playlist.id}" />
+				<SourcePlaylistCard {playlist} href={resolve(`${playlistBaseHref}/${playlist.id}`)} />
 			{/each}
 		</div>
 	{/if}

--- a/frontend/src/lib/components/TimeRangeView.svelte
+++ b/frontend/src/lib/components/TimeRangeView.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { run } from 'svelte/legacy';
 
 	import { onDestroy, onMount } from 'svelte';
@@ -268,7 +269,11 @@
 
 <div class="container mx-auto p-4 md:p-6 lg:p-8">
 	<div class="mb-6 flex items-center gap-4">
-		<button class="btn btn-circle btn-ghost" onclick={() => goto('/')} aria-label="Back to home">
+		<button
+			class="btn btn-circle btn-ghost"
+			onclick={() => goto(resolve('/'))}
+			aria-label="Back to home"
+		>
 			<ChevronLeft class="h-6 w-6" />
 		</button>
 		<div>

--- a/frontend/src/lib/components/TopAlbumsList.svelte
+++ b/frontend/src/lib/components/TopAlbumsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { albumHref } from '$lib/utils/entityRoutes';
 	import { onMount } from 'svelte';
 	import { Disc3, Download } from 'lucide-svelte';
@@ -89,7 +90,7 @@
 		<div class="bg-base-200 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
 			<div>
 				<p class="text-base-content/70 text-sm">Connect a music service to see popular albums</p>
-				<a href="/profile#scrobbling" class="btn btn-primary btn-xs mt-2">Configure</a>
+				<a href={resolve('/profile#scrobbling')} class="btn btn-primary btn-xs mt-2">Configure</a>
 			</div>
 		</div>
 	{:else if albums.length === 0}

--- a/frontend/src/lib/components/TopSongsList.svelte
+++ b/frontend/src/lib/components/TopSongsList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { TopSong, ResolvedTrack } from '$lib/types';
 	import type { QueueItem, SourceType } from '$lib/player/types';
 	import { API } from '$lib/constants';
@@ -135,7 +136,7 @@
 		<div class="bg-base-200 rounded-lg p-4 text-center flex-1 flex items-center justify-center">
 			<div>
 				<p class="text-base-content/70 text-sm">Connect a music service to see popular songs</p>
-				<a href="/profile#scrobbling" class="btn btn-primary btn-xs mt-2">Configure</a>
+				<a href={resolve('/profile#scrobbling')} class="btn btn-primary btn-xs mt-2">Configure</a>
 			</div>
 		</div>
 	{:else if songs.length === 0}

--- a/frontend/src/lib/components/UpdateBanner.svelte
+++ b/frontend/src/lib/components/UpdateBanner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { serviceStatusStore } from '$lib/stores/serviceStatus';
 	import { fromStore } from 'svelte/store';
 	import { PersistedState } from 'runed';
@@ -45,7 +46,7 @@
 					<span class="font-semibold">({latestVersion})</span>
 				{/if}
 			</span>
-			<a href="/settings?tab=about" class="btn btn-accent btn-xs btn-outline">Details</a>
+			<a href={resolve('/settings?tab=about')} class="btn btn-accent btn-xs btn-outline">Details</a>
 			<button
 				class="btn btn-ghost btn-sm btn-circle"
 				onclick={dismiss}

--- a/frontend/src/lib/components/ViewMoreAlbumCard.svelte
+++ b/frontend/src/lib/components/ViewMoreAlbumCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { colors } from '$lib/colors';
@@ -13,7 +14,7 @@
 	function handleClick() {
 		const query = page.url.searchParams.get('q') || '';
 		if (query) {
-			goto(`/search/albums?q=${encodeURIComponent(query)}`);
+			goto(resolve(`/search/albums?q=${encodeURIComponent(query)}`));
 		}
 	}
 </script>

--- a/frontend/src/lib/components/ViewMoreAlbumCard.svelte
+++ b/frontend/src/lib/components/ViewMoreAlbumCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import { base, resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { colors } from '$lib/colors';
@@ -29,7 +29,7 @@
 		<div class="absolute inset-0 overflow-hidden">
 			<img
 				data-testid="view-more-album-background"
-				src="/img/album_bg-250.webp"
+				src="{base}/img/album_bg-250.webp"
 				srcset="/img/album_bg-250.webp 250w, /img/album_bg-500.webp 500w"
 				sizes="200px"
 				width="500"

--- a/frontend/src/lib/components/ViewMoreArtistCard.svelte
+++ b/frontend/src/lib/components/ViewMoreArtistCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { colors } from '$lib/colors';
@@ -13,7 +14,7 @@
 	function handleClick() {
 		const query = page.url.searchParams.get('q') || '';
 		if (query) {
-			goto(`/search/artists?q=${encodeURIComponent(query)}`);
+			goto(resolve(`/search/artists?q=${encodeURIComponent(query)}`));
 		}
 	}
 </script>

--- a/frontend/src/lib/components/ViewMoreArtistCard.svelte
+++ b/frontend/src/lib/components/ViewMoreArtistCard.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
+	import { base, resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { colors } from '$lib/colors';
@@ -29,7 +29,7 @@
 		<div class="absolute inset-0 overflow-hidden">
 			<img
 				data-testid="view-more-artist-background"
-				src="/img/artist_bg-250.webp"
+				src="{base}/img/artist_bg-250.webp"
 				srcset="/img/artist_bg-250.webp 250w, /img/artist_bg-500.webp 500w"
 				sizes="200px"
 				width="500"

--- a/frontend/src/lib/components/WantedRetryingCard.svelte
+++ b/frontend/src/lib/components/WantedRetryingCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import AlbumImage from './AlbumImage.svelte';
 	import { RotateCcw } from 'lucide-svelte';
@@ -41,7 +42,7 @@
 
 	<div class="flex-1 min-w-0">
 		<a
-			href="/album/{item.release_group_mbid}"
+			href={resolve(`/album/${item.release_group_mbid}`)}
 			class="block font-semibold text-sm truncate hover:text-accent hover:underline"
 			title={item.album_title}
 		>
@@ -67,6 +68,8 @@
 	</div>
 
 	<div class="shrink-0">
-		<a href="/downloads" class="btn btn-ghost btn-sm text-base-content/50">Manage in Downloads</a>
+		<a href={resolve('/downloads')} class="btn btn-ghost btn-sm text-base-content/50"
+			>Manage in Downloads</a
+		>
 	</div>
 </div>

--- a/frontend/src/lib/components/WantedWatchCard.svelte
+++ b/frontend/src/lib/components/WantedWatchCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import AlbumImage from './AlbumImage.svelte';
 	import {
@@ -54,7 +55,7 @@
 
 	<div class="flex-1 min-w-0">
 		<a
-			href="/album/{item.release_group_mbid}"
+			href={resolve(`/album/${item.release_group_mbid}`)}
 			class="block font-semibold text-sm truncate hover:text-accent hover:underline"
 			title={item.album_title}
 		>
@@ -109,7 +110,7 @@
 
 		{#if item.new_candidate_count > 0}
 			<a
-				href="/album/{item.release_group_mbid}"
+				href={resolve(`/album/${item.release_group_mbid}`)}
 				class="inline-flex items-center gap-1 mt-1.5 px-2 py-0.5 rounded-full bg-accent/15 text-accent text-xs font-medium hover:bg-accent/25"
 				onclick={() => onseen?.(item)}
 			>

--- a/frontend/src/lib/components/WhatsNewModal.svelte
+++ b/frontend/src/lib/components/WhatsNewModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { isWhatsNewDismissed, dismissWhatsNew } from '$lib/stores/version.svelte';
 	import { renderMarkdown } from '$lib/utils/markdown';
@@ -78,7 +79,7 @@
 
 	function handleViewChangelog() {
 		handleDismiss();
-		goto('/settings?tab=about');
+		goto(resolve('/settings?tab=about'));
 	}
 </script>
 

--- a/frontend/src/lib/components/YouTubeDetailModal.svelte
+++ b/frontend/src/lib/components/YouTubeDetailModal.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		Shuffle,
 		Pencil,
@@ -125,13 +126,13 @@
 		if (!canNavigate || !link) return;
 		const albumId = link.album_id;
 		handleClose();
-		goto(`/album/${albumId}`);
+		goto(resolve(`/album/${albumId}`));
 	}
 
 	function searchArtist(): void {
 		if (!link) return;
 		handleClose();
-		goto(`/search?q=${encodeURIComponent(link.artist_name)}`);
+		goto(resolve(`/search?q=${encodeURIComponent(link.artist_name)}`));
 	}
 
 	async function playFullAlbum(): Promise<void> {

--- a/frontend/src/lib/components/discover/DiscoverTeaserBand.svelte
+++ b/frontend/src/lib/components/discover/DiscoverTeaserBand.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { Compass, Sparkles } from 'lucide-svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
@@ -32,7 +33,7 @@
 </script>
 
 <a
-	href="/discover"
+	href={resolve('/discover')}
 	class="group relative block overflow-hidden rounded-2xl border border-primary/15 bg-gradient-to-r from-primary/10 via-base-200/60 to-secondary/10 shadow-[0_4px_24px_oklch(from_var(--color-primary)_l_c_h_/_0.08)] transition-all duration-300 motion-safe:hover:-translate-y-0.5 hover:border-primary/30 hover:shadow-[0_8px_32px_oklch(from_var(--color-primary)_l_c_h_/_0.15)]"
 >
 	<div class="flex flex-col items-center gap-4 px-5 py-6 sm:flex-row sm:gap-6 sm:px-7">

--- a/frontend/src/lib/components/downloads/AlbumDownloadStatus.svelte
+++ b/frontend/src/lib/components/downloads/AlbumDownloadStatus.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { FolderLock, RotateCcw, TimerOff, X } from 'lucide-svelte';
 
 	import {
@@ -130,7 +131,7 @@
 
 	<div class="flex shrink-0 items-center gap-1.5">
 		{#if isReview}
-			<a href="/downloads" class="btn btn-primary btn-xs">
+			<a href={resolve('/downloads')} class="btn btn-primary btn-xs">
 				{isManagementHold ? 'Review organizer' : 'Review'}
 			</a>
 		{/if}

--- a/frontend/src/lib/components/downloads/ManagementHoldCard.svelte
+++ b/frontend/src/lib/components/downloads/ManagementHoldCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		ArchiveRestore,
 		ChevronDown,
@@ -241,7 +242,7 @@
 							/>
 							{retry.isPending ? 'Retrying organizer…' : 'Retry organizer'}
 						</button>
-						<a href="/library/management?tab=automation" class="btn btn-ghost btn-sm">
+						<a href={resolve('/library/management?tab=automation')} class="btn btn-ghost btn-sm">
 							<Settings2 class="size-4" aria-hidden="true" /> Review automation
 						</a>
 						<button

--- a/frontend/src/lib/components/downloads/RequestButton.svelte
+++ b/frontend/src/lib/components/downloads/RequestButton.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { requestAlbum } from '$lib/queries/downloads/DownloadMutations.svelte';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { integrationStore } from '$lib/stores/integration';
@@ -52,7 +53,7 @@
 	<button class="btn btn-info {klass}" disabled>Requested</button>
 {:else if !configured}
 	{#if isAdmin}
-		<a href="/settings?tab=download-client" class="btn btn-warning {klass}"
+		<a href={resolve('/settings?tab=download-client')} class="btn btn-warning {klass}"
 			>Configure Download Client</a
 		>
 	{:else}

--- a/frontend/src/lib/components/library/ArtistIdentityDesk.svelte
+++ b/frontend/src/lib/components/library/ArtistIdentityDesk.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import {
@@ -147,6 +148,12 @@
 		return value.length > 18 ? `${value.slice(0, 8)}…${value.slice(-6)}` : value;
 	}
 
+	function identityDeskHref(params: SvelteURLSearchParams): string {
+		return params.size
+			? resolve(`/library/management/artists?${params.toString()}`)
+			: resolve('/library/management/artists');
+	}
+
 	function updateUrl(options: { clearGroup?: boolean; useDraftFilters?: boolean } = {}): void {
 		const params = new SvelteURLSearchParams();
 		const nextFilterState = options.useDraftFilters ? filterState : appliedFilterState;
@@ -154,7 +161,7 @@
 		if (nextFilterState) params.set('state', nextFilterState);
 		if (nextSearch) params.set('q', nextSearch);
 		if (!options.clearGroup && selectedGroupId) params.set('group', selectedGroupId);
-		void goto(`/library/management/artists${params.size ? `?${params.toString()}` : ''}`, {
+		void goto(identityDeskHref(params), {
 			noScroll: true,
 			keepFocus: true,
 			replaceState: true
@@ -266,7 +273,7 @@
 				artists.
 			</p>
 		</div>
-		<a href="/library/management?tab=scanning" class="btn btn-ghost btn-sm">
+		<a href={resolve('/library/management?tab=scanning')} class="btn btn-ghost btn-sm">
 			Back to Scan &amp; identify
 		</a>
 	</header>

--- a/frontend/src/lib/components/library/ArtistMergeDialog.svelte
+++ b/frontend/src/lib/components/library/ArtistMergeDialog.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Fingerprint } from 'lucide-svelte';
 
 	import type { LibraryArtistSummary } from '$lib/types';
@@ -9,7 +10,9 @@
 
 	let { artist }: Props = $props();
 	const identityDeskUrl = $derived(
-		`/library/management/artists?artist=${encodeURIComponent(artist.id)}&q=${encodeURIComponent(artist.name)}`
+		resolve(
+			`/library/management/artists?artist=${encodeURIComponent(artist.id)}&q=${encodeURIComponent(artist.name)}`
+		)
 	);
 </script>
 

--- a/frontend/src/lib/components/library/LibraryHubTiles.svelte
+++ b/frontend/src/lib/components/library/LibraryHubTiles.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Disc3, Users, Music2, ArrowUpRight } from 'lucide-svelte';
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
@@ -180,7 +181,7 @@
      context so they can't paint over the library search dropdown above them -->
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 isolate">
 	<a
-		href="/library/albums"
+		href={resolve('/library/albums')}
 		class="group relative flex min-h-[27rem] flex-col overflow-hidden rounded-3xl border border-base-content/10 bg-gradient-to-br from-primary/20 via-primary/5 to-base-200/40 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-primary/40 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 focus-visible:outline-none"
 		aria-label="Browse all albums"
 	>
@@ -214,7 +215,7 @@
 	</a>
 
 	<a
-		href="/library/artists"
+		href={resolve('/library/artists')}
 		class="group relative flex min-h-[27rem] flex-col overflow-hidden rounded-3xl border border-base-content/10 bg-gradient-to-br from-accent/20 via-accent/5 to-base-200/40 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-accent/40 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 focus-visible:outline-none"
 		aria-label="Browse all artists"
 	>
@@ -248,7 +249,7 @@
 	</a>
 
 	<a
-		href="/library/tracks"
+		href={resolve('/library/tracks')}
 		class="group relative col-span-1 flex items-center gap-4 overflow-hidden rounded-3xl border border-base-content/10 bg-gradient-to-r from-info/15 via-info/5 to-base-200/40 px-6 py-5 shadow-lg transition-all duration-300 hover:-translate-y-1 hover:border-info/40 hover:shadow-2xl focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 focus-visible:outline-none sm:col-span-2 sm:gap-8 sm:px-8"
 		aria-label="Browse all tracks"
 	>

--- a/frontend/src/lib/components/library/LibraryManagementControlRoom.svelte
+++ b/frontend/src/lib/components/library/LibraryManagementControlRoom.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { replaceState } from '$app/navigation';
 	import { page } from '$app/state';
 	import { onMount } from 'svelte';
@@ -161,7 +162,7 @@
 					onclick={(event) => openRunner('baseline_restore', event.currentTarget)}
 					><RotateCcw class="h-4 w-4" /> Restore original state...</button
 				>
-				<a href="/library/management?tab=automation" class="btn btn-ghost btn-sm"
+				<a href={resolve('/library/management?tab=automation')} class="btn btn-ghost btn-sm"
 					><Settings2 class="h-4 w-4" /> Automation</a
 				>
 			</div>
@@ -299,7 +300,7 @@
 						<p class="management-step">Audit trail</p>
 						<h3 id="recent-management-work" class="font-semibold">Recent management work</h3>
 					</div>
-					<a class="link text-xs" href="/library/management/history">All history</a>
+					<a class="link text-xs" href={resolve('/library/management/history')}>All history</a>
 				</div>
 				{#if recent.length}{#each recent as item (item.operation.id)}<a
 							href={operationHref(

--- a/frontend/src/lib/components/library/LibraryManagementOperationPage.svelte
+++ b/frontend/src/lib/components/library/LibraryManagementOperationPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import {
@@ -85,7 +86,7 @@
 	$effect(() => {
 		if (!redirectingReadyPreview && operation?.mode === 'preview' && operation.state === 'ready') {
 			redirectingReadyPreview = true;
-			void goto(`/library/management/previews/${encodeURIComponent(jobId)}`, {
+			void goto(resolve(`/library/management/previews/${encodeURIComponent(jobId)}`), {
 				replaceState: true
 			});
 		}
@@ -238,7 +239,7 @@
 			});
 			rememberLibraryManagementPreviewToken(handle.job_id, handle.preview_token);
 			undoDialog.close();
-			await goto(`/library/management/previews/${encodeURIComponent(handle.job_id)}`);
+			await goto(resolve(`/library/management/previews/${encodeURIComponent(handle.job_id)}`));
 		} catch (error) {
 			undoError = error instanceof Error ? error.message : 'Could not create the undo preview.';
 		}
@@ -478,7 +479,7 @@
 						<p class="management-step">Audit trail</p>
 						<h2 class="font-display text-xl font-semibold">Per-file results</h2>
 					</div>
-					<a href="/library/management/history" class="btn btn-ghost btn-sm"
+					<a href={resolve('/library/management/history')} class="btn btn-ghost btn-sm"
 						><History class="h-4 w-4" /> All history</a
 					>
 				</div>
@@ -540,8 +541,9 @@
 					{#if operation.baseline_available_count > 0}<p class="mt-2 text-xs text-base-content/55">
 							{baselineStatus}
 						</p>{/if}
-					<a href="/library/management?runner=baseline_restore" class="btn btn-ghost btn-sm mt-3"
-						>Open baseline restore...</a
+					<a
+						href={resolve('/library/management?runner=baseline_restore')}
+						class="btn btn-ghost btn-sm mt-3">Open baseline restore...</a
 					>
 				</div>
 			</section>

--- a/frontend/src/lib/components/library/LibraryManagementPreviewPage.svelte
+++ b/frontend/src/lib/components/library/LibraryManagementPreviewPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import {
@@ -376,7 +377,7 @@
 			});
 			forgetLibraryManagementPreviewToken(jobId);
 			applyDialog.close();
-			await goto(`/library/management/operations/${encodeURIComponent(operation.id)}`);
+			await goto(resolve(`/library/management/operations/${encodeURIComponent(operation.id)}`));
 		} catch (error) {
 			applyError = error instanceof Error ? error.message : 'Could not apply this preview.';
 		}
@@ -431,7 +432,7 @@
 			});
 			rememberLibraryManagementPreviewToken(handle.job_id, handle.preview_token);
 			collisionDialog.close();
-			await goto(`/library/management/previews/${encodeURIComponent(handle.job_id)}`);
+			await goto(resolve(`/library/management/previews/${encodeURIComponent(handle.job_id)}`));
 		} catch (error) {
 			collisionError =
 				error instanceof Error ? error.message : 'Could not create a resolution preview.';
@@ -582,7 +583,9 @@
 							Selecting a root chooses files; it does not choose each release's exact MusicBrainz
 							edition. Prepare identities first, then generate a fresh management preview.
 						</p>
-						<a class="btn btn-outline btn-sm mt-3" href="/library/management?tab=organize"
+						<a
+							class="btn btn-outline btn-sm mt-3"
+							href={resolve('/library/management?tab=organize')}
 							>Open identity readiness <ArrowRight class="h-4 w-4" /></a
 						>
 					</div>
@@ -797,9 +800,11 @@
 								{jobId}
 								expectedRevision={preview.operation_row_revision}
 								profileName={preview.profile_name}
-								ondiscard={() => goto('/library/management?tab=organize')}
+								ondiscard={() => goto(resolve('/library/management?tab=organize'))}
 							/>
-							<a href="/settings?tab=library" class="btn btn-ghost btn-sm">Library settings</a>
+							<a href={resolve('/settings?tab=library')} class="btn btn-ghost btn-sm"
+								>Library settings</a
+							>
 						</div>
 					</div>{:else}<div
 						bind:this={stickyFooterElement}
@@ -824,7 +829,7 @@
 								{jobId}
 								expectedRevision={preview.operation_row_revision}
 								profileName={preview.profile_name}
-								ondiscard={() => goto('/library/management?tab=organize')}
+								ondiscard={() => goto(resolve('/library/management?tab=organize'))}
 							/>
 							<button
 								class="btn management-btn"

--- a/frontend/src/lib/components/library/LibraryManagementRunner.svelte
+++ b/frontend/src/lib/components/library/LibraryManagementRunner.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 	import {
@@ -295,7 +296,7 @@
 						});
 			rememberLibraryManagementPreviewToken(handle.job_id, handle.preview_token);
 			dialog.close();
-			await goto(`/library/management/previews/${encodeURIComponent(handle.job_id)}`);
+			await goto(resolve(`/library/management/previews/${encodeURIComponent(handle.job_id)}`));
 		} catch (error) {
 			localError = error instanceof Error ? error.message : 'Could not create the preview.';
 		}

--- a/frontend/src/lib/components/library/LibraryOverviewPanel.svelte
+++ b/frontend/src/lib/components/library/LibraryOverviewPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		AlertTriangle,
 		ArrowRight,
@@ -320,7 +321,7 @@
 
 	<div class="stagger-fade-in grid grid-cols-2 gap-3 lg:grid-cols-4">
 		<a
-			href="/library/tracks"
+			href={resolve('/library/tracks')}
 			class="rounded-2xl border border-base-content/10 bg-base-200/40 p-4 transition-colors hover:border-base-content/20 hover:bg-base-200/60"
 		>
 			<span class="flex h-9 w-9 items-center justify-center rounded-xl bg-primary/10 text-primary"
@@ -335,7 +336,7 @@
 			>
 		</a>
 		<a
-			href="/library/management?tab=scanning#recent-runs"
+			href={resolve('/library/management?tab=scanning#recent-runs')}
 			class="rounded-2xl border border-base-content/10 bg-base-200/40 p-4 transition-colors hover:border-base-content/20 hover:bg-base-200/60"
 		>
 			<span
@@ -353,7 +354,7 @@
 			>
 		</a>
 		<a
-			href="/library/review"
+			href={resolve('/library/review')}
 			class="rounded-2xl border border-base-content/10 bg-base-200/40 p-4 transition-colors hover:border-base-content/20 hover:bg-base-200/60"
 		>
 			<span class="flex h-9 w-9 items-center justify-center rounded-xl bg-accent/10 text-accent"
@@ -372,7 +373,7 @@
 		</a>
 		{#if attentionCount > 0}
 			<a
-				href="/library/management?tab=organize"
+				href={resolve('/library/management?tab=organize')}
 				class="rounded-2xl border border-warning/30 bg-base-200/40 p-4 transition-colors hover:border-warning/50 hover:bg-base-200/60"
 			>
 				<span class="flex h-9 w-9 items-center justify-center rounded-xl bg-warning/15 text-warning"
@@ -388,7 +389,7 @@
 			</a>
 		{:else}
 			<a
-				href="/library/management?tab=organize"
+				href={resolve('/library/management?tab=organize')}
 				class="rounded-2xl border border-base-content/10 bg-base-200/40 p-4 transition-colors hover:border-base-content/20 hover:bg-base-200/60"
 			>
 				<span class="flex h-9 w-9 items-center justify-center rounded-xl bg-warning/10 text-warning"
@@ -429,8 +430,9 @@
 				</button>
 				<div class="flex items-center justify-between gap-2 text-xs text-base-content/55">
 					<span>{scheduleText}</span>
-					<a class="link-hover font-semibold text-primary" href="/library/management?tab=scanning"
-						>More scan actions →</a
+					<a
+						class="link-hover font-semibold text-primary"
+						href={resolve('/library/management?tab=scanning')}>More scan actions →</a
 					>
 				</div>
 			</div>
@@ -448,12 +450,15 @@
 				Preview exactly what would change to tags, names, and paths before anything is written.
 			</p>
 			<div class="mt-auto flex flex-col gap-2">
-				<a class="btn management-btn" href="/library/management?tab=organize&runner=manage"
+				<a
+					class="btn management-btn"
+					href={resolve('/library/management?tab=organize&runner=manage')}
 					><Sparkles class="h-4 w-4" /> Preview organization...</a
 				>
 				<div class="flex items-center justify-end gap-2 text-xs text-base-content/55">
-					<a class="link-hover font-semibold text-warning" href="/library/management?tab=automation"
-						>Automation & profiles →</a
+					<a
+						class="link-hover font-semibold text-warning"
+						href={resolve('/library/management?tab=automation')}>Automation & profiles →</a
 					>
 				</div>
 			</div>
@@ -474,7 +479,9 @@
 					>{/if}
 			</p>
 			<div class="mt-auto flex flex-col gap-2">
-				<a class="btn btn-outline" href="/library/management?tab=organize#identity-readiness"
+				<a
+					class="btn btn-outline"
+					href={resolve('/library/management?tab=organize#identity-readiness')}
 					>Open identity readiness</a
 				>
 			</div>

--- a/frontend/src/lib/components/library/LibraryOverviewPanel.svelte
+++ b/frontend/src/lib/components/library/LibraryOverviewPanel.svelte
@@ -201,7 +201,8 @@
 				<p class="text-sm">
 					Scanning and file organization are paused. Existing catalog data and playback keep
 					working. Enable the library in
-					<a class="link link-primary" href="/settings?tab=library">Settings</a> to start new work.
+					<a class="link link-primary" href={resolve('/settings?tab=library')}>Settings</a> to start new
+					work.
 				</p>
 			</div>
 		</div>

--- a/frontend/src/lib/components/library/LibraryRepairPanel.svelte
+++ b/frontend/src/lib/components/library/LibraryRepairPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { CirclePause, CirclePlay, OctagonX, ShieldCheck, Wrench } from 'lucide-svelte';
 	import {
 		getLibraryRepairEstimateQuery,
@@ -211,8 +212,9 @@
 					{#if repair.state === 'succeeded' && repair.repair_summary?.estimated_apply_changes}
 						<a
 							class="text-sm link link-primary sm:col-span-2 sm:justify-self-end"
-							href="/library/review?state=needs_review&reason=LEGACY_IDENTITY_FAILED_SAFETY_RULES"
-							>Review detached albums</a
+							href={resolve(
+								'/library/review?state=needs_review&reason=LEGACY_IDENTITY_FAILED_SAFETY_RULES'
+							)}>Review detached albums</a
 						>
 					{/if}
 				</div>

--- a/frontend/src/lib/components/library/LibraryReviewBrowser.svelte
+++ b/frontend/src/lib/components/library/LibraryReviewBrowser.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { page } from '$app/state';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
@@ -43,6 +44,12 @@
 		)
 	);
 
+	function reviewHref(params: SvelteURLSearchParams): string {
+		return params.size
+			? resolve(`/library/review?${params.toString()}`)
+			: resolve('/library/review');
+	}
+
 	function updateUrl(next: Filters): void {
 		const params = new SvelteURLSearchParams();
 		if (next.cursor) params.set('cursor', next.cursor);
@@ -52,7 +59,7 @@
 		if (next.policy) params.set('policy', next.policy);
 		if (next.search) params.set('q', next.search);
 		if (next.sort && next.sort !== 'newest') params.set('sort', next.sort);
-		void goto(`/library/review${params.size ? `?${params.toString()}` : ''}`, {
+		void goto(reviewHref(params), {
 			noScroll: true,
 			keepFocus: true
 		});
@@ -63,13 +70,13 @@
 	function openReview(id: string): void {
 		const params = new SvelteURLSearchParams(page.url.searchParams);
 		params.set('review', id);
-		void goto(`/library/review?${params.toString()}`, { noScroll: true, keepFocus: true });
+		void goto(reviewHref(params), { noScroll: true, keepFocus: true });
 	}
 
 	function closeReview(): void {
 		const params = new SvelteURLSearchParams(page.url.searchParams);
 		params.delete('review');
-		void goto(`/library/review${params.size ? `?${params.toString()}` : ''}`, {
+		void goto(reviewHref(params), {
 			noScroll: true,
 			keepFocus: true,
 			replaceState: true

--- a/frontend/src/lib/components/library/LibraryScanningPanel.svelte
+++ b/frontend/src/lib/components/library/LibraryScanningPanel.svelte
@@ -176,7 +176,8 @@
 					<p class="text-sm">
 						Scanning and identification are paused. Existing catalog data and playback keep working.
 						Enable the library in
-						<a class="link link-primary" href="/settings?tab=library">Settings</a> to start new work.
+						<a class="link link-primary" href={resolve('/settings?tab=library')}>Settings</a> to start
+						new work.
 					</p>
 				</div>
 			</div>

--- a/frontend/src/lib/components/library/LibraryScanningPanel.svelte
+++ b/frontend/src/lib/components/library/LibraryScanningPanel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		CirclePause,
 		CirclePlay,
@@ -162,7 +163,7 @@
 							''}{:else if scheduleQuery.data?.scan_frequency === 'manual'}Automatic scanning off{:else}Schedule:
 						{scheduleQuery.data?.scan_frequency?.replace('_', ' ') ?? 'loading'}{/if}
 				</p>
-				<a href="/settings?tab=library" class="btn btn-ghost btn-sm">
+				<a href={resolve('/settings?tab=library')} class="btn btn-ghost btn-sm">
 					<Settings2 class="h-4 w-4" /> Settings
 				</a>
 			</div>
@@ -473,7 +474,7 @@
 					<div class="flex flex-wrap items-center justify-between gap-2 text-sm">
 						<span class="text-base-content/55"
 							>Provider work runs in the background without delaying local playback.</span
-						><a class="link link-primary" href="/library/review?state=needs_review"
+						><a class="link link-primary" href={resolve('/library/review?state=needs_review')}
 							>Review identification</a
 						>
 					</div>
@@ -481,7 +482,7 @@
 			</article>
 
 			<a
-				href="/library/management/artists"
+				href={resolve('/library/management/artists')}
 				class="flex flex-wrap items-center gap-4 rounded-box border border-base-content/15 bg-base-200/40 p-4 hover:bg-base-200"
 			>
 				<div

--- a/frontend/src/lib/components/library/LocalFilesBand.svelte
+++ b/frontend/src/lib/components/library/LocalFilesBand.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Headphones, Play, Shuffle, Sparkles, ArrowRight } from 'lucide-svelte';
 	import { getLocalStatsQuery, getLocalRecentQuery } from '$lib/queries/local/LocalQueries.svelte';
 	import { createLibraryTrackLoader } from '$lib/utils/libraryTrackLoader.svelte';
@@ -130,7 +131,7 @@
 
 	<!-- stretched link under the content so empty area navigates, while playback buttons (pointer-events re-enabled) still act in place; avoids nested interactives -->
 	<a
-		href="/library/local"
+		href={resolve('/library/local')}
 		aria-label="Enter the Listening Room"
 		class="absolute inset-0 z-10 rounded-3xl focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-base-100 focus-visible:outline-none"
 		style="--tw-ring-color: rgb(var(--brand-localfiles));"

--- a/frontend/src/lib/components/library/TagEditor.svelte
+++ b/frontend/src/lib/components/library/TagEditor.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { Check, ChevronDown, ListPlus, RotateCcw, ShieldAlert, Tags, X } from 'lucide-svelte';
 
@@ -173,7 +174,7 @@
 			});
 			rememberLibraryManagementPreviewToken(result.job_id, result.preview_token);
 			open = false;
-			await goto(`/library/management/previews/${encodeURIComponent(result.job_id)}`);
+			await goto(resolve(`/library/management/previews/${encodeURIComponent(result.job_id)}`));
 		} catch (error) {
 			localError = error instanceof Error ? error.message : 'Could not create the tag preview.';
 		}

--- a/frontend/src/lib/components/profile/ProfileConnectApps.svelte
+++ b/frontend/src/lib/components/profile/ProfileConnectApps.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { base, resolve } from '$app/paths';
 	import { Copy, Plus, Trash2, TriangleAlert, Waypoints } from 'lucide-svelte';
 
 	import { authStore } from '$lib/stores/authStore.svelte';
@@ -39,8 +40,8 @@
 
 	const isAdmin = $derived(authStore.isAdmin);
 	const origin = $derived(typeof window !== 'undefined' ? window.location.origin : '');
-	const subsonicUrl = $derived(`${origin}/subsonic`);
-	const jellyfinUrl = $derived(`${origin}/jellyfin`);
+	const subsonicUrl = $derived(`${origin}${base}/subsonic`);
+	const jellyfinUrl = $derived(`${origin}${base}/jellyfin`);
 	const username = $derived(authStore.user?.username ?? '');
 
 	const subsonicOn = $derived(settingsQuery.data?.subsonic_enabled ?? false);
@@ -160,7 +161,8 @@
 					{#if isAdmin}
 						<p>
 							Streaming isn't turned on yet. You can still create an app-password below, then
-							<a href="/settings?tab=connect-apps" class="link link-accent">enable it in Settings</a
+							<a href={resolve('/settings?tab=connect-apps')} class="link link-accent"
+								>enable it in Settings</a
 							>.
 						</p>
 					{:else}

--- a/frontend/src/lib/components/profile/SpotifyConnectionCard.svelte
+++ b/frontend/src/lib/components/profile/SpotifyConnectionCard.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Loader2 } from 'lucide-svelte';
 	import SpotifyIcon from '$lib/components/SpotifyIcon.svelte';
 	import { getConnectionsQuery } from '$lib/queries/connections/ConnectionsQuery.svelte';
@@ -98,8 +99,8 @@
 
 		{#if spotify}
 			<p class="px-1 text-xs text-base-content/50">
-				Connected. Go to your <a href="/playlists" class="link link-primary">Playlists</a> to import from
-				Spotify.
+				Connected. Go to your <a href={resolve('/playlists')} class="link link-primary">Playlists</a
+				> to import from Spotify.
 			</p>
 		{:else}
 			<p class="px-1 text-xs text-base-content/40">

--- a/frontend/src/lib/components/settings/SectionPrefsManager.svelte
+++ b/frontend/src/lib/components/settings/SectionPrefsManager.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onDestroy } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { Check, ExternalLink } from 'lucide-svelte';
@@ -175,7 +176,7 @@
 									</div>
 									{#if !section.available && section.requires}
 										<a
-											href="/settings?tab=connect-apps"
+											href={resolve('/settings?tab=connect-apps')}
 											class="link flex shrink-0 items-center gap-1 text-xs text-primary/80"
 										>
 											Connect {section.requires === 'listenbrainz'

--- a/frontend/src/lib/components/settings/SettingsConnectApps.svelte
+++ b/frontend/src/lib/components/settings/SettingsConnectApps.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Trash2, TriangleAlert, Users, Waypoints } from 'lucide-svelte';
 
 	import { toastStore } from '$lib/stores/toast';
@@ -105,7 +106,8 @@
 		</p>
 		<p class="mt-1 max-w-2xl text-sm text-base-content/50">
 			These are server-wide switches. Each person creates their own app-password from their
-			<a href="/profile#connect-apps" class="link link-accent">Profile → Connect Apps</a>.
+			<a href={resolve('/profile#connect-apps')} class="link link-accent">Profile → Connect Apps</a
+			>.
 		</p>
 	</header>
 

--- a/frontend/src/lib/components/settings/SettingsLastFmApp.svelte
+++ b/frontend/src/lib/components/settings/SettingsLastFmApp.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import type { LastFmConnectionSettingsResponse } from '$lib/types';
 	import { createSettingsForm } from '$lib/utils/settingsForm.svelte';
 	import { Radio, ExternalLink } from 'lucide-svelte';
@@ -36,7 +37,7 @@
 		<div class="rounded-xl border border-info/20 bg-info/5 p-3 text-sm text-base-content/70">
 			These are the shared credentials for one registered Last.fm application. Each user links
 			<span class="font-medium">their own</span> Last.fm account and toggles scrobbling from their
-			<a href="/profile" class="link link-primary">profile</a>.
+			<a href={resolve('/profile')} class="link link-primary">profile</a>.
 		</div>
 
 		{#if form.loading}

--- a/frontend/src/lib/components/settings/SettingsLibrary.svelte
+++ b/frontend/src/lib/components/settings/SettingsLibrary.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { AlertTriangle, ArrowRight, CheckCircle2, FolderCog, ScanSearch } from 'lucide-svelte';
 	import { ApiError } from '$lib/api/client';
 	import {
@@ -494,7 +495,7 @@
 						workspace under the Automation tab.
 					</p>
 				</div>
-				<a href="/library/management?tab=automation" class="btn management-btn btn-sm"
+				<a href={resolve('/library/management?tab=automation')} class="btn management-btn btn-sm"
 					>Open Organize files settings <ArrowRight class="h-4 w-4" /></a
 				>
 			</section>

--- a/frontend/src/lib/components/settings/SettingsSabnzbd.svelte
+++ b/frontend/src/lib/components/settings/SettingsSabnzbd.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { CircleCheck, CircleX, FolderTree, Rss, TriangleAlert } from 'lucide-svelte';
 
 	import {
@@ -130,7 +131,7 @@
 						<span class="font-semibold">No indexers configured.</span> SABnzbd downloads the NZBs your
 						indexers find - with none set up, Usenet search returns nothing and this client stays idle.
 					</p>
-					<a class="link link-warning font-medium" href="/settings?tab=indexers">
+					<a class="link link-warning font-medium" href={resolve('/settings?tab=indexers')}>
 						Add an indexer →
 					</a>
 				</div>

--- a/frontend/src/lib/components/settings/SettingsSpotify.svelte
+++ b/frontend/src/lib/components/settings/SettingsSpotify.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { api } from '$lib/api/client';
+	import { base, resolve } from '$app/paths';
 	import type { SpotifySettings } from '$lib/types';
 	import { createSettingsForm } from '$lib/utils/settingsForm.svelte';
 	import { Copy, ExternalLink } from 'lucide-svelte';
@@ -35,7 +36,7 @@
 			);
 			redirectUri = data.redirect_uri;
 		} catch {
-			redirectUri = `${window.location.origin}/api/v1/me/connections/spotify/auth/callback`;
+			redirectUri = `${window.location.origin}${base}/api/v1/me/connections/spotify/auth/callback`;
 		}
 	});
 	onDestroy(() => form.cleanup());
@@ -62,7 +63,7 @@
 		<div class="rounded-xl border border-info/20 bg-info/5 p-3 text-sm text-base-content/70">
 			These are the shared app credentials for one registered Spotify application. Each user links
 			<span class="font-medium">their own</span> Spotify account from their
-			<a href="/profile" class="link link-primary">profile</a> to import their personal playlists.
+			<a href={resolve('/profile')} class="link link-primary">profile</a> to import their personal playlists.
 		</div>
 
 		<div class="rounded-xl border border-warning/20 bg-warning/5 p-3 text-sm text-base-content/70">

--- a/frontend/src/lib/queries/downloads/DownloadSSE.svelte.ts
+++ b/frontend/src/lib/queries/downloads/DownloadSSE.svelte.ts
@@ -1,4 +1,5 @@
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import type { DownloadProgress, DownloadSourceUpdate } from '$lib/types';
 
 interface DownloadStreamState {
@@ -104,7 +105,7 @@ export function createDownloadStream() {
 	function start(taskId: string) {
 		stop();
 		state = { progress: null, status: null, source: null, done: false };
-		source = new EventSource(API.downloads.stream(taskId));
+		source = new EventSource(getApiUrl(API.downloads.stream(taskId)));
 		source.addEventListener('status', (e) => {
 			const d = parse(e);
 			const sourceUpdate = parseSourceUpdate(d, state.source);

--- a/frontend/src/lib/queries/following/FollowingEvents.ts
+++ b/frontend/src/lib/queries/following/FollowingEvents.ts
@@ -1,4 +1,5 @@
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import { toastStore } from '$lib/stores/toast';
 import { authStore } from '$lib/stores/authStore.svelte';
 import { invalidateQueriesWithPersister } from '$lib/queries/QueryClient';
@@ -230,7 +231,7 @@ export function createFollowingEvents() {
 		mixSeen = loadSeen(MIX_SEEN_KEY);
 		wantedSeen = loadSeen(WANTED_SEEN_KEY);
 		requestImportedSeen = loadSeen(REQUEST_IMPORTED_SEEN_KEY);
-		source = new EventSource(API.following.events());
+		source = new EventSource(getApiUrl(API.following.events()));
 		source.addEventListener('auto_download_enqueued', handleEnqueued);
 		source.addEventListener('playlist_imported', handlePlaylistImported);
 		source.addEventListener('personal_mix_refreshed', handlePersonalMixRefreshed);

--- a/frontend/src/lib/queries/library-management/LibraryManagementEvents.ts
+++ b/frontend/src/lib/queries/library-management/LibraryManagementEvents.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from '$lib/api/api-utils';
 import { API } from '$lib/constants';
 
 import { invalidateLibraryManagementSurfaces } from './LibraryManagementInvalidation';
@@ -69,7 +70,7 @@ export function createLibraryManagementEvents() {
 
 	function start(): void {
 		stop();
-		source = new EventSource(API.library.operationsStream());
+		source = new EventSource(getApiUrl(API.library.operationsStream()));
 		source.addEventListener('open', refresh);
 		source.addEventListener('activity.changed', handleActivity);
 	}

--- a/frontend/src/lib/queries/library/LibraryActivityEvents.ts
+++ b/frontend/src/lib/queries/library/LibraryActivityEvents.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from '$lib/api/api-utils';
 import { API } from '$lib/constants';
 import { invalidateQueriesWithPersister, queryClient } from '$lib/queries/QueryClient';
 import { LibraryQueryKeyFactory } from './LibraryQueryKeyFactory';
@@ -95,10 +96,10 @@ export function createLibraryActivityEvents() {
 		unsubscribeQueryCache = queryClient.getQueryCache().subscribe(() => {
 			reconcilePendingInitialRevisions();
 		});
-		activitySource = new EventSource(API.library.activityStream());
+		activitySource = new EventSource(getApiUrl(API.library.activityStream()));
 		activitySource.addEventListener('activity.changed', activityChanged);
 		if (isAdmin) {
-			operationsSource = new EventSource(API.library.operationsStream());
+			operationsSource = new EventSource(getApiUrl(API.library.operationsStream()));
 			operationsSource.addEventListener('open', invalidateOperations);
 			operationsSource.addEventListener('activity.changed', activityChanged);
 		}

--- a/frontend/src/lib/queries/libraryContributions/LibraryContributionMutations.svelte.ts
+++ b/frontend/src/lib/queries/libraryContributions/LibraryContributionMutations.svelte.ts
@@ -1,3 +1,4 @@
+import { resolve } from '$app/paths';
 import { createMutation } from '@tanstack/svelte-query';
 import { goto } from '$app/navigation';
 import { api } from '$lib/api/client';
@@ -43,7 +44,7 @@ export const createLibraryContributionMutation = () =>
 		onSuccess: async (contribution) => {
 			await saveContribution(contribution);
 			toastStore.show({ message: 'Contribution draft ready', type: 'success' });
-			await goto(`/library/contributions/${contribution.id}`);
+			await goto(resolve(`/library/contributions/${contribution.id}`));
 		},
 		onError: () => toastStore.show({ message: "Couldn't start the contribution", type: 'error' })
 	}));
@@ -89,7 +90,7 @@ const revisionMutation = (
 			});
 			toastStore.show({ message: successMessage, type: 'success' });
 			if (action === 'rebuild') {
-				await goto(`/library/contributions/${contribution.id}`, { replaceState: true });
+				await goto(resolve(`/library/contributions/${contribution.id}`), { replaceState: true });
 			}
 		},
 		onError: async (_error, input) => refreshAfterMutationError(input.contributionId, errorMessage)

--- a/frontend/src/lib/stores/nowPlayingSessions.svelte.ts
+++ b/frontend/src/lib/stores/nowPlayingSessions.svelte.ts
@@ -1,4 +1,5 @@
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import { api } from '$lib/api/client';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import type { NowPlayingSession } from '$lib/types';
@@ -94,7 +95,7 @@ function createNowPlayingStore() {
 		if (running) return;
 		running = true;
 		void hydrate();
-		source = new EventSource(API.nowPlaying.events());
+		source = new EventSource(getApiUrl(API.nowPlaying.events()));
 		source.addEventListener('snapshot', onSnapshot as EventListener);
 		tickTimer = setInterval(tick, TICK_MS);
 	}

--- a/frontend/src/lib/stores/playerSourceResolver.spec.ts
+++ b/frontend/src/lib/stores/playerSourceResolver.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { QueueItem, SourceType } from '$lib/player/types';
+
+async function loadResolver(base: string) {
+	vi.doMock('$app/paths', () => ({ base }));
+	vi.doMock('$env/dynamic/public', () => ({ env: {} }));
+	return await import('./playerSourceResolver');
+}
+
+function queueItem(sourceType: SourceType, trackSourceId: string, streamUrl?: string): QueueItem {
+	return {
+		trackSourceId,
+		trackName: 'Track',
+		artistName: 'Artist',
+		trackNumber: 1,
+		albumId: 'album-1',
+		albumName: 'Album',
+		coverUrl: null,
+		sourceType,
+		streamUrl
+	};
+}
+
+describe('resolveSourceUrl', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('returns root-absolute stream URLs unchanged when no base path is set', async () => {
+		const { resolveSourceUrl } = await loadResolver('');
+		expect(resolveSourceUrl(queueItem('local', '77'))).toBe('/api/v1/stream/local/77');
+		expect(resolveSourceUrl(queueItem('jellyfin', 'jf-1'))).toBe('/api/v1/stream/jellyfin/jf-1');
+	});
+
+	it('prefixes stream URLs with the base path so the audio element resolves them', async () => {
+		const { resolveSourceUrl } = await loadResolver('/droppedneedle');
+		expect(resolveSourceUrl(queueItem('local', '77'))).toBe(
+			'/droppedneedle/api/v1/stream/local/77'
+		);
+		expect(resolveSourceUrl(queueItem('navidrome', 'nd-1'))).toBe(
+			'/droppedneedle/api/v1/stream/navidrome/nd-1'
+		);
+	});
+
+	it('prefixes a stream URL persisted before the base path was configured', async () => {
+		const { resolveSourceUrl } = await loadResolver('/droppedneedle');
+		expect(resolveSourceUrl(queueItem('local', '77', '/api/v1/stream/local/77'))).toBe(
+			'/droppedneedle/api/v1/stream/local/77'
+		);
+	});
+
+	it('leaves off-origin stream URLs untouched', async () => {
+		const { resolveSourceUrl } = await loadResolver('/droppedneedle');
+		expect(resolveSourceUrl(queueItem('youtube', 'yt-1', 'https://youtu.be/yt-1'))).toBe(
+			'https://youtu.be/yt-1'
+		);
+		expect(resolveSourceUrl(queueItem('plex', 'px-1', 'https://plex.example/part/1'))).toBe(
+			'https://plex.example/part/1'
+		);
+	});
+});
+
+describe('buildPrefetchUrl', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('stays app-relative because the API client applies the base path itself', async () => {
+		const { buildPrefetchUrl } = await loadResolver('/droppedneedle');
+		expect(buildPrefetchUrl(queueItem('local', '77'))).toBe('/api/v1/stream/local/77');
+	});
+});

--- a/frontend/src/lib/stores/playerSourceResolver.ts
+++ b/frontend/src/lib/stores/playerSourceResolver.ts
@@ -1,3 +1,4 @@
+import { getApiUrl } from '$lib/api/api-utils';
 import { API } from '$lib/constants';
 import type { NowPlaying, QueueItem, SourceType } from '$lib/player/types';
 
@@ -6,13 +7,13 @@ export function resolveSourceUrl(item: QueueItem): string | undefined {
 		case 'youtube':
 			return item.streamUrl;
 		case 'local':
-			return item.streamUrl ?? API.stream.local(item.trackSourceId);
+			return getApiUrl(item.streamUrl ?? API.stream.local(item.trackSourceId));
 		case 'navidrome':
-			return item.streamUrl ?? API.stream.navidrome(item.trackSourceId);
+			return getApiUrl(item.streamUrl ?? API.stream.navidrome(item.trackSourceId));
 		case 'jellyfin':
-			return API.stream.jellyfin(item.trackSourceId);
+			return getApiUrl(API.stream.jellyfin(item.trackSourceId));
 		case 'plex':
-			return item.streamUrl ?? API.stream.plex(item.trackSourceId);
+			return getApiUrl(item.streamUrl ?? API.stream.plex(item.trackSourceId));
 	}
 }
 

--- a/frontend/src/lib/utils/albumCardPlayback.ts
+++ b/frontend/src/lib/utils/albumCardPlayback.ts
@@ -1,5 +1,6 @@
 import { get } from 'svelte/store';
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import { api } from '$lib/api/client';
 import { integrationStore } from '$lib/stores/integration';
 import { playerStore } from '$lib/stores/player.svelte';
@@ -121,7 +122,10 @@ export async function fetchAlbumQueueItems(
 	}
 
 	if (status.navidrome) {
-		const url = new URL(API.navidromeLibrary.albumMatch(meta.mbid), window.location.origin);
+		const url = new URL(
+			getApiUrl(API.navidromeLibrary.albumMatch(meta.mbid)),
+			window.location.origin
+		);
 		if (meta.albumName) url.searchParams.set('name', meta.albumName);
 		if (meta.artistName) url.searchParams.set('artist', meta.artistName);
 		probes.push(
@@ -154,7 +158,10 @@ export async function fetchAlbumQueueItems(
 	}
 
 	if (status.plex) {
-		const plexUrl = new URL(API.plexLibrary.albumMatch(meta.mbid), window.location.origin);
+		const plexUrl = new URL(
+			getApiUrl(API.plexLibrary.albumMatch(meta.mbid)),
+			window.location.origin
+		);
 		if (meta.albumName) plexUrl.searchParams.set('name', meta.albumName);
 		if (meta.artistName) plexUrl.searchParams.set('artist', meta.artistName);
 		probes.push(

--- a/frontend/src/lib/utils/artistTrackLoader.svelte.ts
+++ b/frontend/src/lib/utils/artistTrackLoader.svelte.ts
@@ -15,6 +15,7 @@ import {
 } from '$lib/player/queueHelpers';
 import type { TrackMeta } from '$lib/player/queueHelpers';
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import { api } from '$lib/api/client';
 import { getCoverUrl } from '$lib/utils/errorHandling';
 
@@ -66,7 +67,10 @@ async function fetchAlbumTracksForSource(
 				return buildQueueItemsFromLocal(match.tracks, meta);
 			}
 			case 'navidrome': {
-				const url = new URL(API.navidromeLibrary.albumMatch(mbid), window.location.origin);
+				const url = new URL(
+					getApiUrl(API.navidromeLibrary.albumMatch(mbid)),
+					window.location.origin
+				);
 				url.searchParams.set('name', release.title);
 				url.searchParams.set('artist', artistName);
 				const match = await api.global.get<NavidromeAlbumMatch>(url.toString(), { signal });
@@ -82,7 +86,7 @@ async function fetchAlbumTracksForSource(
 				return buildQueueItemsFromJellyfin(match.tracks, meta);
 			}
 			case 'plex': {
-				const url = new URL(API.plexLibrary.albumMatch(mbid), window.location.origin);
+				const url = new URL(getApiUrl(API.plexLibrary.albumMatch(mbid)), window.location.origin);
 				url.searchParams.set('name', release.title);
 				url.searchParams.set('artist', artistName);
 				const match = await api.global.get<PlexAlbumMatch>(url.toString(), { signal });

--- a/frontend/src/lib/utils/basePath.spec.ts
+++ b/frontend/src/lib/utils/basePath.spec.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+async function loadStripBase(base: string) {
+	vi.doMock('$app/paths', () => ({ base }));
+	return (await import('./basePath')).stripBase;
+}
+
+describe('stripBase', () => {
+	beforeEach(() => {
+		vi.resetModules();
+	});
+
+	it('returns the pathname unchanged when no base path is set', async () => {
+		const stripBase = await loadStripBase('');
+		expect(stripBase('/login')).toBe('/login');
+		expect(stripBase('/')).toBe('/');
+		expect(stripBase('/library/review?state=needs_review')).toBe(
+			'/library/review?state=needs_review'
+		);
+	});
+
+	it('removes the base path prefix so route checks compare app-relative paths', async () => {
+		const stripBase = await loadStripBase('/droppedneedle');
+		expect(stripBase('/droppedneedle/login')).toBe('/login');
+		expect(stripBase('/droppedneedle/library/review')).toBe('/library/review');
+	});
+
+	it('maps the base path root to /', async () => {
+		const stripBase = await loadStripBase('/droppedneedle');
+		expect(stripBase('/droppedneedle')).toBe('/');
+	});
+
+	it('leaves a pathname outside the base path untouched', async () => {
+		const stripBase = await loadStripBase('/droppedneedle');
+		expect(stripBase('/elsewhere/login')).toBe('/elsewhere/login');
+	});
+});

--- a/frontend/src/lib/utils/basePath.ts
+++ b/frontend/src/lib/utils/basePath.ts
@@ -1,0 +1,6 @@
+import { base } from '$app/paths';
+
+export function stripBase(pathname: string): string {
+	if (!base || !pathname.startsWith(base)) return pathname;
+	return pathname.slice(base.length) || '/';
+}

--- a/frontend/src/lib/utils/logout.ts
+++ b/frontend/src/lib/utils/logout.ts
@@ -1,6 +1,7 @@
 import { browser } from '$app/environment';
 import { goto } from '$app/navigation';
 import { resolve } from '$app/paths';
+import { getApiUrl } from '$lib/api/api-utils';
 import { resetQueryCacheForUserSwitch } from '$lib/queries/QueryClient';
 import { authStore, LAST_USER_ID_KEY } from '$lib/stores/authStore.svelte';
 import { musicSourceStore } from '$lib/stores/musicSource';
@@ -11,7 +12,7 @@ import { clearUserScopedLocalCaches } from '$lib/utils/userScopedCaches';
 // sees no prior personalized data; local state clears regardless of network success.
 export async function logout(): Promise<void> {
 	try {
-		await fetch('/api/v1/auth/logout', { method: 'POST', credentials: 'include' });
+		await fetch(getApiUrl('/api/v1/auth/logout'), { method: 'POST', credentials: 'include' });
 	} catch {
 		// A failed revoke must not strand the user in a signed-in UI.
 	}

--- a/frontend/src/routes/+error.svelte
+++ b/frontend/src/routes/+error.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Home, RotateCw } from 'lucide-svelte';
 	import { page } from '$app/state';
 
@@ -23,7 +24,7 @@
 	<h1 class="err-head">{heading}</h1>
 	<p class="err-blurb">{blurb}</p>
 	<div class="err-actions">
-		<a href="/" class="btn btn-ghost btn-sm">
+		<a href={resolve('/')} class="btn btn-ghost btn-sm">
 			<Home class="h-4 w-4" />
 			Home
 		</a>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { stripBase } from '$lib/utils/basePath';
 	import { page } from '$app/state';
 	import { AUTH_FREE_PATHS } from '$lib/constants';
 	import { loadAuthenticatedAppShell } from '$lib/components/lazyComponentLoaders';
@@ -12,7 +13,7 @@
 	let shellLoadFailed = $state(false);
 	let shellLoadAttempt = $state(0);
 	const needsAppShell = $derived(
-		!AUTH_FREE_PATHS.some((path) => page.url.pathname.startsWith(path))
+		!AUTH_FREE_PATHS.some((path) => stripBase(page.url.pathname).startsWith(path))
 	);
 
 	$effect(() => {

--- a/frontend/src/routes/+layout.ts
+++ b/frontend/src/routes/+layout.ts
@@ -1,3 +1,5 @@
+import { resolve } from '$app/paths';
+import { stripBase } from '$lib/utils/basePath';
 import { browser } from '$app/environment';
 import { ApiError, api } from '$lib/api/client';
 import { API, AUTH_FREE_PATHS } from '$lib/constants';
@@ -17,7 +19,7 @@ const BOOTSTRAP_TIMEOUT_MS = 10_000;
 const BUSY_MESSAGE = 'The server is busy. Your session is safe - try again shortly.';
 
 export const load: LayoutLoad = async ({ url }) => {
-	const path = url.pathname;
+	const path = stripBase(url.pathname);
 	const isAuthFree = AUTH_FREE_PATHS.some((p) => path.startsWith(p));
 
 	let setupRequired = authStore.setupRequired;
@@ -71,10 +73,10 @@ export const load: LayoutLoad = async ({ url }) => {
 	}
 
 	if (setupRequired && !isAuthFree) {
-		throw redirect(302, '/setup');
+		throw redirect(302, resolve('/setup'));
 	}
 	if (!setupRequired && path.startsWith('/setup')) {
-		throw redirect(302, authStore.isAuthenticated ? '/' : '/login');
+		throw redirect(302, authStore.isAuthenticated ? resolve('/') : resolve('/login'));
 	}
 
 	// initialized stays true after in-app login; reset persisted caches on account switches
@@ -90,7 +92,7 @@ export const load: LayoutLoad = async ({ url }) => {
 	}
 
 	if (!setupRequired && !isAuthFree && !authStore.isAuthenticated) {
-		throw redirect(302, '/login');
+		throw redirect(302, resolve('/login'));
 	}
 
 	// the primary source is user-specific; connection defaults are global

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		Download,
 		Music,
@@ -166,7 +167,7 @@
 
 	<div class="flex justify-end px-4 -mt-4 mb-4 sm:px-6 lg:px-8">
 		<a
-			href="/settings?tab=home"
+			href={resolve('/settings?tab=home')}
 			class="btn btn-ghost btn-sm gap-2 text-base-content/60 hover:text-base-content"
 			title="Choose which sections appear here"
 		>
@@ -211,7 +212,10 @@
 									<span class="badge badge-accent badge-lg">{feature}</span>
 								{/each}
 							</div>
-							<a href="/settings?tab=download-client" class="btn btn-accent btn-lg gap-2">
+							<a
+								href={resolve('/settings?tab=download-client')}
+								class="btn btn-accent btn-lg gap-2"
+							>
 								<Download class="h-5 w-5" />
 								Configure Download Client
 							</a>
@@ -342,14 +346,14 @@
 								Your library is empty. Add a library path and start a scan to fill it.
 							</p>
 							<div class="flex flex-wrap justify-center gap-2">
-								<a href="/settings?tab=library" class="btn btn-primary">Start scan</a>
-								<a href="/library" class="btn btn-ghost">Go to Library</a>
+								<a href={resolve('/settings?tab=library')} class="btn btn-primary">Start scan</a>
+								<a href={resolve('/library')} class="btn btn-ghost">Go to Library</a>
 							</div>
 						{:else}
 							<p class="mb-6 max-w-md px-4 text-center text-sm text-base-content/70 sm:text-base">
 								Your library is being prepared. An admin is setting things up - check back soon.
 							</p>
-							<a href="/library" class="btn btn-ghost">Go to Library</a>
+							<a href={resolve('/library')} class="btn btn-ghost">Go to Library</a>
 						{/if}
 					</div>
 				{/if}

--- a/frontend/src/routes/album/[id]/LocalAlbumPage.svelte
+++ b/frontend/src/routes/album/[id]/LocalAlbumPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import {
 		ChevronLeft,
@@ -80,7 +81,7 @@
 	function openContribution(): void {
 		if (!album) return;
 		if (album.contribution_id) {
-			void goto(`/library/contributions/${album.contribution_id}`);
+			void goto(resolve(`/library/contributions/${album.contribution_id}`));
 			return;
 		}
 		contributionMutation.mutate(album.id);
@@ -90,7 +91,7 @@
 <svelte:head><title>{album?.title ?? 'Album'} · Library</title></svelte:head>
 
 <main class="container mx-auto p-4 md:p-6 lg:p-8">
-	<button class="btn btn-ghost btn-sm mb-5 gap-2" onclick={() => goto('/library/albums')}>
+	<button class="btn btn-ghost btn-sm mb-5 gap-2" onclick={() => goto(resolve('/library/albums'))}>
 		<ChevronLeft class="h-4 w-4" /> Albums
 	</button>
 

--- a/frontend/src/routes/album/[id]/albumFetchers.ts
+++ b/frontend/src/routes/album/[id]/albumFetchers.ts
@@ -12,6 +12,7 @@ import type {
 } from '$lib/types';
 import { api } from '$lib/api/client';
 import { API } from '$lib/constants';
+import { getApiUrl } from '$lib/api/api-utils';
 import { compareDiscTrack } from '$lib/player/queueHelpers';
 
 export { fetchAlbumTracks } from '$lib/api/albums';
@@ -82,7 +83,10 @@ export async function fetchNavidromeMatch(
 	opts: { albumTitle?: string; artistName?: string },
 	signal?: AbortSignal
 ): Promise<NavidromeAlbumMatch | null> {
-	const matchUrl = new URL(API.navidromeLibrary.albumMatch(albumId), window.location.origin);
+	const matchUrl = new URL(
+		getApiUrl(API.navidromeLibrary.albumMatch(albumId)),
+		window.location.origin
+	);
 	if (opts.albumTitle) matchUrl.searchParams.set('name', opts.albumTitle);
 	if (opts.artistName) matchUrl.searchParams.set('artist', opts.artistName);
 	return api.get<NavidromeAlbumMatch>(matchUrl.toString(), { signal });
@@ -93,7 +97,7 @@ export async function fetchPlexMatch(
 	opts: { albumTitle?: string; artistName?: string },
 	signal?: AbortSignal
 ): Promise<PlexAlbumMatch | null> {
-	const matchUrl = new URL(API.plexLibrary.albumMatch(albumId), window.location.origin);
+	const matchUrl = new URL(getApiUrl(API.plexLibrary.albumMatch(albumId)), window.location.origin);
 	if (opts.albumTitle) matchUrl.searchParams.set('name', opts.albumTitle);
 	if (opts.artistName) matchUrl.searchParams.set('artist', opts.artistName);
 	return api.get<PlexAlbumMatch>(matchUrl.toString(), { signal });

--- a/frontend/src/routes/artist/[id]/LocalArtistPage.svelte
+++ b/frontend/src/routes/artist/[id]/LocalArtistPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { ChevronLeft, Disc3, ExternalLink, FileSearch, FileUp, Mic2 } from 'lucide-svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
@@ -30,7 +31,7 @@
 
 	function openContribution(album: LibraryAlbumSummary): void {
 		if (album.contribution_id) {
-			void goto(`/library/contributions/${album.contribution_id}`);
+			void goto(resolve(`/library/contributions/${album.contribution_id}`));
 			return;
 		}
 		contributionMutation.mutate(album.id);
@@ -48,7 +49,7 @@
 <svelte:head><title>{artist?.name ?? 'Artist'} · Library</title></svelte:head>
 
 <main class="container mx-auto p-4 md:p-6 lg:p-8">
-	<button class="btn btn-ghost btn-sm mb-5 gap-2" onclick={() => goto('/library/artists')}
+	<button class="btn btn-ghost btn-sm mb-5 gap-2" onclick={() => goto(resolve('/library/artists'))}
 		><ChevronLeft class="h-4 w-4" /> Artists</button
 	>
 	{#if artistQuery.isLoading}

--- a/frontend/src/routes/artist/[id]/ProviderArtistPage.svelte
+++ b/frontend/src/routes/artist/[id]/ProviderArtistPage.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { colors } from '$lib/colors';
 	import ArtistHeaderSkeleton from '$lib/components/ArtistHeaderSkeleton.svelte';
 	import AlbumGridSkeleton from '$lib/components/AlbumGridSkeleton.svelte';
@@ -284,7 +285,7 @@
 						<div class="flex flex-wrap gap-2 justify-center sm:justify-start -mt-2">
 							{#each [...new Set(artist.tags)].slice(0, 10) as tag (tag)}
 								<a
-									href="/genre?name={encodeURIComponent(tag)}"
+									href={resolve(`/genre?name=${encodeURIComponent(tag)}`)}
 									class="badge badge-lg cursor-pointer hover:opacity-80 transition-opacity"
 									style="background-color: {colors.primary}; color: {colors.secondary};">{tag}</a
 								>

--- a/frontend/src/routes/auth/callback/+page.svelte
+++ b/frontend/src/routes/auth/callback/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../../../auth.css';
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { ApiError } from '$lib/api/client';
 	import { createOidcExchangeMutation } from '$lib/queries/auth/AuthMutations.svelte';
@@ -24,7 +25,7 @@
 			// hard navigation on purpose: the exchange call just set the session
 			// cookie, and a soft goto() can outrun it and bounce the first
 			// sign-in back to /login
-			window.location.assign('/');
+			window.location.assign(resolve('/'));
 		} catch (e) {
 			error =
 				e instanceof ApiError
@@ -47,7 +48,7 @@
 		{#if error}
 			<div class="flex flex-col items-center gap-3 max-w-sm">
 				<p class="text-base-content/70 text-sm">{error}</p>
-				<a href="/login" class="btn btn-primary btn-sm">Back to sign in</a>
+				<a href={resolve('/login')} class="btn btn-primary btn-sm">Back to sign in</a>
 			</div>
 		{:else}
 			<p class="text-base-content/60 text-sm">Completing sign-in…</p>

--- a/frontend/src/routes/discover/+page.svelte
+++ b/frontend/src/routes/discover/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import HomeSection from '$lib/components/HomeSection.svelte';
 	import DailyMixCard from '$lib/components/DailyMixCard.svelte';
 	import RadioCard from '$lib/components/RadioCard.svelte';
@@ -259,7 +260,7 @@
 					<DiscoverZoneNav {zones}>
 						{#snippet action()}
 							<a
-								href="/settings?tab=discover"
+								href={resolve('/settings?tab=discover')}
 								class="btn btn-ghost btn-xs gap-1.5 text-base-content/60 hover:text-primary"
 								title="Choose which sections appear here"
 							>
@@ -536,7 +537,7 @@
 									Connect a music service to get recommendations. The more you connect, the better
 									they get.
 								</p>
-								<a href="/settings" class="btn btn-primary">Connect Services</a>
+								<a href={resolve('/settings')} class="btn btn-primary">Connect Services</a>
 							</div>
 						{:else if !hasContent && degradedSources.length > 0}
 							<div class="flex flex-col items-center justify-center py-12 sm:py-16">
@@ -571,7 +572,7 @@
 								<p class="mb-6 max-w-md px-4 text-center text-sm text-base-content/70 sm:text-base">
 									Turn some discovery sections back on to fill this page.
 								</p>
-								<a href="/settings?tab=discover" class="btn btn-primary gap-2">
+								<a href={resolve('/settings?tab=discover')} class="btn btn-primary gap-2">
 									<SlidersHorizontal class="h-4 w-4" />
 									Customise Sections
 								</a>

--- a/frontend/src/routes/following/+page.svelte
+++ b/frontend/src/routes/following/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Heart, ArrowRight, CalendarClock, Check, Disc3, ExternalLink } from 'lucide-svelte';
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
@@ -95,7 +96,7 @@
 				class="group/card relative rounded-2xl border border-base-300 bg-base-200/40 p-4 transition-colors hover:border-primary sm:p-5"
 			>
 				<a
-					href="/following/new-releases"
+					href={resolve('/following/new-releases')}
 					class="mb-3 flex items-baseline justify-between after:absolute after:inset-0 after:rounded-2xl after:content-['']"
 				>
 					<h2 class="text-sm font-semibold uppercase tracking-wider text-base-content/50">
@@ -118,7 +119,7 @@
 					<div class="relative z-10 grid grid-cols-3 gap-3 sm:grid-cols-5">
 						{#each releases as release, index (release.release_group_mbid)}
 							<a
-								href="/album/{release.release_group_mbid}"
+								href={resolve(`/album/${release.release_group_mbid}`)}
 								class="group flex flex-col gap-1.5 {heroGrid && index === 0
 									? 'col-span-2 row-span-2'
 									: ''}"
@@ -171,7 +172,7 @@
 				class="group/card relative rounded-2xl border border-base-300 bg-base-200/40 p-4 transition-colors hover:border-primary sm:p-5"
 			>
 				<a
-					href="/following/events"
+					href={resolve('/following/events')}
 					class="mb-3 flex items-baseline justify-between after:absolute after:inset-0 after:rounded-2xl after:content-['']"
 				>
 					<h2 class="text-sm font-semibold uppercase tracking-wider text-base-content/50">
@@ -205,7 +206,7 @@
 										{monthShort(concert.local_date)}
 									</span>
 								</div>
-								<a href="/artist/{concert.artist_mbid}" class="shrink-0">
+								<a href={resolve(`/artist/${concert.artist_mbid}`)} class="shrink-0">
 									<ArtistImage
 										mbid={concert.artist_mbid}
 										alt={concert.artist_name}
@@ -215,7 +216,7 @@
 								</a>
 								<div class="min-w-0 flex-1">
 									<a
-										href="/artist/{concert.artist_mbid}"
+										href={resolve(`/artist/${concert.artist_mbid}`)}
 										class="block truncate font-semibold hover:text-primary"
 									>
 										{concert.artist_name}
@@ -245,7 +246,7 @@
 					</p>
 				{:else if authStore.isAdmin}
 					<a
-						href="/settings?tab=events"
+						href={resolve('/settings?tab=events')}
 						class="relative z-10 flex items-center gap-3 rounded-2xl border border-dashed border-base-300 p-4 text-sm text-base-content/60 transition-colors hover:border-primary hover:text-primary"
 					>
 						<CalendarClock class="h-5 w-5 shrink-0" aria-hidden="true" />
@@ -259,7 +260,7 @@
 				class="group/card relative rounded-2xl border border-base-300 bg-base-200/40 p-4 transition-colors hover:border-primary sm:p-5"
 			>
 				<a
-					href="/following/artists"
+					href={resolve('/following/artists')}
 					class="mb-3 flex items-baseline justify-between after:absolute after:inset-0 after:rounded-2xl after:content-['']"
 				>
 					<h2 class="text-sm font-semibold uppercase tracking-wider text-base-content/50">
@@ -277,13 +278,17 @@
 				</a>
 				<div class="relative z-10 flex flex-wrap items-center gap-2">
 					{#each artists.slice(0, AVATAR_ROW) as artist (artist.mbid)}
-						<a href="/artist/{artist.mbid}" title={artist.name} aria-label="Open {artist.name}">
+						<a
+							href={resolve(`/artist/${artist.mbid}`)}
+							title={artist.name}
+							aria-label="Open {artist.name}"
+						>
 							<ArtistImage mbid={artist.mbid} alt={artist.name} size="xs" rounded="full" />
 						</a>
 					{/each}
 					{#if artists.length > AVATAR_ROW}
 						<a
-							href="/following/artists"
+							href={resolve('/following/artists')}
 							class="badge badge-lg border-base-300 bg-base-200 py-4 font-medium hover:border-primary hover:text-primary"
 						>
 							+{artists.length - AVATAR_ROW}

--- a/frontend/src/routes/following/artists/+page.svelte
+++ b/frontend/src/routes/following/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Heart, X, ArrowLeft, DownloadCloud } from 'lucide-svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
 	import EmptyState from '$lib/components/EmptyState.svelte';
@@ -31,7 +32,11 @@
 
 <div class="mx-auto w-full max-w-6xl px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 	<div class="mb-6 flex items-center gap-3">
-		<a href="/following" class="btn btn-ghost btn-sm btn-circle" aria-label="Back to Following">
+		<a
+			href={resolve('/following')}
+			class="btn btn-ghost btn-sm btn-circle"
+			aria-label="Back to Following"
+		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
 		<Heart class="h-6 w-6 text-primary" aria-hidden="true" />
@@ -75,7 +80,7 @@
 				{@const chip = stateChip(a)}
 				<div class="group flex flex-col gap-2">
 					<div class="relative overflow-hidden rounded-2xl">
-						<a href="/artist/{a.mbid}" aria-label="Open {a.name}">
+						<a href={resolve(`/artist/${a.mbid}`)} aria-label="Open {a.name}">
 							<ArtistImage
 								mbid={a.mbid}
 								alt={a.name}
@@ -92,7 +97,9 @@
 							<X class="h-3.5 w-3.5" />
 						</button>
 					</div>
-					<a href="/artist/{a.mbid}" class="truncate font-semibold hover:underline">{a.name}</a>
+					<a href={resolve(`/artist/${a.mbid}`)} class="truncate font-semibold hover:underline"
+						>{a.name}</a
+					>
 					{#if chip}
 						<span class="badge badge-sm {chip.cls} w-fit">{chip.label}</span>
 					{/if}

--- a/frontend/src/routes/following/events/+page.svelte
+++ b/frontend/src/routes/following/events/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { ArrowLeft, CalendarClock, ExternalLink, Settings } from 'lucide-svelte';
 	import ArtistImage from '$lib/components/ArtistImage.svelte';
@@ -94,7 +95,11 @@
 
 <div class="mx-auto w-full max-w-4xl px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 	<div class="mb-6 flex items-center gap-3">
-		<a href="/following" class="btn btn-ghost btn-sm btn-circle" aria-label="Back to Following">
+		<a
+			href={resolve('/following')}
+			class="btn btn-ghost btn-sm btn-circle"
+			aria-label="Back to Following"
+		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
 		<CalendarClock class="h-6 w-6 text-primary" aria-hidden="true" />
@@ -128,7 +133,7 @@
 				{/if}
 			</p>
 			{#if authStore.isAdmin}
-				<a href="/settings" class="btn btn-primary btn-sm mt-4 gap-2 rounded-full">
+				<a href={resolve('/settings')} class="btn btn-primary btn-sm mt-4 gap-2 rounded-full">
 					<Settings class="h-4 w-4" aria-hidden="true" /> Open Settings
 				</a>
 			{/if}
@@ -188,7 +193,7 @@
 							</div>
 
 							<a
-								href="/artist/{concert.artist_mbid}"
+								href={resolve(`/artist/${concert.artist_mbid}`)}
 								class="shrink-0"
 								aria-label="Open {concert.artist_name}"
 							>
@@ -203,7 +208,7 @@
 							<div class="min-w-0 flex-1">
 								<div class="flex items-center gap-2">
 									<a
-										href="/artist/{concert.artist_mbid}"
+										href={resolve(`/artist/${concert.artist_mbid}`)}
 										class="truncate font-semibold hover:text-primary"
 									>
 										{concert.artist_name}

--- a/frontend/src/routes/following/new-releases/+page.svelte
+++ b/frontend/src/routes/following/new-releases/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { Disc3, Plus, Check, ArrowLeft } from 'lucide-svelte';
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
@@ -54,7 +55,11 @@
 
 <div class="mx-auto w-full max-w-6xl px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 	<div class="mb-6 flex flex-wrap items-center gap-3">
-		<a href="/following" class="btn btn-ghost btn-sm btn-circle" aria-label="Back to Following">
+		<a
+			href={resolve('/following')}
+			class="btn btn-ghost btn-sm btn-circle"
+			aria-label="Back to Following"
+		>
 			<ArrowLeft class="h-5 w-5" />
 		</a>
 		<Disc3 class="h-6 w-6 text-primary" aria-hidden="true" />
@@ -95,7 +100,7 @@
 				{@const isRequested = requested.has(item.release_group_mbid)}
 				<div class="group flex flex-col gap-2">
 					<a
-						href="/album/{item.release_group_mbid}"
+						href={resolve(`/album/${item.release_group_mbid}`)}
 						class="relative block aspect-square w-full overflow-hidden rounded-2xl"
 						aria-label="Open {item.title}"
 					>
@@ -117,11 +122,14 @@
 							</span>
 						{/if}
 					</a>
-					<a href="/album/{item.release_group_mbid}" class="truncate font-semibold hover:underline">
+					<a
+						href={resolve(`/album/${item.release_group_mbid}`)}
+						class="truncate font-semibold hover:underline"
+					>
 						{item.title}
 					</a>
 					<a
-						href="/artist/{item.artist_mbid}"
+						href={resolve(`/artist/${item.artist_mbid}`)}
 						class="truncate text-sm text-base-content/70 hover:underline"
 					>
 						{item.artist_name}

--- a/frontend/src/routes/genre/+page.svelte
+++ b/frontend/src/routes/genre/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import GenreArtistCard from '$lib/components/GenreArtistCard.svelte';
 	import GenreAlbumCard from '$lib/components/GenreAlbumCard.svelte';
@@ -105,7 +106,10 @@
 <div class="min-h-screen bg-base-100 relative overflow-hidden">
 	<div class="container mx-auto p-4 max-w-7xl relative" style="z-index: 1;">
 		<header class="mb-10 pt-2">
-			<a href="/" class="btn btn-ghost btn-sm gap-2 mb-6 -ml-2 opacity-70 hover:opacity-100">
+			<a
+				href={resolve('/')}
+				class="btn btn-ghost btn-sm gap-2 mb-6 -ml-2 opacity-70 hover:opacity-100"
+			>
 				<ArrowLeft class="w-4 h-4" />
 				Back
 			</a>

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -50,7 +50,7 @@
 			</a>
 			{#if authStore.isAdmin}
 				<a
-					href="/library/management"
+					href={resolve('/library/management')}
 					class="group btn btn-sm gap-2 rounded-full border border-base-content/15 bg-base-100/50 text-base-content backdrop-blur transition-all duration-200 hover:-translate-y-0.5 hover:border-primary/40 hover:bg-base-100/80 sm:btn-md"
 				>
 					<SlidersHorizontal

--- a/frontend/src/routes/library/+page.svelte
+++ b/frontend/src/routes/library/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { page } from '$app/state';
+	import { resolve } from '$app/paths';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import LibraryDashboard from '$lib/components/library/LibraryDashboard.svelte';
 	import { authStore } from '$lib/stores/authStore.svelte';
@@ -34,7 +35,7 @@
 		{#snippet title()}Library{/snippet}
 		{#snippet actions()}
 			<a
-				href="/library/local"
+				href={resolve('/library/local')}
 				class="group btn btn-sm gap-2 rounded-full border-0 bg-primary text-primary-content shadow-lg shadow-primary/25 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-primary/40 sm:btn-md"
 			>
 				<Headphones class="h-4 w-4 transition-transform duration-200 group-hover:scale-110" />

--- a/frontend/src/routes/library/albums/+page.svelte
+++ b/frontend/src/routes/library/albums/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import { ChevronLeft, Disc3, Search, X } from 'lucide-svelte';
@@ -67,7 +68,7 @@
 	<div class="flex items-center gap-4 mb-6">
 		<button
 			class="btn btn-ghost btn-circle"
-			onclick={() => goto('/library')}
+			onclick={() => goto(resolve('/library'))}
 			aria-label="Back to library"
 		>
 			<ChevronLeft class="w-6 h-6" />

--- a/frontend/src/routes/library/artists/+page.svelte
+++ b/frontend/src/routes/library/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { page } from '$app/state';
 	import { goto } from '$app/navigation';
 	import ArtistCardSkeleton from '$lib/components/ArtistCardSkeleton.svelte';
@@ -100,7 +101,7 @@
 	<header class="mb-6 flex items-center gap-4">
 		<button
 			class="btn btn-ghost btn-circle"
-			onclick={() => goto('/library')}
+			onclick={() => goto(resolve('/library'))}
 			aria-label="Back to library"
 		>
 			<ChevronLeft class="h-6 w-6" />

--- a/frontend/src/routes/library/contributions/[id]/+page.svelte
+++ b/frontend/src/routes/library/contributions/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import {
 		AlertTriangle,
@@ -217,7 +218,7 @@
 		<div class="mb-6 flex flex-wrap items-center justify-between gap-3">
 			<button
 				class="btn btn-ghost btn-sm gap-2"
-				onclick={() => goto(`/album/${contribution.local_album_id}`)}
+				onclick={() => goto(resolve(`/album/${contribution.local_album_id}`))}
 			>
 				<ArrowLeft class="h-4 w-4" /> Back to album
 			</button>

--- a/frontend/src/routes/library/jellyfin/+page.svelte
+++ b/frontend/src/routes/library/jellyfin/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api, ApiError } from '$lib/api/client';
 	import { getSourcePlaylistsQuery } from '$lib/queries/source-playlists/SourcePlaylistQueries.svelte';
@@ -504,9 +505,11 @@
 						index={genericArtistIndex}
 						onselect={(artist) => {
 							if (artist.musicbrainz_id) {
-								goto(`/artist/${artist.musicbrainz_id}`);
+								goto(resolve(`/artist/${artist.musicbrainz_id}`));
 							} else {
-								goto(`/library/jellyfin/artists?search=${encodeURIComponent(artist.name)}`);
+								goto(
+									resolve(`/library/jellyfin/artists?search=${encodeURIComponent(artist.name)}`)
+								);
 							}
 						}}
 					/>

--- a/frontend/src/routes/library/jellyfin/artists/+page.svelte
+++ b/frontend/src/routes/library/jellyfin/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import SourceArtistCard from '$lib/components/SourceArtistCard.svelte';
@@ -91,7 +92,7 @@
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
 		<a
-			href="/library/jellyfin"
+			href={resolve('/library/jellyfin')}
 			class="btn btn-ghost btn-sm gap-1"
 			aria-label="Back to Jellyfin library"
 		>

--- a/frontend/src/routes/library/jellyfin/tracks/+page.svelte
+++ b/frontend/src/routes/library/jellyfin/tracks/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import { buildDiscoveryQueueFromJellyfin } from '$lib/player/queueHelpers';
@@ -172,7 +173,7 @@
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
 		<a
-			href="/library/jellyfin"
+			href={resolve('/library/jellyfin')}
 			class="btn btn-ghost btn-sm gap-1"
 			aria-label="Back to Jellyfin library"
 		>

--- a/frontend/src/routes/library/local/+page.svelte
+++ b/frontend/src/routes/library/local/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount, onDestroy } from 'svelte';
 	import { browser } from '$app/environment';
 	import { playerStore } from '$lib/stores/player.svelte';
@@ -367,7 +368,7 @@
 				</button>
 				{#if isMbid(album.musicbrainz_id)}
 					<a
-						href="/album/{album.musicbrainz_id}"
+						href={resolve(`/album/${album.musicbrainz_id}`)}
 						class="mt-2 block truncate text-sm font-semibold transition-colors hover:text-accent hover:underline"
 						title={album.name}>{album.name}</a
 					>
@@ -376,7 +377,7 @@
 				{/if}
 				{#if isMbid(album.artist_mbid)}
 					<a
-						href="/artist/{album.artist_mbid}"
+						href={resolve(`/artist/${album.artist_mbid}`)}
 						class="block truncate text-xs text-base-content/55 transition-colors hover:text-accent hover:underline"
 						title={album.artist_name}>{album.artist_name}</a
 					>
@@ -458,8 +459,9 @@
 				<div>
 					<p class="font-semibold">No local music yet</p>
 					<p class="text-sm text-base-content/55">
-						Add a music folder in <a href="/settings?tab=library" class="link link-accent"
-							>Settings &rarr; Library</a
+						Add a music folder in <a
+							href={resolve('/settings?tab=library')}
+							class="link link-accent">Settings &rarr; Library</a
 						>, then run a scan.
 					</p>
 				</div>

--- a/frontend/src/routes/library/management/+layout.ts
+++ b/frontend/src/routes/library/management/+layout.ts
@@ -1,8 +1,9 @@
+import { resolve } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 
 export const load: LayoutLoad = async ({ parent }) => {
 	const { user } = await parent();
-	if (user?.role !== 'admin') throw redirect(302, '/library');
+	if (user?.role !== 'admin') throw redirect(302, resolve('/library'));
 	return {};
 };

--- a/frontend/src/routes/library/management/+page.svelte
+++ b/frontend/src/routes/library/management/+page.svelte
@@ -215,8 +215,8 @@
 							<p class="text-sm">
 								File organization is paused. Existing catalog data and playback keep working. Enable
 								the library in
-								<a class="link link-primary" href="/settings?tab=library">Settings</a> to run organization
-								again.
+								<a class="link link-primary" href={resolve('/settings?tab=library')}>Settings</a> to run
+								organization again.
 							</p>
 						</div>
 					</div>
@@ -244,8 +244,8 @@
 							<strong>The local library is disabled</strong>
 							<p class="text-sm">
 								Automatic organization is paused. Enable the library in
-								<a class="link link-primary" href="/settings?tab=library">Settings</a> to manage profiles
-								and automation again.
+								<a class="link link-primary" href={resolve('/settings?tab=library')}>Settings</a> to manage
+								profiles and automation again.
 							</p>
 						</div>
 					</div>

--- a/frontend/src/routes/library/management/+page.svelte
+++ b/frontend/src/routes/library/management/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import {
 		ArrowLeft,
 		ArrowUpRight,
@@ -129,7 +130,7 @@
 	>
 		{#snippet title()}Library Management{/snippet}
 		{#snippet actions()}
-			<a href="/library" class="btn btn-ghost btn-sm gap-2 rounded-full sm:btn-md">
+			<a href={resolve('/library')} class="btn btn-ghost btn-sm gap-2 rounded-full sm:btn-md">
 				<ArrowLeft class="h-4 w-4" />
 				<span class="hidden sm:inline">Back to Library</span>
 				<span class="sm:hidden">Library</span>
@@ -189,7 +190,7 @@
 				<Settings2 class="h-4 w-4" />
 				Automation
 			</button>
-			<a role="tab" class={segmentIdle} href="/library/management/history">
+			<a role="tab" class={segmentIdle} href={resolve('/library/management/history')}>
 				<History class="h-4 w-4" />
 				Organization history
 				<ArrowUpRight class="h-3.5 w-3.5 opacity-60" />

--- a/frontend/src/routes/library/navidrome/+page.svelte
+++ b/frontend/src/routes/library/navidrome/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api, ApiError } from '$lib/api/client';
 	import { getSourcePlaylistsQuery } from '$lib/queries/source-playlists/SourcePlaylistQueries.svelte';
@@ -623,9 +624,11 @@
 						index={genericArtistIndex}
 						onselect={(artist) => {
 							if (artist.musicbrainz_id) {
-								goto(`/artist/${artist.musicbrainz_id}`);
+								goto(resolve(`/artist/${artist.musicbrainz_id}`));
 							} else {
-								goto(`/library/navidrome/albums?search=${encodeURIComponent(artist.name)}`);
+								goto(
+									resolve(`/library/navidrome/albums?search=${encodeURIComponent(artist.name)}`)
+								);
 							}
 						}}
 					/>

--- a/frontend/src/routes/library/navidrome/artists/+page.svelte
+++ b/frontend/src/routes/library/navidrome/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import SourceArtistCard from '$lib/components/SourceArtistCard.svelte';
@@ -61,7 +62,7 @@
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
 		<a
-			href="/library/navidrome"
+			href={resolve('/library/navidrome')}
 			class="btn btn-ghost btn-sm gap-1"
 			aria-label="Back to Navidrome library"
 		>

--- a/frontend/src/routes/library/navidrome/tracks/+page.svelte
+++ b/frontend/src/routes/library/navidrome/tracks/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import { buildDiscoveryQueueFromNavidrome } from '$lib/player/queueHelpers';
@@ -140,7 +141,7 @@
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
 		<a
-			href="/library/navidrome"
+			href={resolve('/library/navidrome')}
 			class="btn btn-ghost btn-sm gap-1"
 			aria-label="Back to Navidrome library"
 		>

--- a/frontend/src/routes/library/plex/+page.svelte
+++ b/frontend/src/routes/library/plex/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api, ApiError } from '$lib/api/client';
 	import { getSourcePlaylistsQuery } from '$lib/queries/source-playlists/SourcePlaylistQueries.svelte';
@@ -434,7 +435,7 @@
 					</div>
 					{#if historyTotal > 10}
 						<div class="mt-2 flex gap-2">
-							<a href="/library/plex/activity" class="btn btn-sm btn-outline">
+							<a href={resolve('/library/plex/activity')} class="btn btn-sm btn-outline">
 								View full history and analytics ({historyTotal.toLocaleString()} plays)
 							</a>
 						</div>
@@ -454,9 +455,9 @@
 						index={genericArtistIndex}
 						onselect={(artist) => {
 							if (artist.musicbrainz_id) {
-								goto(`/artist/${artist.musicbrainz_id}`);
+								goto(resolve(`/artist/${artist.musicbrainz_id}`));
 							} else {
-								goto(`/library/plex/artists?search=${encodeURIComponent(artist.name)}`);
+								goto(resolve(`/library/plex/artists?search=${encodeURIComponent(artist.name)}`));
 							}
 						}}
 					/>

--- a/frontend/src/routes/library/plex/activity/+page.svelte
+++ b/frontend/src/routes/library/plex/activity/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import PlexIcon from '$lib/components/PlexIcon.svelte';
@@ -63,7 +64,7 @@
 
 <div class="container mx-auto space-y-6 p-6">
 	<div class="flex items-center gap-3">
-		<a href="/library/plex" class="btn btn-ghost btn-sm">← Back</a>
+		<a href={resolve('/library/plex')} class="btn btn-ghost btn-sm">← Back</a>
 		<PlexIcon class="h-6 w-6" style="color: rgb(var(--brand-plex));" />
 		<h1 class="text-2xl font-bold">Plex activity and analytics</h1>
 	</div>

--- a/frontend/src/routes/library/plex/artists/+page.svelte
+++ b/frontend/src/routes/library/plex/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import SourceArtistCard from '$lib/components/SourceArtistCard.svelte';
@@ -88,7 +89,11 @@
 	<div
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
-		<a href="/library/plex" class="btn btn-ghost btn-sm gap-1" aria-label="Back to Plex library">
+		<a
+			href={resolve('/library/plex')}
+			class="btn btn-ghost btn-sm gap-1"
+			aria-label="Back to Plex library"
+		>
 			<ChevronLeft class="h-4 w-4" />
 			Back
 		</a>

--- a/frontend/src/routes/library/plex/tracks/+page.svelte
+++ b/frontend/src/routes/library/plex/tracks/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
 	import { buildDiscoveryQueueFromPlex } from '$lib/player/queueHelpers';
@@ -190,7 +191,11 @@
 	<div
 		class="mb-6 rounded-xl bg-base-200/30 backdrop-blur-sm border border-base-content/5 px-5 py-4 shadow-sm flex items-center gap-3"
 	>
-		<a href="/library/plex" class="btn btn-ghost btn-sm gap-1" aria-label="Back to Plex library">
+		<a
+			href={resolve('/library/plex')}
+			class="btn btn-ghost btn-sm gap-1"
+			aria-label="Back to Plex library"
+		>
 			<ChevronLeft class="h-4 w-4" />
 			Back
 		</a>

--- a/frontend/src/routes/library/review/+page.ts
+++ b/frontend/src/routes/library/review/+page.ts
@@ -1,8 +1,9 @@
+import { resolve } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
 	const { user } = await parent();
-	if (user?.role !== 'admin') throw redirect(302, '/library');
+	if (user?.role !== 'admin') throw redirect(302, resolve('/library'));
 	return {};
 };

--- a/frontend/src/routes/library/tracks/+page.svelte
+++ b/frontend/src/routes/library/tracks/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { API } from '$lib/constants';
 	import { api } from '$lib/api/client';
@@ -148,7 +149,7 @@
 	<div class="flex items-center gap-4 mb-6">
 		<button
 			class="btn btn-ghost btn-circle"
-			onclick={() => goto('/library')}
+			onclick={() => goto(resolve('/library'))}
 			aria-label="Back to library"
 		>
 			<ChevronLeft class="w-6 h-6" />

--- a/frontend/src/routes/library/unmatched/+page.svelte
+++ b/frontend/src/routes/library/unmatched/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onMount } from 'svelte';
 
-	onMount(() => void goto('/library/review', { replaceState: true }));
+	onMount(() => void goto(resolve('/library/review'), { replaceState: true }));
 </script>
 
 <svelte:head><title>Identification review · DroppedNeedle</title></svelte:head>

--- a/frontend/src/routes/library/unmatched/+page.ts
+++ b/frontend/src/routes/library/unmatched/+page.ts
@@ -1,10 +1,11 @@
+import { resolve } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
 	const { user } = await parent();
 	if (user?.role !== 'admin') {
-		throw redirect(302, '/library');
+		throw redirect(302, resolve('/library'));
 	}
 	return {};
 };

--- a/frontend/src/routes/library/youtube/+page.svelte
+++ b/frontend/src/routes/library/youtube/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount } from 'svelte';
 	import { API } from '$lib/constants';
 	import { integrationStore } from '$lib/stores/integration';
@@ -169,7 +170,7 @@
 		<div class="alert alert-warning mb-4">
 			<Info class="h-4 w-4" />
 			<span
-				>YouTube is not enabled. <a href="/settings?tab=youtube" class="link"
+				>YouTube is not enabled. <a href={resolve('/settings?tab=youtube')} class="link"
 					>Enable it in settings</a
 				> to use YouTube features.</span
 			>
@@ -179,7 +180,7 @@
 			<Info class="h-4 w-4" />
 			<span
 				>YouTube API is not configured. You can add links manually, or <a
-					href="/settings?tab=youtube"
+					href={resolve('/settings?tab=youtube')}
 					class="link">enable the API in settings</a
 				> for auto-generation.</span
 			>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../../auth.css';
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { api, ApiError } from '$lib/api/client';
@@ -73,7 +74,7 @@
 
 	function storeSession(data: AuthSessionResponse) {
 		authStore.setUser(toAuthUser(data.user));
-		goto('/');
+		goto(resolve('/'));
 	}
 
 	async function handleLocalLogin() {

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -226,7 +226,10 @@
 								</button>
 							</label>
 							<div class="mt-1 flex justify-end">
-								<a href="/recover-password" class="link link-primary text-xs font-medium">
+								<a
+									href={resolve('/recover-password')}
+									class="link link-primary text-xs font-medium"
+								>
 									Forgot password?
 								</a>
 							</div>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import '../../auth.css';
-	import { resolve } from '$app/paths';
+	import { base, resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { api, ApiError } from '$lib/api/client';
@@ -146,7 +146,7 @@
 <div class="login-wrap grain min-h-screen flex items-center justify-center p-4">
 	<div class="w-full max-w-md">
 		<div class="login-brand">
-			<img src="/logo_icon.png" alt="" aria-hidden="true" class="login-mark" />
+			<img src="{base}/logo_icon.png" alt="" aria-hidden="true" class="login-mark" />
 			<h1 class="login-wordmark">DroppedNeedle</h1>
 			<div class="login-rule" aria-hidden="true"></div>
 			<p class="login-sub">Sign in to continue</p>

--- a/frontend/src/routes/playlists/+page.svelte
+++ b/frontend/src/routes/playlists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import {
 		isRedactedPlaylist,
@@ -61,7 +62,7 @@
 			const created = await createMutation.mutateAsync(trimmed);
 			newName = '';
 			showNewInput = false;
-			await goto(`/playlists/${created.id}`);
+			await goto(resolve(`/playlists/${created.id}`));
 		} catch (_e) {
 			toastStore.show({ message: "Couldn't create the playlist", type: 'error' });
 		}
@@ -90,7 +91,7 @@
 		<div class="flex items-center gap-2">
 			{#if spotifyLinked}
 				<a
-					href="/playlists/spotify"
+					href={resolve('/playlists/spotify')}
 					class="btn btn-sm gap-1.5 bg-green-600 text-white hover:bg-green-500"
 				>
 					<SpotifyIcon class="h-3.5 w-3.5" />

--- a/frontend/src/routes/playlists/[id]/+error.svelte
+++ b/frontend/src/routes/playlists/[id]/+error.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { Music, ArrowLeft } from 'lucide-svelte';
 	import { page } from '$app/state';
 </script>
@@ -18,7 +19,7 @@
 			{/if}
 		</p>
 		<div class="flex items-center gap-2">
-			<a href="/playlists" class="btn btn-ghost btn-sm">
+			<a href={resolve('/playlists')} class="btn btn-ghost btn-sm">
 				<ArrowLeft class="h-4 w-4" />
 				Back to Playlists
 			</a>

--- a/frontend/src/routes/playlists/[id]/+page.svelte
+++ b/frontend/src/routes/playlists/[id]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { onDestroy, untrack } from 'svelte';
 	import { SvelteSet } from 'svelte/reactivity';
@@ -244,7 +245,7 @@
 				queryKey: PlaylistQueryKeyFactory.list(authStore.user?.id)
 			});
 			toastStore.show({ message: 'Playlist deleted', type: 'success' });
-			await goto('/playlists');
+			await goto(resolve('/playlists'));
 		} catch {
 			toastStore.show({ message: "Couldn't delete the playlist", type: 'error' });
 		} finally {

--- a/frontend/src/routes/playlists/[id]/PlaylistTrackList.svelte
+++ b/frontend/src/routes/playlists/[id]/PlaylistTrackList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { tick } from 'svelte';
 	import { slide, fly } from 'svelte/transition';
 	import {
@@ -445,7 +446,7 @@
 					<div class="flex-1 min-w-0">
 						{#if track.album_id}
 							<a
-								href="/album/{track.album_id}"
+								href={resolve(`/album/${track.album_id}`)}
 								class="font-medium truncate text-sm block hover:underline {isCurrentlyPlaying
 									? 'text-accent'
 									: ''}">{track.track_name}</a
@@ -458,15 +459,18 @@
 						{/if}
 						<span class="text-xs text-base-content/60 truncate block">
 							{#if track.artist_id}
-								<a href="/artist/{track.artist_id}" class="hover:underline">{track.artist_name}</a>
+								<a href={resolve(`/artist/${track.artist_id}`)} class="hover:underline"
+									>{track.artist_name}</a
+								>
 							{:else}
 								{track.artist_name}
 							{/if}
 							{#if track.album_name}
 								<span class="text-base-content/30"> · </span>
 								{#if track.album_id}
-									<a href="/album/{track.album_id}" class="text-base-content/40 hover:underline"
-										>{track.album_name}</a
+									<a
+										href={resolve(`/album/${track.album_id}`)}
+										class="text-base-content/40 hover:underline">{track.album_name}</a
 									>
 								{:else}
 									<span class="text-base-content/40">{track.album_name}</span>

--- a/frontend/src/routes/playlists/spotify/+page.svelte
+++ b/frontend/src/routes/playlists/spotify/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { Loader2, Music2, ArrowLeft, RefreshCw, CheckCircle2, Download } from 'lucide-svelte';
 	import SpotifyIcon from '$lib/components/SpotifyIcon.svelte';
@@ -25,7 +26,7 @@
 				message: `"${playlist.name}" is importing in the background`,
 				type: 'success'
 			});
-			await goto(`/playlists/${result.playlist_id}`);
+			await goto(resolve(`/playlists/${result.playlist_id}`));
 		} catch {
 			toastStore.show({ message: `Failed to import "${playlist.name}"`, type: 'error' });
 		} finally {
@@ -81,7 +82,7 @@
 
 <div class="space-y-6 px-4 sm:px-6 lg:px-8">
 	<div class="flex items-center gap-3">
-		<a href="/playlists" class="btn btn-ghost btn-sm btn-circle">
+		<a href={resolve('/playlists')} class="btn btn-ghost btn-sm btn-circle">
 			<ArrowLeft class="h-4 w-4" />
 		</a>
 		<h1 class="flex min-w-0 flex-1 items-center gap-2 text-2xl font-bold sm:text-3xl">
@@ -121,7 +122,7 @@
 			</span>
 			<div class="flex gap-2">
 				{#if err instanceof Error && err.message.includes('400')}
-					<a href="/profile" class="btn btn-sm btn-ghost">Go to Profile</a>
+					<a href={resolve('/profile')} class="btn btn-sm btn-ghost">Go to Profile</a>
 				{:else}
 					<button class="btn btn-sm btn-ghost" onclick={() => void playlistsQuery.refetch()}>
 						Retry
@@ -158,7 +159,7 @@
 								class="absolute inset-0 flex flex-col items-center justify-center gap-2 bg-black/60 opacity-0 transition-opacity group-hover:opacity-100"
 							>
 								<a
-									href="/playlists/{playlist.imported_playlist_id}"
+									href={resolve(`/playlists/${playlist.imported_playlist_id}`)}
 									class="btn btn-sm btn-ghost rounded-full text-white"
 								>
 									View Playlist

--- a/frontend/src/routes/profile/+page.svelte
+++ b/frontend/src/routes/profile/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { ApiError } from '$lib/api/client';
 	import {
 		UserRound,
@@ -856,7 +857,7 @@
 
 				<section class="flex justify-center gap-3 pt-2 xl:ml-40">
 					<a
-						href="/settings"
+						href={resolve('/settings')}
 						class="btn btn-outline btn-sm gap-2 rounded-full border-base-content/20 text-base-content/60 transition-all hover:border-primary hover:text-primary"
 					>
 						<Settings class="h-4 w-4" />

--- a/frontend/src/routes/recover-password/+page.svelte
+++ b/frontend/src/routes/recover-password/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import '../../auth.css';
-	import { resolve } from '$app/paths';
+	import { base, resolve } from '$app/paths';
 	import { ApiError } from '$lib/api/client';
 	import { createPasswordRecoveryResetMutation } from '$lib/queries/auth/AuthMutations.svelte';
 	import {
@@ -88,7 +88,7 @@
 <div class="recovery-wrap grain min-h-screen flex items-center justify-center p-4 py-10">
 	<div class="w-full max-w-lg">
 		<div class="recovery-brand">
-			<img src="/logo_icon.png" alt="" aria-hidden="true" class="recovery-mark" />
+			<img src="{base}/logo_icon.png" alt="" aria-hidden="true" class="recovery-mark" />
 			<h1 class="recovery-wordmark">DroppedNeedle</h1>
 			<div class="recovery-rule" aria-hidden="true"></div>
 			<p class="recovery-kicker">Account recovery</p>

--- a/frontend/src/routes/recover-password/+page.svelte
+++ b/frontend/src/routes/recover-password/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../../auth.css';
+	import { resolve } from '$app/paths';
 	import { ApiError } from '$lib/api/client';
 	import { createPasswordRecoveryResetMutation } from '$lib/queries/auth/AuthMutations.svelte';
 	import {
@@ -110,7 +111,9 @@
 						Connect Apps passwords were not changed. Review them after signing in if you suspect
 						that someone accessed your account.
 					</p>
-					<a href="/login" class="btn btn-primary mt-7 w-full sm:w-auto">Return to sign in</a>
+					<a href={resolve('/login')} class="btn btn-primary mt-7 w-full sm:w-auto"
+						>Return to sign in</a
+					>
 				</div>
 			{:else}
 				<div class="border-b border-base-300 p-6 sm:p-7">
@@ -263,7 +266,7 @@
 		{/if}
 
 		<a
-			href="/login"
+			href={resolve('/login')}
 			class="mx-auto mt-5 flex w-fit items-center gap-2 text-sm text-base-content/50 hover:text-primary"
 		>
 			<ArrowLeft class="h-4 w-4" aria-hidden="true" /> Back to sign in

--- a/frontend/src/routes/requests/+page.svelte
+++ b/frontend/src/routes/requests/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onMount, onDestroy, untrack } from 'svelte';
 	import { SvelteMap } from 'svelte/reactivity';
 	import { page } from '$app/state';
@@ -1041,7 +1042,7 @@
 						your quality cutoff.
 					</p>
 					{#if authStore.isAdmin}
-						<a href="/settings?tab=download-client" class="btn btn-sm btn-primary mt-4">
+						<a href={resolve('/settings?tab=download-client')} class="btn btn-sm btn-primary mt-4">
 							Open download settings
 						</a>
 					{/if}
@@ -1086,7 +1087,7 @@
 							</div>
 							<div class="flex-1 min-w-0">
 								<a
-									href="/album/{item.release_group_mbid}"
+									href={resolve(`/album/${item.release_group_mbid}`)}
 									class="block font-semibold text-sm truncate hover:text-accent hover:underline"
 								>
 									{item.album_title ?? 'Unknown album'}
@@ -1185,7 +1186,7 @@
 							</div>
 							<div class="flex-1 min-w-0">
 								<a
-									href="/artist/{item.artist_mbid}"
+									href={resolve(`/artist/${item.artist_mbid}`)}
 									class="block font-semibold text-sm truncate hover:text-accent hover:underline"
 									title={item.artist_name}>{item.artist_name}</a
 								>

--- a/frontend/src/routes/search/+page.svelte
+++ b/frontend/src/routes/search/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { onDestroy } from 'svelte';
 	import { goto } from '$app/navigation';
 	import AlbumCard from '$lib/components/AlbumCard.svelte';
@@ -95,7 +96,7 @@
 
 	function navigateToBucket(bucket: 'artists' | 'albums') {
 		if (data.query) {
-			goto(`/search/${bucket}?q=${encodeURIComponent(data.query)}`);
+			goto(resolve(`/search/${bucket}?q=${encodeURIComponent(data.query)}`));
 		}
 	}
 

--- a/frontend/src/routes/search/albums/+page.svelte
+++ b/frontend/src/routes/search/albums/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { run } from 'svelte/legacy';
 
 	import { onDestroy, onMount } from 'svelte';
@@ -37,13 +38,13 @@
 
 	function navigateBack() {
 		if (data.query) {
-			goto(`/search?q=${encodeURIComponent(data.query)}`);
+			goto(resolve(`/search?q=${encodeURIComponent(data.query)}`));
 		}
 	}
 
 	function navigateToBucket(bucket: 'artists') {
 		if (data.query) {
-			goto(`/search/${bucket}?q=${encodeURIComponent(data.query)}`);
+			goto(resolve(`/search/${bucket}?q=${encodeURIComponent(data.query)}`));
 		}
 	}
 

--- a/frontend/src/routes/search/artists/+page.svelte
+++ b/frontend/src/routes/search/artists/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { resolve } from '$app/paths';
 	import { run } from 'svelte/legacy';
 
 	import { onDestroy, onMount } from 'svelte';
@@ -35,13 +36,13 @@
 
 	function navigateBack() {
 		if (data.query) {
-			goto(`/search?q=${encodeURIComponent(data.query)}`);
+			goto(resolve(`/search?q=${encodeURIComponent(data.query)}`));
 		}
 	}
 
 	function navigateToBucket(bucket: 'albums') {
 		if (data.query) {
-			goto(`/search/${bucket}?q=${encodeURIComponent(data.query)}`);
+			goto(resolve(`/search/${bucket}?q=${encodeURIComponent(data.query)}`));
 		}
 	}
 

--- a/frontend/src/routes/settings/+layout.ts
+++ b/frontend/src/routes/settings/+layout.ts
@@ -1,3 +1,4 @@
+import { resolve } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 
@@ -6,6 +7,6 @@ export const ssr = false;
 export const load: LayoutLoad = async ({ parent }) => {
 	const { user } = await parent();
 	if (user?.role !== 'admin') {
-		throw redirect(302, '/');
+		throw redirect(302, resolve('/'));
 	}
 };

--- a/frontend/src/routes/settings/library/+page.ts
+++ b/frontend/src/routes/settings/library/+page.ts
@@ -1,3 +1,4 @@
+import { resolve } from '$app/paths';
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
@@ -5,7 +6,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const { user } = await parent();
 	if (user?.role !== 'admin') {
-		throw redirect(302, '/');
+		throw redirect(302, resolve('/'));
 	}
-	throw redirect(307, '/settings?tab=library');
+	throw redirect(307, resolve('/settings?tab=library'));
 };

--- a/frontend/src/routes/setup/+page.svelte
+++ b/frontend/src/routes/setup/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import '../../auth.css';
+	import { resolve } from '$app/paths';
 	import { goto } from '$app/navigation';
 	import { authStore } from '$lib/stores/authStore.svelte';
 	import { ApiError } from '$lib/api/client';
@@ -36,7 +37,7 @@
 			});
 			authStore.setUser(toAuthUser(data.user));
 			authStore.setSetupRequired(false);
-			goto('/');
+			goto(resolve('/'));
 		} catch (e) {
 			error =
 				e instanceof ApiError ? e.message : 'Could not reach the server. Is DroppedNeedle running?';

--- a/frontend/svelte.config.js
+++ b/frontend/svelte.config.js
@@ -1,6 +1,13 @@
 import adapter from '@sveltejs/adapter-static';
 import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
+// SvelteKit requires base to start with `/` and not end with one; empty = domain root.
+function normalizeBase(value) {
+	const trimmed = (value ?? '').trim().replace(/\/+$/, '');
+	if (!trimmed) return '';
+	return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+}
+
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
 	preprocess: vitePreprocess(),
@@ -13,7 +20,7 @@ const config = {
 			precompress: true
 		}),
 		paths: {
-			base: ''
+			base: normalizeBase(process.env.BASE_PATH)
 		},
 		appDir: '_app'
 	}


### PR DESCRIPTION
## What

Resolves #176 
Add a BASE_PATH setting so DroppedNeedle can be served under a subpath (e.g. /droppedneedle) behind a reverse proxy instead of only at the domain root. Empty/unset (the default) serves at the root exactly as before.

The SvelteKit static build bakes paths.base at build time, so the image builds the frontend with a placeholder token that the entrypoint rewrites to the runtime BASE_PATH; a single prebuilt image works at any subpath with no rebuild. All in-app links, goto() calls, API/EventSource URLs and browser-facing redirects are made base-aware (no-ops when the base is empty). The backend sets FastAPI root_path so generated URLs (docs, OAuth redirect URIs) carry the prefix. The proxy is expected to forward the subpath stripped.

## Why

I filed #176 because I believe this to be a basic and necessary feature for any self-hosted service.
If that opinion isn't enough, I'll go with "Lidarr can do it, so this helps DroppedNeedle be a Lidarr replacement"

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

## AI-Assisted Contributions

> If any part of this PR was generated or assisted by AI (Copilot, ChatGPT, etc.), please describe which sections and how the AI was used. See `CONTRIBUTING.md` for the full policy.

Claude helped self-review code for avoiding missed responses

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`)
- [x] Frontend lint passes (`make frontend-lint`)
- [x] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source
