### PR TITLE
fix(scanner): skip files with un-encodable names instead of aborting the whole scan (#230)

### DIFF
--- a/backend/services/native/library_scanner.py
+++ b/backend/services/native/library_scanner.py
@@ -617,6 +617,20 @@ class LibraryScanner:
     ) -> _FileEntry | None:
         """Stat, incremental-skip and tag read for one file; None if skipped or errored."""
         spath = str(path)
+        # A filename whose bytes aren't valid UTF-8 surfaces from the OS walk as a
+        # path with lone surrogate code points (e.g. '\udc85'). SQLite binds TEXT as
+        # UTF-8, so such a path raises UnicodeEncodeError the moment it reaches the
+        # library DB - which aborts the entire scan (issue #230). It can't be stored
+        # or matched, so drop it here (logging the offending name) and carry on.
+        try:
+            spath.encode("utf-8")
+        except UnicodeEncodeError:
+            logger.warning(
+                "Skipping file with un-encodable name: %s",
+                spath.encode("utf-8", "backslashreplace").decode("ascii"),
+            )
+            stats.errored += 1
+            return None
         try:
             stat = path.stat()
             signature = (stat.st_mtime, stat.st_size)

--- a/backend/services/native/library_scanner.py
+++ b/backend/services/native/library_scanner.py
@@ -626,8 +626,8 @@ class LibraryScanner:
             spath.encode("utf-8")
         except UnicodeEncodeError:
             logger.warning(
-                "Skipping file with un-encodable name: %s",
-                spath.encode("utf-8", "backslashreplace").decode("ascii"),
+                "scanner.skip_file reason=unencodable_name path=%r",
+                spath,
             )
             stats.errored += 1
             return None

--- a/backend/tests/services/test_library_scanner.py
+++ b/backend/tests/services/test_library_scanner.py
@@ -6,6 +6,7 @@ the two network boundaries - ``MusicBrainzMatcher`` (Tier 2/3) and
 ``AudioFingerprinter`` (Tier 3) - to drive each tier deterministically.
 """
 
+import logging
 import os
 import shutil
 import threading
@@ -984,6 +985,27 @@ async def test_prepare_file_skips_surrogate_escaped_name(tmp_path, monkeypatch):
     assert entry is None
     assert stats.errored == 1
     assert stats.matched == 0
+
+
+@pytest.mark.asyncio
+async def test_prepare_file_skips_mixed_unicode_surrogate_name(tmp_path, monkeypatch, caplog):
+    scanner, _manager, _state, _db = _build(tmp_path)
+    stats = ScanStats()
+    bad = Path("/music/trué\udc85mp.flac")
+
+    def _fail_stat(*_a, **_k):
+        raise AssertionError("stat() must not run for an un-encodable path")
+
+    monkeypatch.setattr(Path, "stat", _fail_stat)
+
+    with caplog.at_level(logging.WARNING, logger="services.native.library_scanner"):
+        entry = await scanner._prepare_file(bad, {}, stats)
+
+    assert entry is None
+    assert stats.errored == 1
+    assert "scanner.skip_file reason=unencodable_name" in caplog.text
+    assert "trué" in caplog.text
+    assert r"\udc85" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_library_scanner.py
+++ b/backend/tests/services/test_library_scanner.py
@@ -21,7 +21,7 @@ from infrastructure.sse_publisher import SSEPublisher
 from core.exceptions import ResourceNotFoundError, ValidationError
 from models.audio import AudioTag, FingerprintResult
 from services.native.library_manager import LibraryManager
-from services.native.library_scanner import LibraryScanner, _LEDGER_BATCH_SIZE
+from services.native.library_scanner import LibraryScanner, ScanStats, _LEDGER_BATCH_SIZE
 from services.native.musicbrainz_matcher import MatchResult
 
 FIXTURES = Path(__file__).resolve().parent.parent / "fixtures" / "library"
@@ -958,6 +958,32 @@ async def test_get_attributions_for_paths_returns_active_rows(tmp_path):
     assert got[str(p)]["release_group_mbid"] == "rg-x"
     assert got[str(p)]["source"] == "download"
     assert await manager.get_attributions_for_paths([]) == {}
+
+
+@pytest.mark.asyncio
+async def test_prepare_file_skips_surrogate_escaped_name(tmp_path, monkeypatch):
+    # Regression for #230: a filename whose bytes aren't valid UTF-8 comes off the
+    # OS walk as a Path carrying a lone surrogate (e.g. '\udc85'). Binding it to
+    # SQLite raises UnicodeEncodeError and used to abort the whole library scan.
+    # _prepare_file must drop it (counting it errored) BEFORE it touches the
+    # filesystem/DB, so the rest of the library still scans.
+    scanner, _manager, _state, _db = _build(tmp_path)
+    stats = ScanStats()
+    bad = Path("/music/tru\udc85mp.flac")
+
+    # If the guard fails to short-circuit, the path reaches stat()/read_tags() and
+    # then the SQLite bind that raises UnicodeEncodeError - so a called stat() means
+    # the surrogate path leaked past the guard.
+    def _fail_stat(*_a, **_k):
+        raise AssertionError("stat() must not run for an un-encodable path")
+
+    monkeypatch.setattr(Path, "stat", _fail_stat)
+
+    entry = await scanner._prepare_file(bad, {}, stats)
+
+    assert entry is None
+    assert stats.errored == 1
+    assert stats.matched == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

Fixes #230 — a library scan aborts entirely when the library contains a file whose name isn't valid UTF-8.

## Why

A filename with bytes that aren't valid UTF-8 comes off the OS directory walk as a `Path` carrying a lone surrogate code point (e.g. `\udc85`). SQLite binds `TEXT` parameters as UTF-8, so the first time such a path reaches the library DB — the scanner's anchor read `get_attributions_for_paths` — the bind raises:

```
UnicodeEncodeError: 'utf-8' codec can't encode character '\udc85' in position 150: surrogates not allowed
```

That exception propagates out of `_run_scan`, so the whole scan fails and the rest of the library is never scanned (exactly the traceback in the issue).

## Fix

Such a path can never be stored in or matched against `library_files` (a stored `file_path` is always valid UTF-8), so there's nothing to gain by letting it reach SQLite. `_prepare_file` now detects an un-encodable path up front, logs the offending name, counts it as errored, and returns `None` — so the scan carries on with the rest of the library. This is the single ingestion chokepoint for scanned files, so it also keeps the surrogate path out of the later upsert / review-queue writes that would hit the same error.

This also lines up with the issue's ask — the skipped file is now surfaced in the logs rather than silently killing the scan.

## Test

`test_prepare_file_skips_surrogate_escaped_name` feeds a surrogate-escaped path and asserts it's dropped (errored, no entry) **before** any `stat()`/DB access — the test fails (via a stubbed `stat` that must never run) without the guard and passes with it.

```
backend/tests/services/test_library_scanner.py .... 58 passed
```

Reproduced the crash locally against `main`, confirmed the fix, and ran the scanner + file-processor + persistence suites green.

---
AI-assisted (Claude) per CONTRIBUTING — I reproduced the failure, reviewed the change, and verified the tests myself.