### PR TITLE
fix(identify,import): stop empty artist credits filing albums under Various Artists

### DIFF
--- a/backend/core/dependencies/service_providers.py
+++ b/backend/core/dependencies/service_providers.py
@@ -506,6 +506,8 @@ def _build_file_processor(library_manager, library_paths) -> "FileProcessor":
         download_store=get_download_store(),
         held_dir=Path(get_settings().cache_dir) / "held",
         recycle_bin=resolve_bin_path(policy.recycle_bin_path, library_paths),
+        # repairs an empty/"Various Artists" manifest credit before tagging/pathing
+        resolve_rg_artist=get_album_identifier().resolve_release_group_artist,
     )
 
 

--- a/backend/services/native/album_matcher.py
+++ b/backend/services/native/album_matcher.py
@@ -52,7 +52,10 @@ _ALBUM_SEARCH_LIMIT = 8
 _TRACK_SAMPLE = 4
 
 _VA_MBID = "89ad4ac3-39f7-470e-963a-56509c546377"
-_VA_NAMES = {"", "various artists", "various", "va", "unknown"}
+# Credit names that mean Various Artists. Deliberately no "": an empty credit is
+# an unknown identity, not a VA claim - treating it as VA filed 197 single-artist
+# albums under /Various Artists/ (2026-07-19 incident).
+_VA_NAMES = {"various artists", "various", "va"}
 
 _NON_ALNUM = re.compile(r"[\W_]+", re.UNICODE)
 
@@ -487,9 +490,11 @@ class AlbumIdentifier:
     ) -> tuple[_ReleaseMeta, list[MBTrack]] | None:
         """Pick the release whose track count is closest to the folder's, then fetch its tracklist."""
         try:
+            # "artist-credits" is load-bearing: without it MB omits the credit and
+            # every album's artist read as "" (see the _VA_NAMES note).
             detail = await self._mb_repo.get_release_group_by_id(
                 rg_id,
-                includes=["releases", "media"],
+                includes=["artist-credits", "releases", "media"],
                 priority=RequestPriority.BACKGROUND_SYNC,
             )
         except Exception as exc:  # noqa: BLE001
@@ -499,13 +504,22 @@ class AlbumIdentifier:
             return None
         rg_title = detail.get("title", "") or ""
         rg_artist = extract_artist_name(detail) or ""
-        is_various = self._is_various(detail)
         primary_type = (detail.get("primary-type") or "").lower() or None
         secondary_types = frozenset(
             s.lower() for s in (detail.get("secondary-types") or [])
         )
         credit = detail.get("artist-credit") or []
         rg_artist_mbid = (credit[0].get("artist") or {}).get("id") if credit else None
+        if not rg_artist:
+            # The credit can still be missing (genuinely uncredited MB data, a
+            # transient hiccup); it is knowable, so resolve it rather than proceed
+            # with an empty identity.
+            resolved_mbid, resolved_name = await self.resolve_release_group_artist(
+                rg_id
+            )
+            rg_artist = resolved_name or ""
+            rg_artist_mbid = rg_artist_mbid or resolved_mbid
+        is_various = self._is_various(detail, rg_artist_mbid, rg_artist)
 
         scored: list[tuple[int, int, str, str]] = []
         fallback_id: str | None = None
@@ -552,12 +566,16 @@ class AlbumIdentifier:
         return meta, _build_mb_tracks(release)
 
     @staticmethod
-    def _is_various(rg_detail: dict) -> bool:
+    def _is_various(rg_detail: dict, artist_mbid: str | None, artist_name: str) -> bool:
+        """Whether the release group is ACTUALLY credited to Various Artists (by
+        VA MBID or credit name) - never merely uncredited (see ``_VA_NAMES``)."""
         for credit in rg_detail.get("artist-credit") or []:
             artist = credit.get("artist") or {}
             if artist.get("id") == _VA_MBID:
                 return True
-        return (extract_artist_name(rg_detail) or "").strip().lower() in _VA_NAMES
+        if artist_mbid == _VA_MBID:
+            return True
+        return artist_name.strip().lower() in _VA_NAMES
 
 
 def _build_mb_tracks(release: dict) -> list[MBTrack]:

--- a/backend/services/native/album_matcher.py
+++ b/backend/services/native/album_matcher.py
@@ -53,8 +53,8 @@ _TRACK_SAMPLE = 4
 
 _VA_MBID = "89ad4ac3-39f7-470e-963a-56509c546377"
 # Credit names that mean Various Artists. Deliberately no "": an empty credit is
-# an unknown identity, not a VA claim - treating it as VA filed 197 single-artist
-# albums under /Various Artists/ (2026-07-19 incident).
+# an unknown identity, not a VA claim - treating it as VA misfiles single-artist
+# albums under /Various Artists/.
 _VA_NAMES = {"various artists", "various", "va"}
 
 _NON_ALNUM = re.compile(r"[\W_]+", re.UNICODE)

--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -65,8 +65,8 @@ SOURCE_FILE_MISSING = "downloaded file not found on the downloads mount"
 
 # Manifest credits that claim Various Artists: re-resolved (like an empty credit)
 # against the release group's own MB credit before tagging/pathing, so VA is
-# reserved for release groups actually credited to VA (2026-07-19 incident: empty
-# credits filed 197 single-artist albums under /Various Artists/).
+# reserved for release groups actually credited to VA. Treating an empty credit as
+# VA would misfile single-artist albums under /Various Artists/.
 _VA_CREDIT_NAMES = frozenset({"various artists", "various", "va"})
 
 

--- a/backend/services/native/file_processor.py
+++ b/backend/services/native/file_processor.py
@@ -63,6 +63,12 @@ WRONG_TRACK = "wrong_track"
 # failing over to another peer hits the same wall - never blacklist the source.
 SOURCE_FILE_MISSING = "downloaded file not found on the downloads mount"
 
+# Manifest credits that claim Various Artists: re-resolved (like an empty credit)
+# against the release group's own MB credit before tagging/pathing, so VA is
+# reserved for release groups actually credited to VA (2026-07-19 incident: empty
+# credits filed 197 single-artist albums under /Various Artists/).
+_VA_CREDIT_NAMES = frozenset({"various artists", "various", "va"})
+
 
 class VerifyStatus:
     PASS = "pass"
@@ -461,6 +467,7 @@ class FileProcessor:
         download_store: "DownloadStore | None" = None,
         held_dir: Path | None = None,
         recycle_bin: Path | None = None,
+        resolve_rg_artist=None,  # async (rg_mbid) -> (artist_mbid|None, name|None)
     ) -> None:
         self._tagger = tagger
         self._naming = naming_engine
@@ -480,6 +487,9 @@ class FileProcessor:
         # disables replace-on-import entirely - an upgrade must never destroy the
         # only copy of the old bytes.
         self._recycle_bin = recycle_bin
+        # Repairs an empty/"Various Artists" manifest credit from the release
+        # group's own MB credit (see _album_artist_credit). None -> used as-is.
+        self._resolve_rg_artist = resolve_rg_artist
 
     def verify_downloaded_file(
         self,
@@ -536,9 +546,16 @@ class FileProcessor:
         targets = manifest.target_files
         if only_filenames is not None:
             targets = [f for f in targets if f.filename in only_filenames]
+        # One credit per import run - per-file resolution could split an album
+        # across two {albumartist} folders when a single MB call blips mid-import.
+        album_artist, album_artist_mbid = (
+            await self._album_artist_credit(manifest) if targets else (None, None)
+        )
         for expected in targets:
             try:
-                target = await self._process_one(expected, manifest)
+                target = await self._process_one(
+                    expected, manifest, album_artist, album_artist_mbid
+                )
                 succeeded.append(str(target))
             except AlreadyImported as already:
                 # prior run already imported this file: count its library path a
@@ -639,9 +656,15 @@ class FileProcessor:
 
         succeeded: list[str] = []
         failed: list[FileFailure] = []
+        # one credit per import run (see process_downloaded)
+        album_artist, album_artist_mbid = (
+            await self._album_artist_credit(manifest) if matches else (None, None)
+        )
         for candidate, track in matches:
             try:
-                target = await self._place_matched_file(manifest, candidate, track)
+                target = await self._place_matched_file(
+                    manifest, candidate, track, album_artist, album_artist_mbid
+                )
                 succeeded.append(str(target))
             except AlreadyImported as already:
                 succeeded.append(str(already.path))
@@ -662,14 +685,55 @@ class FileProcessor:
                 logger.warning("post-import reconcile failed for task %s", manifest.task_id)
         return ProcessResult(succeeded=succeeded, failed=failed)
 
+    async def _album_artist_credit(
+        self, manifest: DownloadManifest
+    ) -> tuple[str | None, str | None]:
+        """The (name, MBID) stamped into ALBUMARTIST and the ``{albumartist}`` path
+        segment: the manifest credit when it names a real artist, else the release
+        group's own MB credit (a genuine VA release resolves back to VA - see
+        ``_VA_CREDIT_NAMES``). Fail-open to the manifest credit when unresolvable.
+        Resolved ONCE per import run, never per file - a per-file blip would split
+        one album's files across two top-level folders."""
+        name = (manifest.artist_name or "").strip()
+        mbid = manifest.artist_mbid or None
+        if name and name.lower() not in _VA_CREDIT_NAMES:
+            return name, mbid
+        resolved_mbid = resolved_name = None
+        if self._resolve_rg_artist is not None and manifest.release_group_mbid:
+            try:
+                resolved_mbid, resolved_name = await self._resolve_rg_artist(
+                    manifest.release_group_mbid
+                )
+            except Exception:  # noqa: BLE001 - resolution is best-effort, never blocks import
+                resolved_mbid = resolved_name = None
+        if resolved_name:
+            if resolved_name != name:
+                logger.info(
+                    "process.album_artist_resolved",
+                    extra={
+                        "task_id": manifest.task_id,
+                        "manifest_credit": name or "(empty)",
+                        "resolved_credit": resolved_name,
+                    },
+                )
+            return resolved_name, (resolved_mbid or mbid)
+        return (name or None), mbid
+
     async def _place_matched_file(
-        self, manifest: DownloadManifest, candidate: "_FolderCandidate", track: "ExpectedTrack"
+        self,
+        manifest: DownloadManifest,
+        candidate: "_FolderCandidate",
+        track: "ExpectedTrack",
+        album_artist: str | None,
+        album_artist_mbid: str | None,
     ) -> Path:
         """Tag (from the matched MB track) -> position-dedup -> verify -> move -> insert.
         Duration already gated the match, so re-checking it here would be a tautology -
         AcoustID is the optional recording-identity backstop."""
         source, tag, info = candidate.path, candidate.tag, candidate.info
-        target_tag = self._build_folder_target_tag(manifest, track, tag)
+        target_tag = self._build_folder_target_tag(
+            manifest, track, tag, album_artist, album_artist_mbid
+        )
         target_path = self._library_paths[0] / self._naming.format_path(
             manifest.naming_template, target_tag, info.file_format
         )
@@ -999,15 +1063,20 @@ class FileProcessor:
 
     @staticmethod
     def _build_folder_target_tag(
-        manifest: DownloadManifest, track: "ExpectedTrack", file_tag: AudioTag
+        manifest: DownloadManifest,
+        track: "ExpectedTrack",
+        file_tag: AudioTag,
+        album_artist: str | None,
+        album_artist_mbid: str | None,
     ) -> AudioTag:
         """Target tag for a folder-matched file: identity comes from the matched MB
-        track (the file's own tags may be empty), album identity from the manifest."""
+        track (the file's own tags may be empty), album identity from the manifest,
+        the album-artist credit from ``_album_artist_credit``."""
         return AudioTag(
             title=track.title or file_tag.title or "",
-            artist=file_tag.artist or manifest.artist_name or "",
+            artist=file_tag.artist or album_artist or "",
             album=manifest.album_title,
-            album_artist=manifest.artist_name,
+            album_artist=album_artist,
             track_number=track.track_number,
             disc_number=track.disc_number or 1,
             year=manifest.year,
@@ -1016,13 +1085,17 @@ class FileProcessor:
             musicbrainz_release_id=manifest.release_mbid,
             musicbrainz_recording_id=track.recording_mbid or file_tag.musicbrainz_recording_id,
             musicbrainz_artist_id=file_tag.musicbrainz_artist_id,
-            musicbrainz_album_artist_id=manifest.artist_mbid,
+            musicbrainz_album_artist_id=album_artist_mbid,
             acoustid_id=file_tag.acoustid_id,
             compilation=file_tag.compilation,
         )
 
     async def _process_one(
-        self, expected: ExpectedFile, manifest: DownloadManifest
+        self,
+        expected: ExpectedFile,
+        manifest: DownloadManifest,
+        album_artist: str | None,
+        album_artist_mbid: str | None,
     ) -> Path:
         """Verify -> tag -> move -> insert one file. Raises ``VerificationFailed``
         (per-file) or ``AlreadyImported`` (crash-idempotency)."""
@@ -1089,7 +1162,7 @@ class FileProcessor:
                 f"Cannot read tags: {exc}", reason="corrupt", filename=expected.filename
             ) from exc
 
-        target_tag = self._build_target_tag(manifest, tag)
+        target_tag = self._build_target_tag(manifest, tag, album_artist, album_artist_mbid)
         target_path = self._library_paths[0] / self._naming.format_path(
             manifest.naming_template, target_tag, info.file_format
         )
@@ -1394,14 +1467,20 @@ class FileProcessor:
             directory = directory.parent
 
     @staticmethod
-    def _build_target_tag(manifest: DownloadManifest, file_tag: AudioTag) -> AudioTag:
+    def _build_target_tag(
+        manifest: DownloadManifest,
+        file_tag: AudioTag,
+        album_artist: str | None,
+        album_artist_mbid: str | None,
+    ) -> AudioTag:
         """Merge the file's existing descriptive tags with the manifest's album
-        identity (the authoritative MBIDs come from the request, not the audio)."""
+        identity (authoritative MBIDs come from the request or MB resolution, never
+        the audio); the album-artist credit comes from ``_album_artist_credit``."""
         return AudioTag(
             title=file_tag.title,
             artist=file_tag.artist,
             album=manifest.album_title,
-            album_artist=manifest.artist_name,
+            album_artist=album_artist,
             track_number=file_tag.track_number,
             disc_number=file_tag.disc_number or 1,
             year=manifest.year,
@@ -1410,7 +1489,7 @@ class FileProcessor:
             musicbrainz_release_id=manifest.release_mbid,
             musicbrainz_recording_id=file_tag.musicbrainz_recording_id,
             musicbrainz_artist_id=file_tag.musicbrainz_artist_id,
-            musicbrainz_album_artist_id=manifest.artist_mbid,
+            musicbrainz_album_artist_id=album_artist_mbid,
             acoustid_id=file_tag.acoustid_id,
             compilation=file_tag.compilation,
         )

--- a/backend/tests/services/test_album_matcher.py
+++ b/backend/tests/services/test_album_matcher.py
@@ -286,6 +286,74 @@ async def test_resolve_release_group_artist_handles_missing_data():
 
 
 @pytest.mark.asyncio
+async def test_best_release_fetches_the_artist_credit():
+    """The RG detail fetch must include artist-credits: without it MusicBrainz
+    omits the credit entirely, the extracted artist was "" for EVERY album, and
+    "" used to classify as Various Artists (the 197-album /Various Artists/
+    misfiling incident)."""
+    repo = AsyncMock()
+    repo.get_release_group_by_id = AsyncMock(
+        return_value=_rg_detail("Santana", "Santana", [_release("rel-debut", [9])])
+    )
+    repo.get_release_by_id = AsyncMock(return_value=_release_tracks([_SANTANA]))
+
+    picked = await AlbumIdentifier(repo).release_tracks("rg-debut", 9)
+
+    assert picked is not None
+    meta, _tracks = picked
+    assert meta.artist == "Santana"
+    assert meta.is_various is False
+    kwargs = repo.get_release_group_by_id.await_args_list[0].kwargs
+    assert "artist-credits" in kwargs["includes"]
+
+
+@pytest.mark.asyncio
+async def test_creditless_release_group_is_not_various_and_resolves_credit():
+    """A detail response WITHOUT an artist-credit (pre-fix cache entries, MB
+    hiccups) is an UNKNOWN identity: never Various Artists - and the credit is
+    knowable, so it is resolved with a dedicated artist-credits lookup."""
+    creditless = _rg_detail("Definitely Maybe", "ignored", [_release("rel-dm", [11])])
+    del creditless["artist-credit"]
+
+    async def rg_detail(mbid, includes=None, priority=None):
+        if includes == ["artist-credits"]:  # the fallback resolve
+            return _rg_detail("Definitely Maybe", "Oasis", [])
+        return creditless
+
+    repo = AsyncMock()
+    repo.get_release_group_by_id = AsyncMock(side_effect=rg_detail)
+    repo.get_release_by_id = AsyncMock(
+        return_value=_release_tracks([[f"T{i}" for i in range(11)]])
+    )
+
+    picked = await AlbumIdentifier(repo).release_tracks("rg-dm", 11)
+
+    assert picked is not None
+    meta, _tracks = picked
+    assert meta.is_various is False  # empty credit is NOT a VA claim
+    assert meta.artist == "Oasis"  # resolved from the RG's own credit
+    assert meta.artist_mbid == "a1"
+
+
+@pytest.mark.asyncio
+async def test_release_group_credited_to_va_is_various():
+    """'Various Artists' stays reserved for release groups actually credited so."""
+    detail = _rg_detail("Now 94", "Various Artists", [_release("rel-now", [20])])
+    detail["artist-credit"][0]["artist"]["id"] = "89ad4ac3-39f7-470e-963a-56509c546377"
+    repo = AsyncMock()
+    repo.get_release_group_by_id = AsyncMock(return_value=detail)
+    repo.get_release_by_id = AsyncMock(
+        return_value=_release_tracks([[f"T{i}" for i in range(20)]])
+    )
+
+    picked = await AlbumIdentifier(repo).release_tracks("rg-now", 20)
+
+    assert picked is not None
+    meta, _tracks = picked
+    assert meta.is_various is True
+
+
+@pytest.mark.asyncio
 async def test_identify_returns_none_for_single_file():
     identifier = AlbumIdentifier(_santana_repo())
     assert await identifier.identify(_locals(["Waiting"])) is None

--- a/backend/tests/services/test_file_processor.py
+++ b/backend/tests/services/test_file_processor.py
@@ -103,14 +103,20 @@ def _place(downloads: Path, rel: str) -> None:
 
 
 def _manifest(
-    *files: ExpectedFile, task_id="t1", rg="rg-1", is_track=False, expected_tracks=()
+    *files: ExpectedFile,
+    task_id="t1",
+    rg="rg-1",
+    is_track=False,
+    expected_tracks=(),
+    artist_name="Radiohead",
+    artist_mbid="a74b1b7f-71a5-4011-9441-d0b5e4122711",
 ) -> DownloadManifest:
     return DownloadManifest(
         task_id=task_id,
         source_username="peer",
         release_group_mbid=rg,
-        artist_name="Radiohead",
-        artist_mbid="a74b1b7f-71a5-4011-9441-d0b5e4122711",
+        artist_name=artist_name,
+        artist_mbid=artist_mbid,
         album_title="OK Computer",
         naming_template=_TEMPLATE,
         target_files=list(files),
@@ -120,7 +126,14 @@ def _manifest(
     )
 
 
-def _make_processor(tmp_path: Path, *, downloads=None, fingerprinter=None, verify=True):
+def _make_processor(
+    tmp_path: Path,
+    *,
+    downloads=None,
+    fingerprinter=None,
+    verify=True,
+    resolve_rg_artist=None,
+):
     downloads = downloads or (tmp_path / "downloads")
     downloads.mkdir(parents=True, exist_ok=True)
     library = tmp_path / "library"
@@ -138,6 +151,7 @@ def _make_processor(tmp_path: Path, *, downloads=None, fingerprinter=None, verif
         slskd_downloads_path=downloads,
         fingerprinter=fingerprinter,
         verify_downloads=verify,
+        resolve_rg_artist=resolve_rg_artist,
     )
     return fp, manager, client, library, downloads
 
@@ -163,6 +177,139 @@ async def test_process_downloaded_imports_and_moves(tmp_path: Path):
     assert await manager.has_album("rg-1") is True
     # DEC-1: FileProcessor never touches slskd transfers
     client.cancel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Album-artist credit resolution (2026-07-19 incident: empty identification
+# credits filed 197 single-artist albums under /Various Artists/)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_manifest_credit_resolves_rg_artist_for_tag_and_path(tmp_path: Path):
+    """An EMPTY album-artist credit must be resolved from the release group's own
+    MB credit - the RG is known (its MBID is stamped on the same file), so the
+    file must never be tagged/filed under an empty or substitute identity."""
+    resolver = AsyncMock(return_value=("oasis-mbid", "Oasis"))
+    fp, _m, _c, library, downloads = _make_processor(tmp_path, resolve_rg_artist=resolver)
+    _place(downloads, "X/01 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="X/01 Airbag.flac", size=1),
+        artist_name="",
+        artist_mbid=None,
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    assert result.failed == []
+    moved = Path(result.succeeded[0])
+    assert moved.relative_to(library).parts[0] == "Oasis"  # not Various Artists
+    tag, _ = AudioTagger().read_tags(moved)
+    assert tag.album_artist == "Oasis"
+    assert tag.musicbrainz_album_artist_id == "oasis-mbid"
+    resolver.assert_awaited_once_with("rg-1")
+
+
+@pytest.mark.asyncio
+async def test_credit_resolved_once_per_run_keeps_album_in_one_folder(tmp_path: Path):
+    """The credit is resolved ONCE per import run - resolving per file could split
+    one album across two {albumartist} folders if a single MB call blipped."""
+    resolver = AsyncMock(return_value=("oasis-mbid", "Oasis"))
+    fp, _m, _c, library, downloads = _make_processor(tmp_path, resolve_rg_artist=resolver)
+    _place(downloads, "X/01 Airbag.flac")
+    _place(downloads, "X/02 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="X/01 Airbag.flac", size=1),
+        ExpectedFile(filename="X/02 Airbag.flac", size=1),
+        artist_name="",
+        artist_mbid=None,
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    assert len(result.succeeded) == 2
+    folders = {Path(p).relative_to(library).parts[0] for p in result.succeeded}
+    assert folders == {"Oasis"}
+    resolver.assert_awaited_once_with("rg-1")
+
+
+@pytest.mark.asyncio
+async def test_various_artists_manifest_credit_repaired_from_rg_credit(tmp_path: Path):
+    """A 'Various Artists' credit on a release group actually credited to a single
+    artist (a VA-poisoned request/library row) is repaired from the RG credit."""
+    resolver = AsyncMock(return_value=("oasis-mbid", "Oasis"))
+    fp, _m, _c, library, downloads = _make_processor(tmp_path, resolve_rg_artist=resolver)
+    _place(downloads, "X/01 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="X/01 Airbag.flac", size=1),
+        artist_name="Various Artists",
+        artist_mbid=None,
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    moved = Path(result.succeeded[0])
+    assert moved.relative_to(library).parts[0] == "Oasis"
+    tag, _ = AudioTagger().read_tags(moved)
+    assert tag.album_artist == "Oasis"
+
+
+@pytest.mark.asyncio
+async def test_genuine_various_artists_release_stays_various(tmp_path: Path):
+    """A release group ACTUALLY credited to Various Artists keeps the VA credit."""
+    va_mbid = "89ad4ac3-39f7-470e-963a-56509c546377"
+    resolver = AsyncMock(return_value=(va_mbid, "Various Artists"))
+    fp, _m, _c, library, downloads = _make_processor(tmp_path, resolve_rg_artist=resolver)
+    _place(downloads, "X/01 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="X/01 Airbag.flac", size=1),
+        artist_name="Various Artists",
+        artist_mbid=va_mbid,
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    moved = Path(result.succeeded[0])
+    assert moved.relative_to(library).parts[0] == "Various Artists"
+    tag, _ = AudioTagger().read_tags(moved)
+    assert tag.album_artist == "Various Artists"
+
+
+@pytest.mark.asyncio
+async def test_real_manifest_credit_is_authoritative_no_resolution(tmp_path: Path):
+    """A manifest naming a real artist is used as-is - no MB round-trip."""
+    resolver = AsyncMock(return_value=("other-mbid", "Someone Else"))
+    fp, _m, _c, library, downloads = _make_processor(tmp_path, resolve_rg_artist=resolver)
+    _place(downloads, "Radiohead - OK Computer/01 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="Radiohead - OK Computer/01 Airbag.flac", size=1)
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    moved = Path(result.succeeded[0])
+    assert moved.relative_to(library).parts[0] == "Radiohead"
+    resolver.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_empty_credit_without_resolver_falls_back_to_file_artist(tmp_path: Path):
+    """No resolver wired (minimal builds): an empty credit must still never invent
+    'Various Artists' - the path falls back to the file's own artist tag."""
+    fp, _m, _c, library, downloads = _make_processor(tmp_path)
+    _place(downloads, "X/01 Airbag.flac")
+    manifest = _manifest(
+        ExpectedFile(filename="X/01 Airbag.flac", size=1),
+        artist_name="",
+        artist_mbid=None,
+    )
+
+    result = await fp.process_downloaded(manifest)
+
+    moved = Path(result.succeeded[0])
+    # fixture artist is Radiohead; the {albumartist} token falls back to {artist}
+    assert moved.relative_to(library).parts[0] == "Radiohead"
+    assert "Various Artists" not in str(moved)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Stops single-artist albums being tagged/filed under "Various Artists" when identification yields an empty artist credit:

- `_best_release` fetched RG detail without the `artist-credits` include, so MusicBrainz omitted the credit and the extracted artist was `""` for every album. The include is added; a still-credit-less response resolves via `resolve_release_group_artist`.
- `_VA_NAMES` contained `""`, so that empty credit *classified* as VA. Empty/unresolvable credits are now unknown, never a VA claim.
- Downloads stamp the request credit verbatim, so `FileProcessor` now repairs an empty/"Various Artists" manifest credit from the release group's own credit before tagging/pathing — resolved once per import run (so an album can't split across folders on a transient MB blip). Genuine VA releases resolve back to VA. Fail-open when unwired.

Not retroactive: already-misfiled files keep `albumartist="Various Artists"` on disk until re-identified. No existing issue tracks this.

## Why

197 consecutive single-artist albums (1,848 files) filed under `/music/Various Artists/`, each carrying the correct `musicbrainz_releasegroupid` on the same files. Test fixtures always embedded the credit in stubbed responses, so no test caught the missing include.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

New tests: credit-less detail is not VA and resolves the credit; genuine VA stays VA; empty/VA manifest credits repaired for tag and path; real credits used with no MB round-trip; one resolve per multi-file run; no-resolver fallback never invents VA. Full backend suite green except pre-existing docker-dependent failures that fail identically on clean `main`.

## AI-Assisted Contributions

Written with Claude Code (analysis, implementation, tests), then adversarially reviewed by independent AI passes; commits carry `Co-Authored-By` trailers. I read through the changes — while I'm not deeply familiar with this codebase, they make sense to me. Verified via the test suite only; I haven't re-run the fixed import pipeline in my own stack, so the runtime behaviour rests on the new tests.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [x] Backend tests pass (`make backend-test`) — pre-existing env failures excepted
- [ ] Frontend lint passes — N/A, backend only
- [ ] Frontend type check passes — N/A
- [ ] No `any` in TypeScript — N/A
- [ ] No hardcoded colors — N/A
- [x] All external API calls have timeouts (reuses the existing MB client/rate-limiter)
- [x] New msgspec structs follow existing patterns (none added)
- [ ] TanStack Query used for all new data fetching — N/A
- [x] No secrets, tokens, or credentials in source

🤖 Generated with [Claude Code](https://claude.com/claude-code)
