### PR TITLE
fix(subsonic): treat a quoted empty search3 query as match-all so Symfonium can sync

### DIFF
--- a/backend/api/compat/subsonic/router.py
+++ b/backend/api/compat/subsonic/router.py
@@ -348,8 +348,13 @@ async def _get_music_directory(c: Ctx) -> Response:
 
 async def _search(c: Ctx):
     # missing/empty query means "match everything", matching Navidrome/gonic (clients
-    # like Arpeggi rely on this for their "all songs" view)
-    q = c.p("query") or None
+    # like Arpeggi rely on this for their "all songs" view). Symfonium sends the query
+    # wrapped in literal double quotes (`query=""` for its full-library sync), so strip
+    # a surrounding quote pair first, like Navidrome does.
+    q = c.p("query") or ""
+    if len(q) >= 2 and q.startswith('"') and q.endswith('"'):
+        q = q[1:-1]
+    q = q or None
     a_count = max(c.pint("artistCount", 20) or 0, 0)
     a_offset = max(c.pint("artistOffset", 0) or 0, 0)
     al_count = max(c.pint("albumCount", 20) or 0, 0)

--- a/backend/tests/compat/test_subsonic_search_cover.py
+++ b/backend/tests/compat/test_subsonic_search_cover.py
@@ -40,6 +40,19 @@ async def test_search3_missing_query_pages_everything(compat_env):
     assert len(res["song"]) == 2
 
 
+async def test_search3_quoted_empty_query_pages_everything(compat_env):
+    # Symfonium's full-library sync sends the query as two literal double-quote
+    # characters (query=""); it must page everything like an empty query, otherwise
+    # Symfonium syncs an empty library. Navidrome strips the quote pair the same way.
+    res = _sub(_get(compat_env, "search3", query='""', songCount="100"))["searchResult3"]
+    assert len(res["song"]) == 2
+
+
+async def test_search3_quoted_query_matches_unquoted(compat_env):
+    res = _sub(_get(compat_env, "search3", query='"Radiohead"'))["searchResult3"]
+    assert any(a["name"] == "Radiohead" for a in res.get("artist", []))
+
+
 async def test_search2_file_structure(compat_env):
     res = _sub(_get(compat_env, "search2", query=""))["searchResult2"]
     assert res["album"][0]["isDir"] is True


### PR DESCRIPTION

## Problem

Symfonium performs its full-library sync by calling `search3` with the query set to **two literal double-quote characters** (`query=%22%22`), paging artists, albums, and songs with empty-query searches. DroppedNeedle's `_search` only special-cases a *missing or empty* `query` param as "match everything", so the two quote characters are searched literally, match nothing, and every sync page comes back empty:

```
GET /subsonic/rest/search3.view?query=%22%22&songOffset=0&songCount=500&...&c=Symfonium  → 200
{"searchResult3": {"artist": [], "album": [], "song": []}}
```

The result is that Symfonium connects successfully, syncs, and shows a completely empty library even though `getArtists`/`getAlbumList2` return the full library. Other Subsonic servers have hit this same client behavior (gonic sentriz/gonic#229, Navidrome navidrome/navidrome#2862); Navidrome handles it by stripping a surrounding double-quote pair from the query.

## Fix

Strip one surrounding pair of double quotes from the query in `_search` before the existing emptiness check, matching Navidrome's behavior. This fixes both `search3` and `search2`, and also makes quoted searches (`query="Radiohead"`) behave like their unquoted equivalent.

## Testing

- Two new tests in `tests/compat/test_subsonic_search_cover.py`:
  - `test_search3_quoted_empty_query_pages_everything` — the Symfonium sync shape (`query=""` + `songCount`)
  - `test_search3_quoted_query_matches_unquoted`
- Full compat suite passes on `python:3.13-slim` (matching the Dockerfile): **277 passed, 2 skipped**
- Verified against a live instance: replaying Symfonium's exact sync request returned an empty `searchResult3` before the fix while `getArtists` showed indexed music; after the fix Symfonium's compatibility-mode-free sync works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
