### PR TITLE
feat(naming): add {initial} variable for first-letter artist buckets

### DIFF
--- a/backend/services/native/naming.py
+++ b/backend/services/native/naming.py
@@ -52,6 +52,8 @@ class NamingTemplateEngine:
     _TOKEN = re.compile(r"(\{[^}]+\})")
     # FS-reserved chars plus all C0 control characters and DEL.
     _INVALID_FS_CHARS = re.compile(r'[<>:"/\\|?*\x00-\x1f\x7f]')
+    # Leading "The " article for {initial} — any whitespace after "the".
+    _LEADING_THE = re.compile(r"the\s+", re.IGNORECASE)
 
     def format_path(self, template: str, tag: AudioTag, ext: str) -> Path:
         return self._normalize(self._render(template, tag, ext))
@@ -127,8 +129,8 @@ class NamingTemplateEngine:
             case _:
                 return ""  # unknown variable renders empty (lenient; validate_template is strict)
 
-    @staticmethod
-    def _initial(album_artist: str) -> str:
+    @classmethod
+    def _initial(cls, album_artist: str) -> str:
         """First-letter bucket for {initial}: 'The National' -> 'N', '2 Chainz' -> '#'.
 
         A leading "The " is ignored, the first character is uppercased
@@ -136,8 +138,9 @@ class NamingTemplateEngine:
         anything non-alphabetic buckets under '#'.
         """
         name = album_artist.strip()
-        if name[:4].lower() == "the ":
-            name = name[4:].strip()
+        article = cls._LEADING_THE.match(name)
+        if article:
+            name = name[article.end() :].strip()
         if not name:
             return "#"
         first = name[0]

--- a/backend/services/native/naming.py
+++ b/backend/services/native/naming.py
@@ -37,6 +37,7 @@ class NamingTemplateEngine:
             "artist",
             "album",
             "albumartist",
+            "initial",
             "year",
             "title",
             "ext",
@@ -103,6 +104,8 @@ class NamingTemplateEngine:
                 return tag.album
             case "albumartist":
                 return tag.album_artist or tag.artist
+            case "initial":
+                return self._initial(tag.album_artist or tag.artist)
             case "year":
                 return str(tag.year) if tag.year else ""
             case "title":
@@ -123,6 +126,22 @@ class NamingTemplateEngine:
                 return tag.musicbrainz_artist_id or ""
             case _:
                 return ""  # unknown variable renders empty (lenient; validate_template is strict)
+
+    @staticmethod
+    def _initial(album_artist: str) -> str:
+        """First-letter bucket for {initial}: 'The National' -> 'N', '2 Chainz' -> '#'.
+
+        A leading "The " is ignored, the first character is uppercased
+        (Unicode-aware, so accented/CJK letters keep their own bucket), and
+        anything non-alphabetic buckets under '#'.
+        """
+        name = album_artist.strip()
+        if name[:4].lower() == "the ":
+            name = name[4:].strip()
+        if not name:
+            return "#"
+        first = name[0]
+        return first.upper() if first.isalpha() else "#"
 
     def _normalize(self, path: Path) -> Path:
         parts: list[str] = []

--- a/backend/tests/services/test_naming_template_engine.py
+++ b/backend/tests/services/test_naming_template_engine.py
@@ -71,6 +71,39 @@ def test_genre_variable(engine):
     assert result == Path("Jazz")
 
 
+@pytest.mark.parametrize(
+    ("album_artist", "expected"),
+    [
+        ("Radiohead", "R"),
+        ("The National", "N"),  # leading "The " ignored
+        ("the xx", "X"),  # case-insensitive "the", result uppercased
+        ("t0ni", "T"),  # lowercase first letter uppercased
+        ("2 Chainz", "#"),  # digit lead -> '#'
+        ("_m0lly", "#"),  # punctuation lead -> '#'
+        ("Öxxö Xööx", "Ö"),  # accented letters keep their own bucket
+        ("高橋洋子", "高"),  # CJK letters keep their own bucket
+        ("The", "T"),  # bare "The" is a name, not an article
+    ],
+)
+def test_initial_variable_buckets(engine, album_artist, expected):
+    result = engine.format_path("{initial}", _tag(album_artist=album_artist), "flac")
+    assert result == Path(expected)
+
+
+def test_initial_falls_back_to_artist(engine):
+    result = engine.format_path("{initial}", _tag(album_artist=None), "flac")
+    assert result == Path("R")  # artist "Radiohead"
+
+
+def test_initial_empty_artist_buckets_under_hash(engine):
+    result = engine.format_path("{initial}/x.{ext}", _tag(album_artist=None, artist=""), "flac")
+    assert result == Path("#/x.flac")
+
+
+def test_validate_template_accepts_initial(engine):
+    assert engine.validate_template("{initial}/{albumartist}/{album}.{ext}") == []
+
+
 def test_medium_variable_is_empty(engine):
     result = engine.format_path("x{medium}y", _tag(), "flac")
     assert result == Path("xy")

--- a/backend/tests/services/test_naming_template_engine.py
+++ b/backend/tests/services/test_naming_template_engine.py
@@ -76,6 +76,8 @@ def test_genre_variable(engine):
     [
         ("Radiohead", "R"),
         ("The National", "N"),  # leading "The " ignored
+        ("The\tNational", "N"),  # any whitespace after "The", not just a space
+        ("The  Doors", "D"),  # multiple spaces after "The"
         ("the xx", "X"),  # case-insensitive "the", result uppercased
         ("t0ni", "T"),  # lowercase first letter uppercased
         ("2 Chainz", "#"),  # digit lead -> '#'

--- a/frontend/src/lib/components/library/LibraryNamingPreview.svelte
+++ b/frontend/src/lib/components/library/LibraryNamingPreview.svelte
@@ -11,6 +11,7 @@
 		artist: 'Radiohead',
 		album: 'OK Computer',
 		albumartist: 'Radiohead',
+		initial: 'R',
 		year: 1997,
 		track: 2,
 		title: 'Paranoid Android',

--- a/frontend/src/lib/components/settings/SettingsLibrary.svelte
+++ b/frontend/src/lib/components/settings/SettingsLibrary.svelte
@@ -128,7 +128,9 @@
 		<section class="space-y-2">
 			<h3 class="font-semibold">Naming template</h3>
 			<p class="text-xs text-base-content/60">
-				Applies to downloaded imports only. Variables: {'{albumartist} {album} {year} {disc} {track} {title} {ext}'}.
+				Applies to downloaded imports only. Variables: {'{initial} {artist} {albumartist} {album} {year} {disc} {track} {title} {genre} {ext}'}.
+				{'{initial}'} is the album artist's first letter (ignoring a leading "The"; # for digits
+				and symbols), for letter-bucketed libraries.
 			</p>
 			<input
 				class="input input-bordered w-full font-mono text-sm"


### PR DESCRIPTION
## What

Adds an `{initial}` naming-template variable that renders the album artist's first-letter bucket: `The National` → `N`, `t0ni` → `T`, `2 Chainz` → `#`.

Rules:
- A leading `"The "` is ignored (case-insensitive): `The National` buckets under `N`.
- The first remaining character is uppercased.
- Non-alphabetic leads (digits, punctuation) bucket under `#`.
- Unicode-aware via `str.isalpha()`, so accented/CJK letters keep their own bucket (`Öxxö Xööx` → `Ö`, `高橋洋子` → `高`) — consistent with the engine's existing no-transliteration stance.
- Empty/missing artist falls back to `#` (then the existing normalisation applies).

Like `{albumartist}`, it prefers `album_artist` and falls back to `artist`.

## Why

Many existing libraries shard artists into first-letter directories (`A/`, `B/`, …, `#/`) to keep top-level directory listings manageable. The naming engine can reproduce every part of such a layout except that top-level bucket, because no variable derives the first letter from the artist. This adds that one missing primitive, e.g.:

```
{initial}/{albumartist}/{year} -- {album}/{track:02d}. {title}.{ext}
→ L/Leonard Cohen/1968 -- Songs of Leonard Cohen/03. Winter Lady.flac
→ #/2 Chainz/…
```

Backward compatible: `DEFAULT` is unchanged, and `validate_template` accepts the new variable automatically since it checks `_VARIABLES`. The settings help text and the client-side preview sample are updated to match.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

12 new tests: parameterized bucket cases (leading "The", lowercase, digit/punctuation leads, accented + CJK, bare "The" as a name), albumartist→artist fallback, empty-artist `#` bucket, and `validate_template` acceptance. Full backend suite: 4253 passed, 3 skipped.

## AI-Assisted Contributions

This PR was written with Claude Code (implementation, tests, and this description). The bucketing rules were derived from and verified against a real ~30k-file letter-bucketed library; I reviewed and ran everything locally.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`)
- [x] Frontend lint passes (`make frontend-lint`)
- [x] Frontend type check passes (`make frontend-check`)
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts (n/a — no API calls added)
- [x] New msgspec structs follow existing patterns (n/a — none added)
- [x] TanStack Query used for all new data fetching (n/a — no data fetching added)
- [x] No secrets, tokens, or credentials in source
