### PR TITLE
fix(downloads): stop partially-failed slskd albums closing as completed

### DIFF
--- a/backend/repositories/protocols/download_client.py
+++ b/backend/repositories/protocols/download_client.py
@@ -84,19 +84,19 @@ class DownloadTaskStatus(AppStruct):
     bytes_downloaded: int = 0
     progress_percent: float = 0.0
     error: str | None = None
-    # Filenames whose transfer has succeeded so far. Lets the orchestrator import
-    # the already-finished subset of a stalled task without touching files that
-    # never arrived (which would otherwise be quarantined as verify failures).
+    # Filenames whose LATEST transfer attempt succeeded (retries deduped). The
+    # orchestrator imports ONLY these - a never-finished file must not reach the
+    # verify/import phase, where it could only be quarantined or logged as missing.
     succeeded_filenames: list[str] = []
     # True when at least one non-terminal transfer is actively connecting or
     # moving bytes (vs. sitting in the peer's remote upload queue). The stall
     # watchdog uses this to pick the active-stall timeout vs the queued timeout.
     has_active_transfer: bool = False
-    # Number of slskd transfer records matched to this task. 0 means the enqueue
-    # produced nothing (peer offline / silently rejected) - distinct from a real
-    # transfer sitting queued in the peer's upload queue, which has a record. Lets
-    # the orchestrator fail a no-show enqueue over fast instead of waiting out the
-    # full queued timeout for a transfer that never existed.
+    # Number of FILES with a matched transfer record (retries deduped, like every
+    # tally here). 0 means the enqueue produced nothing (peer offline / silently
+    # rejected) - distinct from a real transfer queued at the peer, which has a
+    # record. Lets the orchestrator fail a no-show enqueue over fast instead of
+    # waiting out the full queued timeout for a transfer that never existed.
     matched_transfers: int = 0
 
 

--- a/backend/repositories/slskd/slskd_models.py
+++ b/backend/repositories/slskd/slskd_models.py
@@ -74,6 +74,9 @@ class SlskdTransfer(msgspec.Struct, rename="camel", kw_only=True):
     direction: str = ""
     place_in_queue: int | None = None
     exception: str | None = None
+    # slskd keeps one transfer record per ATTEMPT; this orders a retried file's
+    # records so status is judged on the latest attempt only.
+    requested_at: str | None = None
 
 
 class SlskdDirectories(msgspec.Struct, kw_only=True):

--- a/backend/repositories/slskd/slskd_repository.py
+++ b/backend/repositories/slskd/slskd_repository.py
@@ -47,10 +47,10 @@ class SlskdRepository:
     _DIAGNOSIS_SAMPLE = 3
     # Mount-top dirs that never hold a FINISHED download: slskd's staging dir (a hit
     # there is a partial file - e.g. a "Completed, TimedOut" leftover) and the
-    # failed-import quarantine. Both grow unboundedly (2,330 dead files on one live
-    # mount, 2026-07-18) and would eat the walk budget. Pruned at the mount root
-    # ONLY, where both are created by configuration - deeper dirs with these names
-    # are peer-chosen album folders that may hold the very file being searched for.
+    # failed-import quarantine. Both grow unboundedly and would eat the walk budget.
+    # Pruned at the mount root ONLY, where both are created by configuration - deeper
+    # dirs with these names are peer-chosen album folders that may hold the very file
+    # being searched for.
     _EXCLUDED_MOUNT_DIRS = frozenset({"incomplete", "failed_imports"})
     # Whole-mount fallback only (step 6): it must cover the entire mount, runs in a
     # worker thread, and a busy mount easily exceeds the 10k scoped-walk backstop.
@@ -614,11 +614,11 @@ class SlskdRepository:
         transfers: list[SlskdTransfer],
     ) -> list[SlskdTransfer]:
         """One record per FILE, judged on the latest attempt: slskd keeps a record
-        per ATTEMPT, so counting per record let a stale ``Succeeded`` shadow a final
-        ``TimedOut`` and pushed ``files_completed`` past ``files_total`` (39/29,
-        2026-07-18 incident - the file was lost but read as delivered). Ordered by
-        ``requestedAt`` when both records carry one, else by record order (slskd
-        appends) - a lone timestamp must not outrank a later untimestamped retry."""
+        per ATTEMPT, so counting per record lets a stale ``Succeeded`` shadow a final
+        ``TimedOut`` and push ``files_completed`` past ``files_total`` - a lost file
+        read as delivered. Ordered by ``requestedAt`` when both records carry one,
+        else by record order (slskd appends) - a lone timestamp must not outrank a
+        later untimestamped retry."""
         latest: dict[str, tuple[str | None, SlskdTransfer]] = {}
         for transfer in transfers:
             prev = latest.get(transfer.filename)

--- a/backend/repositories/slskd/slskd_repository.py
+++ b/backend/repositories/slskd/slskd_repository.py
@@ -48,7 +48,9 @@ class SlskdRepository:
     # Mount-top dirs that never hold a FINISHED download: slskd's staging dir (a hit
     # there is a partial file - e.g. a "Completed, TimedOut" leftover) and the
     # failed-import quarantine. Both grow unboundedly (2,330 dead files on one live
-    # mount, 2026-07-18) and would eat the walk budget.
+    # mount, 2026-07-18) and would eat the walk budget. Pruned at the mount root
+    # ONLY, where both are created by configuration - deeper dirs with these names
+    # are peer-chosen album folders that may hold the very file being searched for.
     _EXCLUDED_MOUNT_DIRS = frozenset({"incomplete", "failed_imports"})
     # Whole-mount fallback only (step 6): it must cover the entire mount, runs in a
     # worker thread, and a busy mount easily exceeds the 10k scoped-walk backstop.
@@ -608,7 +610,9 @@ class SlskdRepository:
         return [f for f in requested if f not in failed] if failed else requested
 
     @staticmethod
-    def _latest_transfer_per_file(transfers: list[SlskdTransfer]) -> list[SlskdTransfer]:
+    def _latest_transfer_per_file(
+        transfers: list[SlskdTransfer],
+    ) -> list[SlskdTransfer]:
         """One record per FILE, judged on the latest attempt: slskd keeps a record
         per ATTEMPT, so counting per record let a stale ``Succeeded`` shadow a final
         ``TimedOut`` and pushed ``files_completed`` past ``files_total`` (39/29,

--- a/backend/repositories/slskd/slskd_repository.py
+++ b/backend/repositories/slskd/slskd_repository.py
@@ -45,6 +45,14 @@ class SlskdRepository:
     # How many finished transfers diagnose_downloads_mount tries to locate under the
     # mount. Small: it's a settings-page check and a wrong mount makes each a full walk.
     _DIAGNOSIS_SAMPLE = 3
+    # Mount-top dirs that never hold a FINISHED download: slskd's staging dir (a hit
+    # there is a partial file - e.g. a "Completed, TimedOut" leftover) and the
+    # failed-import quarantine. Both grow unboundedly (2,330 dead files on one live
+    # mount, 2026-07-18) and would eat the walk budget.
+    _EXCLUDED_MOUNT_DIRS = frozenset({"incomplete", "failed_imports"})
+    # Whole-mount fallback only (step 6): it must cover the entire mount, runs in a
+    # worker thread, and a busy mount easily exceeds the 10k scoped-walk backstop.
+    _WHOLE_MOUNT_MAX_ENTRIES = 100_000
 
     def __init__(
         self,
@@ -243,7 +251,7 @@ class SlskdRepository:
         # 4. slskd may have sanitised the folder name - scan one level down for it.
         try:
             for child in sorted(mount.iterdir()):
-                if child.is_dir():
+                if child.is_dir() and child.name not in self._EXCLUDED_MOUNT_DIRS:
                     cand = _within_mount(child / basename)
                     if cand is not None and cand.exists():
                         return cand
@@ -280,7 +288,9 @@ class SlskdRepository:
             except OSError:
                 return False
 
-        hit = self._walk_find(mount, mount, _name_size_match)
+        hit = self._walk_find(
+            mount, mount, _name_size_match, max_entries=self._WHOLE_MOUNT_MAX_ENTRIES
+        )
         if hit is not None:
             return hit
         try:
@@ -298,21 +308,30 @@ class SlskdRepository:
         return None
 
     @staticmethod
-    def _walk_find(root: Path, mount: Path, predicate) -> Path | None:
+    def _walk_find(
+        root: Path, mount: Path, predicate, max_entries: int = 10000
+    ) -> Path | None:
         """First file under ``root`` (bounded DFS, exact-name compare so glob
         metacharacters in filenames are harmless) for which ``predicate`` is true,
         confined to ``mount``. The entry cap is a backstop against a pathological
-        tree or a symlink loop."""
-        max_entries = 10000
+        tree or a symlink loop. ``_EXCLUDED_MOUNT_DIRS`` at the mount's top level
+        are neither descended nor counted (see the constant's note)."""
         try:
             stack = [root]
             seen = 0
             while stack:
                 for entry in stack.pop().iterdir():
+                    is_dir = entry.is_dir()
+                    if (
+                        is_dir
+                        and entry.parent == mount
+                        and entry.name in SlskdRepository._EXCLUDED_MOUNT_DIRS
+                    ):
+                        continue
                     seen += 1
                     if seen > max_entries:
                         return None
-                    if entry.is_dir():
+                    if is_dir:
                         stack.append(entry)
                         continue
                     if not entry.is_file() or not predicate(entry):
@@ -588,10 +607,30 @@ class SlskdRepository:
         failed = set(names(result.failed))
         return [f for f in requested if f not in failed] if failed else requested
 
+    @staticmethod
+    def _latest_transfer_per_file(transfers: list[SlskdTransfer]) -> list[SlskdTransfer]:
+        """One record per FILE, judged on the latest attempt: slskd keeps a record
+        per ATTEMPT, so counting per record let a stale ``Succeeded`` shadow a final
+        ``TimedOut`` and pushed ``files_completed`` past ``files_total`` (39/29,
+        2026-07-18 incident - the file was lost but read as delivered). Ordered by
+        ``requestedAt`` when both records carry one, else by record order (slskd
+        appends) - a lone timestamp must not outrank a later untimestamped retry."""
+        latest: dict[str, tuple[str | None, SlskdTransfer]] = {}
+        for transfer in transfers:
+            prev = latest.get(transfer.filename)
+            if prev is not None:
+                prev_ts = prev[0]
+                ts = transfer.requested_at
+                if ts and prev_ts and ts < prev_ts:
+                    continue  # genuinely older attempt (both stamped)
+            latest[transfer.filename] = (transfer.requested_at, transfer)
+        return [transfer for _, transfer in latest.values()]
+
     def _aggregate_status(
         self, handle: TaskHandle, transfers: list[SlskdTransfer]
     ) -> DownloadTaskStatus:
         files_total = len(handle.filenames)
+        transfers = self._latest_transfer_per_file(transfers)
         bytes_total = sum(t.size for t in transfers)
         bytes_downloaded = sum(t.bytes_transferred for t in transfers)
         completed = 0

--- a/backend/services/native/acquisition/strategy.py
+++ b/backend/services/native/acquisition/strategy.py
@@ -73,6 +73,9 @@ class SourceStrategy(Protocol):
     # Whether this source can report a LOCAL disk/write fault on a terminal outcome (SABnzbd
     # does; slskd's only local fault is the downloads mount, handled via attempt_mount).
     has_local_disk_faults: bool
+    # Per known FILE (slskd, honours ``only_filenames``) vs per unpacked FOLDER
+    # (Usenet - filenames unknown up front, so the filter is ignored).
+    per_file_imports: bool
 
     @property
     def client(self):  # noqa: ANN201
@@ -128,6 +131,7 @@ class SoulseekStrategy:
     name = "soulseek"
     applies_queued_timeout = True
     has_local_disk_faults = False  # slskd's only local fault is the downloads mount
+    per_file_imports = True  # imports the exact enqueued filenames, one by one
 
     def __init__(  # noqa: ANN001
         self, *, indexer, scorer, track_matcher, client, store, file_processor,
@@ -356,6 +360,7 @@ class UsenetStrategy:
     # accrue the queued-peer clock (the 6h deadline is the only backstop for a paused job).
     applies_queued_timeout = False
     has_local_disk_faults = True  # SABnzbd reports disk/write/permission errors
+    per_file_imports = False  # folder import; filenames unknown until unpack (D18)
 
     def __init__(  # noqa: ANN001
         self, *, indexer, scorer, client, store, file_processor, import_settle_seconds,

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -718,10 +718,9 @@ class DownloadOrchestrator:
                 )
                 # A per-file source imports ONLY files whose latest transfer attempt
                 # succeeded, on every outcome: a terminal-but-failed transfer left no
-                # finished file, so importing it can only log SOURCE_FILE_MISSING
-                # and mis-blame the mount (162 such events in one day, 2026-07-18) -
-                # the completeness veto below re-enters it into failover/retry
-                # instead. Folder sources (Usenet) ignore the filter.
+                # finished file, so importing it can only log SOURCE_FILE_MISSING and
+                # mis-blame the mount - the completeness veto below re-enters it into
+                # failover/retry instead. Folder sources (Usenet) ignore the filter.
                 strategy = self._strategy(task.source)
                 terminal = outcome in (_OUT_COMPLETED, _OUT_TERMINAL)
                 if strategy.per_file_imports or not terminal:
@@ -764,9 +763,9 @@ class DownloadOrchestrator:
                 )
                 # Never close 'completed' over never-imported expected files: stale
                 # library rows (an old copy an upgrade meant to replace) can satisfy
-                # coverage while the download delivered less than it claims (13
-                # tracks silently lost on one album, 2026-07-18). Vetoed attempts
-                # settle 'partial'/'failed', which re-enter the auto-retry ladder.
+                # coverage while the download delivered less than it claims, silently
+                # losing tracks. Vetoed attempts settle 'partial'/'failed', which
+                # re-enter the auto-retry ladder.
                 if is_complete:
                     never_imported = await self._files_never_imported(
                         task, only, result

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -777,9 +777,9 @@ class DownloadOrchestrator:
                             extra={
                                 "task_id": task.id,
                                 "count": len(never_imported),
-                                "files": sorted(
-                                    _basename(f) for f in never_imported
-                                )[:10],
+                                "files": sorted(_basename(f) for f in never_imported)[
+                                    :10
+                                ],
                             },
                         )
                         is_complete = False
@@ -1141,8 +1141,16 @@ class DownloadOrchestrator:
                     download_task_id=task.id, filename=filename
                 )
             except Exception:  # noqa: BLE001 - reconcile is best-effort
+                logger.warning(
+                    "download.reconcile_error task_id=%s file=%s",
+                    task.id,
+                    _basename(filename),
+                    exc_info=True,
+                )
                 row = None
-            if row is not None and Path(row["file_path"]).exists():
+            if row is not None and await asyncio.to_thread(
+                Path(row["file_path"]).exists
+            ):
                 continue
             confirmed_missing.add(filename)
         return confirmed_missing
@@ -1159,6 +1167,11 @@ class DownloadOrchestrator:
             )
             rows = await self._library.get_file_rows_for_album(task.release_group_mbid)
         except Exception:  # noqa: BLE001 - the message is a bonus, never a blocker
+            logger.warning(
+                "download.missing_tracks_message_error task_id=%s",
+                task.id,
+                exc_info=True,
+            )
             return None
         tracks = list(info.tracks or [])
         if not tracks:

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -46,7 +46,7 @@ from services.native.acquisition.strategy import (
     UsenetStrategy,
 )
 from services.native.album_preflight_scorer import AlbumPreflightScorer
-from services.native.coverage import match_rows_to_tracks
+from services.native.coverage import match_rows_to_tracks, uncovered_tracks
 from services.native.quality_tiers import (
     candidate_tier,
     in_range,
@@ -136,6 +136,12 @@ class _Cancelled(Exception):
     """Internal signal: the task was cancelled out-of-band (by cancel_task) while a
     poll loop was running. Caught by process_task / _resume_single_task, which return
     without overwriting the already-set 'cancelled' status."""
+
+
+def _basename(filename: str) -> str:
+    """Last path segment (slskd filenames use backslashes); log basenames not full peer
+    paths to keep log lines free of identifying directory structure."""
+    return filename.replace("\\", "/").rsplit("/", 1)[-1]
 
 
 def _user_error_message(exc: Exception) -> str:
@@ -710,16 +716,18 @@ class DownloadOrchestrator:
                     "status",
                     {"status": DownloadStatus.PROCESSING},
                 )
-                # On an interrupted (stalled/queued/deadline) outcome, import ONLY
-                # the transfers that actually succeeded - files that never arrived
-                # are not processed, so they can't be quarantined as verify failures
-                # (which would wrongly blacklist a slow-but-good peer). On a terminal
-                # outcome every transfer settled, so import the full manifest and let
-                # a genuinely failed source be quarantined as before.
-                if outcome in (_OUT_COMPLETED, _OUT_TERMINAL):
-                    only = None
-                else:
+                # A per-file source imports ONLY files whose latest transfer attempt
+                # succeeded, on every outcome: a terminal-but-failed transfer left no
+                # finished file, so importing it can only log SOURCE_FILE_MISSING
+                # and mis-blame the mount (162 such events in one day, 2026-07-18) -
+                # the completeness veto below re-enters it into failover/retry
+                # instead. Folder sources (Usenet) ignore the filter.
+                strategy = self._strategy(task.source)
+                terminal = outcome in (_OUT_COMPLETED, _OUT_TERMINAL)
+                if strategy.per_file_imports or not terminal:
                     only = set(status.succeeded_filenames)
+                else:
+                    only = None  # folder import: the whole unpacked dir
                 result, enumerated = await self._import_files(
                     task, only_filenames=only, completed=outcome == _OUT_COMPLETED
                 )
@@ -745,7 +753,6 @@ class DownloadOrchestrator:
                 # unreachable download path / disk error as a warning, never a release
                 # failure. Stop without failing over (another peer can't fix a local problem)
                 # and let the backoff'd auto-retry try once the environment recovers.
-                strategy = self._strategy(task.source)
                 sab_local_fault = (
                     strategy.has_local_disk_faults
                     and outcome == _OUT_TERMINAL
@@ -755,6 +762,27 @@ class DownloadOrchestrator:
                 is_complete = await self._download_is_complete(
                     task, imported_any, result
                 )
+                # Never close 'completed' over never-imported expected files: stale
+                # library rows (an old copy an upgrade meant to replace) can satisfy
+                # coverage while the download delivered less than it claims (13
+                # tracks silently lost on one album, 2026-07-18). Vetoed attempts
+                # settle 'partial'/'failed', which re-enter the auto-retry ladder.
+                if is_complete:
+                    never_imported = await self._files_never_imported(
+                        task, only, result
+                    )
+                    if never_imported:
+                        logger.info(
+                            "download.completed_veto_never_imported",
+                            extra={
+                                "task_id": task.id,
+                                "count": len(never_imported),
+                                "files": sorted(
+                                    _basename(f) for f in never_imported
+                                )[:10],
+                            },
+                        )
+                        is_complete = False
                 # A release that genuinely finished (e.g. SABnzbd Completed/Failed) but did NOT
                 # deliver what was requested is blocklisted by source identity BEFORE failover so
                 # a re-search/retry finds a COMPLETE release instead of re-grabbing this one
@@ -765,7 +793,7 @@ class DownloadOrchestrator:
                 # no-op - its per-file quarantine already ran at import).
                 if (
                     not is_complete
-                    and outcome in (_OUT_COMPLETED, _OUT_TERMINAL)
+                    and terminal
                     and not local_fault
                     and not attempt_import_fault
                 ):
@@ -861,11 +889,8 @@ class DownloadOrchestrator:
         # fresh enqueue -> fail fast if the peer never materialises a transfer
         outcome, status = await self._poll_until_done(task, expect_materialization=True)
         await self._store.update_status(task.id, DownloadStatus.PROCESSING)
-        only = (
-            None
-            if outcome in (_OUT_COMPLETED, _OUT_TERMINAL)
-            else set(status.succeeded_filenames)
-        )
+        # succeeded files only, same rule (and reasons) as the failover loop
+        only = set(status.succeeded_filenames)
         result, _enumerated = await self._import_files(
             task, only_filenames=only, completed=outcome == _OUT_COMPLETED
         )
@@ -1092,6 +1117,61 @@ class DownloadOrchestrator:
         # source before settling, rather than declaring done on the first track.
         return bool(result and result.succeeded and not result.failed)
 
+    async def _files_never_imported(  # noqa: ANN001
+        self, task, only: "set[str] | None", result
+    ) -> set[str]:
+        """Expected files this attempt did not land: excluded up front (latest
+        transfer never succeeded) plus attempted-and-failed. Files a prior run of
+        this task already imported (a crash between import and finalize) reconcile
+        from the library, mirroring ``_process_one``'s ``AlreadyImported`` check;
+        when the library can't confirm, the file stays counted."""
+        missing = {f.filename for f in result.failed if f.filename}
+        if only is not None and self._strategy(task.source).per_file_imports:
+            try:
+                expected = {
+                    f.filename for f in self._read_manifest(task.id).target_files
+                }
+            except OrchestrationError:
+                expected = set()
+            missing |= expected - only
+        confirmed_missing: set[str] = set()
+        for filename in missing:
+            try:
+                row = await self._library.get_imported_file(
+                    download_task_id=task.id, filename=filename
+                )
+            except Exception:  # noqa: BLE001 - reconcile is best-effort
+                row = None
+            if row is not None and Path(row["file_path"]).exists():
+                continue
+            confirmed_missing.add(filename)
+        return confirmed_missing
+
+    async def _missing_tracks_message(self, task) -> str | None:  # noqa: ANN001
+        """The 'partial' settle message naming the uncovered tracks - same matcher
+        as the completeness gate, so message and status can never disagree. ``None``
+        when the tracklist is unavailable or nothing is missing (fail-open)."""
+        if self._album_service is None or not task.release_group_mbid:
+            return None
+        try:
+            info = await self._album_service.get_album_tracks_info(
+                task.release_group_mbid, priority=RequestPriority.BACKGROUND_SYNC
+            )
+            rows = await self._library.get_file_rows_for_album(task.release_group_mbid)
+        except Exception:  # noqa: BLE001 - the message is a bonus, never a blocker
+            return None
+        tracks = list(info.tracks or [])
+        if not tracks:
+            return None
+        missing = uncovered_tracks(rows, tracks)
+        if not missing:
+            return None
+        names = [t.title or f"track {t.position}" for t in missing[:5]]
+        more = len(missing) - len(names)
+        suffix = f" (+{more} more)" if more > 0 else ""
+        plural = "s" if len(missing) != 1 else ""
+        return f"Missing {len(missing)} track{plural}: {', '.join(names)}{suffix}"
+
     async def _settle_incomplete(  # noqa: ANN001
         self,
         task,
@@ -1119,7 +1199,11 @@ class DownloadOrchestrator:
             await self._finalize(task, DownloadStatus.FAILED, error_message=fail_msg)
             return
         if await self._imported_track_count(task) > 0:
-            await self._finalize(task, DownloadStatus.PARTIAL)
+            await self._finalize(
+                task,
+                DownloadStatus.PARTIAL,
+                error_message=await self._missing_tracks_message(task),
+            )
         else:
             await self._finalize(task, DownloadStatus.FAILED, error_message=fail_msg)
 
@@ -1525,10 +1609,18 @@ class DownloadOrchestrator:
 
             await self._cancel_transfers(task, manifest)
 
-            if await self._download_is_complete(task, bool(result.succeeded), result):
+            # same completeness veto as the failover loop: files that failed this
+            # reimport must not be papered over by stale library coverage
+            if not result.failed and await self._download_is_complete(
+                task, bool(result.succeeded), result
+            ):
                 await self._finalize(task, DownloadStatus.COMPLETED)
             elif result.succeeded:
-                await self._finalize(task, DownloadStatus.PARTIAL)
+                await self._finalize(
+                    task,
+                    DownloadStatus.PARTIAL,
+                    error_message=await self._missing_tracks_message(task),
+                )
             else:
                 if any(f.reason == SOURCE_FILE_MISSING for f in result.failed):
                     fail_msg = _FILES_NOT_FOUND_MSG

--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -523,9 +523,9 @@ class FileProcessor:
         reachable).
 
         ``only_filenames`` restricts the import to a subset of the manifest - the
-        orchestrator passes the files whose slskd transfer actually succeeded, so a
-        stalled task imports what arrived without the never-arrived files being
-        recorded as (quarantinable) verification failures."""
+        orchestrator passes the files whose latest slskd transfer succeeded, so a
+        file that never arrived can't be recorded as a (quarantinable) verification
+        failure or logged as missing from the mount."""
         if self._naming is None or self._library is None or not self._library_paths \
                 or self._client is None:
             # in production all four are injected by the DI provider

--- a/backend/tests/e2e/test_full_download_pipeline.py
+++ b/backend/tests/e2e/test_full_download_pipeline.py
@@ -109,6 +109,10 @@ class _StubClient:
         return DownloadTaskStatus(
             task_id="", status=self._status, files_total=n, files_completed=n,
             bytes_total=0, bytes_downloaded=0, progress_percent=100.0,
+            # the orchestrator imports only these (mirrors the real repository)
+            succeeded_filenames=(
+                list(handle.filenames) if self._status == "completed" else []
+            ),
         )
 
     async def cancel(self, handle: TaskHandle) -> bool:

--- a/backend/tests/infrastructure/test_e2e_download.py
+++ b/backend/tests/infrastructure/test_e2e_download.py
@@ -109,6 +109,8 @@ class _StubClient:
         return DownloadTaskStatus(
             task_id="", status="completed", files_total=n, files_completed=n,
             bytes_total=0, bytes_downloaded=0, progress_percent=100.0,
+            # the orchestrator imports only these (mirrors the real repository)
+            succeeded_filenames=list(handle.filenames),
         )
 
     async def cancel(self, handle: TaskHandle) -> bool:

--- a/backend/tests/repositories/test_slskd_repository.py
+++ b/backend/tests/repositories/test_slskd_repository.py
@@ -373,7 +373,7 @@ def _repo_with_transfers(transfers) -> SlskdRepository:
 async def test_get_status_dedupes_retry_attempts_per_file():
     """slskd keeps one transfer record per ATTEMPT: a file retried after a timeout has
     two records. Status must count FILES (latest attempt wins), or files_completed
-    outruns files_total (the observed 39/29) and the task lies about completion."""
+    outruns files_total and the task lies about completion."""
     repo = _repo_with_transfers(
         [
             _transfer(
@@ -698,8 +698,8 @@ async def test_get_file_path_prefers_finished_file_over_incomplete_twin(tmp_path
 
 
 def test_walk_find_excluded_dirs_do_not_consume_the_entry_budget(tmp_path):
-    # thousands of dead files under incomplete/ and failed_imports/ (2,330 observed
-    # live) must not eat the walk cap and defeat the legitimate whole-mount fallback
+    # thousands of dead files under incomplete/ and failed_imports/ must not eat the
+    # walk cap and defeat the legitimate whole-mount fallback
     for name in ("incomplete", "failed_imports"):
         d = tmp_path / name
         d.mkdir()

--- a/backend/tests/repositories/test_slskd_repository.py
+++ b/backend/tests/repositories/test_slskd_repository.py
@@ -349,6 +349,157 @@ async def test_get_status_correlates_by_filename(mock_repo):
     assert status.status == "completed"
 
 
+def _transfer(filename, state, *, requested_at=None, size=0, done=0, username="peer"):
+    return SlskdTransfer(
+        id=f"{filename}-{requested_at or 'x'}",
+        username=username,
+        filename=filename,
+        state=state,
+        requested_at=requested_at,
+        size=size,
+        bytes_transferred=done,
+    )
+
+
+def _repo_with_transfers(transfers) -> SlskdRepository:
+    client = AsyncMock()
+    client.get_downloads = AsyncMock(return_value=transfers)
+    return SlskdRepository(
+        client=client, url="http://slskd", api_key="k", downloads_mount=Path("/dl")
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_status_dedupes_retry_attempts_per_file():
+    """slskd keeps one transfer record per ATTEMPT: a file retried after a timeout has
+    two records. Status must count FILES (latest attempt wins), or files_completed
+    outruns files_total (the observed 39/29) and the task lies about completion."""
+    repo = _repo_with_transfers(
+        [
+            _transfer(
+                "a/01.flac", "Completed, TimedOut", requested_at="2026-07-18T01:00:00Z"
+            ),
+            _transfer(
+                "a/01.flac", "Completed, Succeeded", requested_at="2026-07-18T02:00:00Z"
+            ),
+            _transfer(
+                "a/02.flac", "Completed, Succeeded", requested_at="2026-07-18T01:00:00Z"
+            ),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac", "a/02.flac"]))
+    assert status.files_total == 2
+    assert status.files_completed == 2  # never 3
+    assert status.files_failed == 0  # the old timed-out attempt is superseded
+    assert status.status == "completed"
+    assert sorted(status.succeeded_filenames) == ["a/01.flac", "a/02.flac"]
+    assert status.matched_transfers == 2  # per FILE, not per record
+
+
+@pytest.mark.asyncio
+async def test_get_status_stale_success_does_not_shadow_final_timeout():
+    """A file whose LATEST attempt timed out is FAILED, even when an older record for
+    it reads Succeeded - the stale record shadowing the real outcome is exactly how a
+    partially-failed album closed as 'completed' with tracks silently missing."""
+    repo = _repo_with_transfers(
+        [
+            _transfer(
+                "a/01.flac", "Completed, Succeeded", requested_at="2026-07-18T01:00:00Z"
+            ),
+            _transfer(
+                "a/01.flac", "Completed, TimedOut", requested_at="2026-07-18T02:00:00Z"
+            ),
+            _transfer(
+                "a/02.flac", "Completed, Succeeded", requested_at="2026-07-18T01:00:00Z"
+            ),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac", "a/02.flac"]))
+    assert status.files_completed == 1
+    assert status.files_failed == 1
+    assert status.status == "partial"  # NOT 'completed'
+    assert status.succeeded_filenames == ["a/02.flac"]
+
+
+@pytest.mark.asyncio
+async def test_get_status_orders_attempts_by_requested_at_not_list_order():
+    # the newest attempt listed FIRST must still win over an older failed one
+    repo = _repo_with_transfers(
+        [
+            _transfer(
+                "a/01.flac", "Completed, Succeeded", requested_at="2026-07-18T02:00:00Z"
+            ),
+            _transfer(
+                "a/01.flac", "Completed, TimedOut", requested_at="2026-07-18T01:00:00Z"
+            ),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac"]))
+    assert status.status == "completed"
+    assert status.files_completed == 1
+
+
+@pytest.mark.asyncio
+async def test_get_status_dedup_mixed_timestamps_trusts_record_order():
+    # only ONE record carries requestedAt: timestamps can't order the pair, so the
+    # later record (slskd appends new attempts) must win - a lone stamp on the old
+    # Succeeded record must not shadow the untimestamped final TimedOut
+    repo = _repo_with_transfers(
+        [
+            _transfer(
+                "a/01.flac", "Completed, Succeeded", requested_at="2026-07-18T01:00:00Z"
+            ),
+            _transfer("a/01.flac", "Completed, TimedOut"),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac"]))
+    assert status.files_completed == 0
+    assert status.files_failed == 1
+    assert status.status == "failed"
+
+
+@pytest.mark.asyncio
+async def test_get_status_dedup_falls_back_to_record_order_without_timestamps():
+    # no requestedAt on either record: slskd appends new attempts, so the later
+    # record is the later attempt
+    repo = _repo_with_transfers(
+        [
+            _transfer("a/01.flac", "Completed, TimedOut"),
+            _transfer("a/01.flac", "Completed, Succeeded"),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac"]))
+    assert status.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_get_status_dedup_uses_latest_attempt_bytes():
+    # bytes/size tallies must come from the winning record only, not sum attempts
+    repo = _repo_with_transfers(
+        [
+            _transfer(
+                "a/01.flac",
+                "Completed, TimedOut",
+                requested_at="2026-07-18T01:00:00Z",
+                size=100,
+                done=40,
+            ),
+            _transfer(
+                "a/01.flac",
+                "InProgress",
+                requested_at="2026-07-18T02:00:00Z",
+                size=100,
+                done=10,
+            ),
+        ]
+    )
+    status = await repo.get_status(_h("peer", ["a/01.flac"]))
+    assert status.bytes_total == 100
+    assert status.bytes_downloaded == 10
+    assert status.has_active_transfer is True  # the retry is live, not terminal
+    assert status.files_failed == 0
+
+
 @pytest.mark.asyncio
 async def test_cancel_removes_matching_transfers(mock_repo):
     ref = await mock_repo.enqueue(
@@ -499,6 +650,68 @@ async def test_get_file_path_whole_mount_fallback_disambiguates_by_size(tmp_path
         _h("peer1"), "@@p\\X\\AlbumB\\01 - Track.flac", size=10
     )
     assert path == right.resolve()
+
+
+@pytest.mark.asyncio
+async def test_get_file_path_never_returns_a_file_from_incomplete_staging(tmp_path):
+    # slskd's incomplete staging dir often lives INSIDE the downloads mount. A file
+    # found only there (e.g. the truncated leftover of a "Completed, TimedOut"
+    # transfer) is by definition not a finished download - it must never resolve,
+    # even when its name and byte size match exactly.
+    staged = tmp_path / "incomplete" / "01 - Track.flac"
+    staged.parent.mkdir()
+    staged.write_bytes(b"abcdefghij")  # size 10 - matches exactly
+    repo = SlskdRepository(client=None, url="", api_key="", downloads_mount=tmp_path)
+    assert (
+        await repo.get_file_path(_h("peer1"), "@@p\\A\\01 - Track.flac", size=10)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_file_path_never_returns_a_file_from_failed_imports(tmp_path):
+    # same for the failed-import quarantine dir some deployments keep on the mount:
+    # a quarantined copy is not a finished download to import again
+    bad = tmp_path / "failed_imports" / "Album" / "01 - Track.flac"
+    bad.parent.mkdir(parents=True)
+    bad.write_bytes(b"abcdefghij")
+    repo = SlskdRepository(client=None, url="", api_key="", downloads_mount=tmp_path)
+    assert (
+        await repo.get_file_path(_h("peer1"), "@@p\\A\\01 - Track.flac", size=10)
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_file_path_prefers_finished_file_over_incomplete_twin(tmp_path):
+    # the finished download must still be found when a truncated same-named twin
+    # sits under incomplete/
+    trunc = tmp_path / "incomplete" / "Album" / "01 - Track.flac"
+    trunc.parent.mkdir(parents=True)
+    trunc.write_bytes(b"abc")  # truncated
+    real = tmp_path / "Artist" / "Album (2020)" / "01 - Track.flac"
+    real.parent.mkdir(parents=True)
+    real.write_bytes(b"abcdefghij")  # the full 10 bytes
+    repo = SlskdRepository(client=None, url="", api_key="", downloads_mount=tmp_path)
+    path = await repo.get_file_path(_h("peer1"), "@@p\\X\\Y\\01 - Track.flac", size=10)
+    assert path == real.resolve()
+
+
+def test_walk_find_excluded_dirs_do_not_consume_the_entry_budget(tmp_path):
+    # thousands of dead files under incomplete/ and failed_imports/ (2,330 observed
+    # live) must not eat the walk cap and defeat the legitimate whole-mount fallback
+    for name in ("incomplete", "failed_imports"):
+        d = tmp_path / name
+        d.mkdir()
+        for i in range(50):
+            (d / f"junk-{i}.flac").write_bytes(b"x")
+    real = tmp_path / "Artist" / "01 - Track.flac"
+    real.parent.mkdir()
+    real.write_bytes(b"x")
+    hit = SlskdRepository._walk_find(
+        tmp_path, tmp_path, lambda e: e.name == "01 - Track.flac", max_entries=10
+    )
+    assert hit == real.resolve()
 
 
 def _completed(filename, username="peer"):

--- a/backend/tests/security/test_no_secrets_in_logs.py
+++ b/backend/tests/security/test_no_secrets_in_logs.py
@@ -118,6 +118,8 @@ class _StubClient:
         return DownloadTaskStatus(
             task_id="", status="completed", files_total=n, files_completed=n,
             bytes_total=0, bytes_downloaded=0, progress_percent=100.0,
+            # the orchestrator imports only these (mirrors the real repository)
+            succeeded_filenames=list(handle.filenames),
         )
 
     async def cancel(self, handle: TaskHandle) -> bool:

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -832,10 +832,10 @@ async def test_terminal_outcome_imports_only_succeeded_transfers(tmp_path: Path)
 async def test_stale_library_coverage_cannot_close_completed_over_missing_file(
     tmp_path: Path,
 ):
-    """The incident shape: the client CLAIMS 'completed' but one file's transfer never
-    succeeded, while stale library rows (an old copy the download was meant to
-    replace) satisfy the completeness check. The task must settle 'partial' - which
-    re-enters the auto-retry ladder - never 'completed' with the track silently lost."""
+    """The client CLAIMS 'completed' but one file's transfer never succeeded, while
+    stale library rows (an old copy the download was meant to replace) satisfy the
+    completeness check. The task must settle 'partial' - which re-enters the
+    auto-retry ladder - never 'completed' with the track silently lost."""
     client = _StubClient(
         _status(
             "completed",  # the (buggy/stale) claim

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -134,9 +134,15 @@ class _FakeLibrary:
     def __init__(self, rows=None):
         self.rows = list(rows or [])
         self.present_tracks: set[str] = set()
+        # filename -> library row, for the crash-resume "already imported" reconcile
+        # (_files_never_imported); empty = nothing previously imported by this task
+        self.imported_by_filename: dict[str, dict] = {}
 
     async def get_file_rows_for_album(self, release_group_mbid):
         return list(self.rows)
+
+    async def get_imported_file(self, download_task_id, filename):
+        return self.imported_by_filename.get(filename)
 
     async def has_track(self, recording_mbid):
         return recording_mbid in self.present_tracks or bool(self.rows)
@@ -399,7 +405,11 @@ async def test_process_task_autopicks_and_completes(tmp_path: Path):
 async def test_process_task_uses_later_auto_candidate_when_first_needs_review(
     tmp_path: Path,
 ):
-    client = _StubClient()
+    # the canned status must name the picked candidate's file, or the completeness
+    # veto (rightly) treats the enqueued file as never-imported
+    client = _StubClient(
+        _status("completed", files_completed=1, succeeded=["safe-auto/01.flac"])
+    )
     store, orch, fp, _lib = _build(
         tmp_path,
         client=client,
@@ -774,6 +784,169 @@ async def test_stall_harvests_succeeded_subset_without_quarantining_missing(
     assert final.status == "partial"  # kept the 1 track that arrived
     assert len(lib.rows) == 1
     assert await store.load_quarantine_set() == set()  # missing track NOT quarantined
+
+
+# ---------------------------------------------------------------------------
+# Succeeded-only import + completeness veto (silent-track-loss fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_terminal_outcome_imports_only_succeeded_transfers(tmp_path: Path):
+    """Even on a TERMINAL outcome, only files whose latest transfer succeeded reach
+    the verify/import phase. A timed-out transfer left no finished file on disk, so
+    importing it can only log 'file not found' noise and mis-blame the mount."""
+    client = _StubClient(
+        _status(
+            "partial",  # terminal: 1 succeeded, 1 timed out
+            files_total=2,
+            files_completed=1,
+            succeeded=["peer/01.flac"],
+        )
+    )
+    store, orch, fp, lib = _build(
+        tmp_path,
+        client=client,
+        scorer_result=[_candidate(0.9, files=2)],
+        max_failover=1,
+    )
+    _coupled_fp(fp, lib)
+    task = await _new_task(store, track_count=2)
+
+    await orch.process_task(task.id)
+
+    # the import phase was handed ONLY the succeeded file, so the timed-out one
+    # produced no verify/import attempt (and thus no SOURCE_FILE_MISSING noise)
+    only_seen = [
+        call.kwargs.get("only_filenames") for call in fp.process_downloaded.await_args_list
+    ]
+    assert only_seen == [{"peer/01.flac"}]
+    final = await store.get_task(task.id)
+    assert final.status == "partial"  # never 'completed' with a track missing
+    assert len(lib.rows) == 1
+    # the message must not mis-blame the downloads mount for a peer-side timeout
+    assert final.error_message is None or "slskd downloads" not in final.error_message
+
+
+@pytest.mark.asyncio
+async def test_stale_library_coverage_cannot_close_completed_over_missing_file(
+    tmp_path: Path,
+):
+    """The incident shape: the client CLAIMS 'completed' but one file's transfer never
+    succeeded, while stale library rows (an old copy the download was meant to
+    replace) satisfy the completeness check. The task must settle 'partial' - which
+    re-enters the auto-retry ladder - never 'completed' with the track silently lost."""
+    client = _StubClient(
+        _status(
+            "completed",  # the (buggy/stale) claim
+            files_total=2,
+            files_completed=2,
+            succeeded=["peer/01.flac"],  # ...but only one file actually succeeded
+        )
+    )
+    store, orch, fp, lib = _build(
+        tmp_path,
+        client=client,
+        scorer_result=[_candidate(0.9, files=2)],
+        max_failover=1,
+        # two stale rows already satisfy the count-based completeness check
+        imported_rows=[{"file_path": "/lib/old1"}, {"file_path": "/lib/old2"}],
+    )
+    _coupled_fp(fp, lib)
+    task = await _new_task(store, track_count=2)
+
+    await orch.process_task(task.id)
+
+    final = await store.get_task(task.id)
+    assert final.status == "partial"  # vetoed: peer/02.flac never imported
+    assert len(lib.rows) == 3  # the succeeded file still landed
+
+
+@pytest.mark.asyncio
+async def test_crash_resume_reconciles_prior_import_and_still_completes(tmp_path: Path):
+    """The veto must not demote a genuinely-finished task: after a crash between
+    import and finalize (transfers already cleaned from slskd), the resumed poll sees
+    no succeeded transfers - but the library holds the file this task imported, so
+    the reconcile clears it and the task closes 'completed'."""
+    real = tmp_path / "imported.flac"
+    real.write_bytes(b"x")
+    client = _StubClient(_status("queued", matched=0))  # records gone after cleanup
+    store, orch, fp, lib = _build(
+        tmp_path,
+        client=client,
+        queued_minutes=0.0,
+        imported_rows=[{"file_path": str(real)}],
+    )
+    _coupled_fp(fp, lib)
+    lib.imported_by_filename["peer/01.flac"] = {"file_path": str(real)}
+    task = await _new_task(store, status="downloading", source_username="peer")
+    _write_manifest(orch, task.id, ["peer/01.flac"])
+
+    await orch._resume_single_task(task.id)
+
+    assert (await store.get_task(task.id)).status == "completed"
+
+
+class _FakeAlbumService:
+    def __init__(self, tracks):
+        self._tracks = tracks
+
+    async def get_album_tracks_info(self, mbid, priority=None):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(tracks=self._tracks)
+
+
+@pytest.mark.asyncio
+async def test_partial_settle_names_the_missing_tracks(tmp_path: Path):
+    """A partial album must say WHICH tracks are missing, so the loss is visible."""
+    from types import SimpleNamespace
+
+    tracks = [
+        SimpleNamespace(
+            position=1, disc_number=1, title="One", recording_id="rec-1", length=None
+        ),
+        SimpleNamespace(
+            position=2, disc_number=1, title="Two", recording_id="rec-2", length=None
+        ),
+    ]
+    client = _StubClient(
+        _status(
+            "partial",
+            files_total=2,
+            files_completed=1,
+            succeeded=["peer/01.flac"],
+        )
+    )
+    store, orch, fp, lib = _build(
+        tmp_path,
+        client=client,
+        scorer_result=[_candidate(0.9, files=2)],
+        max_failover=1,
+        album_service=_FakeAlbumService(tracks),
+    )
+
+    async def _proc(manifest, only_filenames=None):
+        targets = manifest.target_files
+        if only_filenames is not None:
+            targets = [f for f in targets if f.filename in only_filenames]
+        succeeded = []
+        for f in targets:
+            path = f"/lib/{f.filename}"
+            succeeded.append(path)
+            lib.rows.append(
+                {"id": "row-1", "file_path": path, "recording_mbid": "rec-1"}
+            )
+        return ProcessResult(succeeded=succeeded, failed=[])
+
+    fp.process_downloaded = AsyncMock(side_effect=_proc)
+    task = await _new_task(store, track_count=2)
+
+    await orch.process_task(task.id)
+
+    final = await store.get_task(task.id)
+    assert final.status == "partial"
+    assert final.error_message == "Missing 1 track: Two"
 
 
 # ---------------------------------------------------------------------------
@@ -2230,7 +2403,11 @@ async def test_coverage_complete_via_recording_ids(tmp_path: Path):
         },
     ]
     client = _StubClient(
-        _status("completed", files_completed=2, succeeded=["p/1", "p/2"])
+        _status(
+            "completed",
+            files_completed=2,
+            succeeded=["peer/01.flac", "peer/02.flac"],
+        )
     )
     store, orch, fp, lib = _build(
         tmp_path,
@@ -2278,7 +2455,9 @@ async def test_coverage_positional_squatter_does_not_shadow_shifted_correct_file
             "duration_seconds": 155.0,
         },
     ]
-    client = _StubClient(_status("completed", files_completed=1, succeeded=["p/1"]))
+    client = _StubClient(
+        _status("completed", files_completed=1, succeeded=["peer/01.flac"])
+    )
     store, orch, fp, lib = _build(
         tmp_path,
         client=client,
@@ -2311,7 +2490,9 @@ async def test_coverage_null_length_untagged_row_covers_failopen(tmp_path: Path)
             "duration_seconds": None,
         }
     ]
-    client = _StubClient(_status("completed", files_completed=1, succeeded=["p/1"]))
+    client = _StubClient(
+        _status("completed", files_completed=1, succeeded=["peer/01.flac"])
+    )
     store, orch, fp, lib = _build(
         tmp_path,
         client=client,


### PR DESCRIPTION
## What

Stops slskd download tasks closing as `completed` while tracks were never imported:

- **Per-file transfer dedup**: slskd keeps one record per retry attempt; counting per record let a stale `Succeeded` shadow a final `TimedOut`. Status is now judged on each file's latest attempt.
- **Succeeded-only import**: terminal outcomes imported the full manifest, logging never-arrived files as "not found on the downloads mount" and mis-blaming the mount. Only files whose latest transfer succeeded reach verify/import.
- **Completeness veto**: stale library rows (e.g. old copies an upgrade should replace) satisfied coverage while tracks were missing. Tasks with never-imported files now settle `partial` (auto-retried)
- **Locator hygiene**: `incomplete/` and `failed_imports/` are excluded from `get_file_path` walks (a truncated staging file could be returned; 2,330 dead files were exhausting the 10k walk budget). Whole-mount fallback gets a 100k budget.

Behavioural change: a never-delivered file re-enters retry/failover instead of reaching verify so no quarantine for it. Delivered-but-bad files still quarantine.

Likely related: #131 (same aggregation defect, inverse symptom) and #122 (truncated-file import).
Not marked `Fixes` as it's unverified against those setups.

## Why

a bunch of albums were getting marked as  `completed` at 100% with many tracks silently missing and no retry was scheduled. 
I sent Claude off to debug the issue based on the logs and the solution it came up with seems sound.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

New tests cover dedup (incl. stale-success shadowing, mixed/absent `requestedAt`), succeeded-only import, the veto, crash-resume, and walk exclusions. Full backend suite green except pre-existing docker-dependent failures that fail identically on clean `main`. Four test stubs claiming `completed` without `succeeded_filenames` were aligned to the now-enforced contract.

## AI-Assisted Contributions

Written with Claude Code (analysis, implementation, tests), then adversarially reviewed by independent AI passes; commits carry `Co-Authored-By` trailers. 
Reviewed and tested manually in my own stack and couldn't reproduce the issue after letting it run for a couple of days.
I read through the changes, and while I'm not familiar with the codebase at all, the changes make sense to me.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`) — pre-existing env failures excepted
- [ ] Frontend lint passes — N/A, backend only
- [ ] Frontend type check passes — N/A
- [ ] No `any` in TypeScript — N/A
- [ ] No hardcoded colors — N/A
- [x] All external API calls have timeouts (no new external calls)
- [x] New msgspec structs follow existing patterns (one field on `SlskdTransfer`)
- [ ] TanStack Query used for all new data fetching — N/A
- [x] No secrets, tokens, or credentials in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
