### PR TITLE
fix(discovery): warm the artist cache under the target lifecycle

### DIFF
--- a/backend/services/native/target_library_repository.py
+++ b/backend/services/native/target_library_repository.py
@@ -144,9 +144,16 @@ class TargetLibraryRepository:
         warmed.
         """
         cursor = after_mbid.casefold()
+        # Casefolded to match LibraryDB, which selects the already-lowercased
+        # library_artists.mbid_lower column (populated via _normalize -> str.lower).
+        # Callers page on the returned value as the next cursor, so ordering and the
+        # cursor comparison have to agree on case.
         mbids = sorted(
             value.casefold() for value in await self.get_artist_mbids() if value
         )
+        # max(1, limit) mirrors LibraryDB.get_artist_mbid_page. A limit <= 0 must not
+        # yield an empty page: the warmer treats an empty page as "no artists left" and
+        # would stop paging for the rest of the cycle.
         return [mbid for mbid in mbids if mbid > cursor][: max(1, limit)]
 
     async def existing_album_mbids(self, identifiers: list[str]) -> set[str]:

--- a/backend/services/native/target_library_repository.py
+++ b/backend/services/native/target_library_repository.py
@@ -134,6 +134,21 @@ class TargetLibraryRepository:
     async def get_artist_mbids(self) -> set[str]:
         return await self._store.target_provider_artist_ids()
 
+    async def get_artist_mbid_page(self, *, after_mbid: str, limit: int) -> list[str]:
+        """Keyset page over artist MBIDs, ordered case-insensitively.
+
+        Mirrors ``LibraryDB.get_artist_mbid_page`` so background tasks that page the
+        library work against either repository. Without it,
+        ``core.tasks.warm_artist_discovery_cache_periodically`` raises AttributeError
+        on every cycle under the target lifecycle, and the discovery cache is never
+        warmed.
+        """
+        cursor = after_mbid.casefold()
+        mbids = sorted(
+            value.casefold() for value in await self.get_artist_mbids() if value
+        )
+        return [mbid for mbid in mbids if mbid > cursor][: max(1, limit)]
+
     async def existing_album_mbids(self, identifiers: list[str]) -> set[str]:
         normalized = {
             value.strip().casefold() for value in identifiers if value.strip()

--- a/backend/tests/services/test_target_library_repository_artist_paging.py
+++ b/backend/tests/services/test_target_library_repository_artist_paging.py
@@ -1,0 +1,65 @@
+"""TargetLibraryRepository must satisfy the artist-paging half of the library repository
+protocol that core/tasks.py pages with.
+
+Regression: the target lifecycle injects TargetLibraryRepository into
+start_artist_discovery_cache_warming_task, but the class had no get_artist_mbid_page, so
+warm_artist_discovery_cache_periodically raised AttributeError on every cycle and the
+artist discovery cache was never warmed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.native.target_library_repository import TargetLibraryRepository
+
+MBIDS = {
+    "0c1f7f1e-2a3b-4c5d-8e9f-000000000003",
+    "0A1F7F1E-2A3B-4C5D-8E9F-000000000001",
+    "0b1f7f1e-2a3b-4c5d-8e9f-000000000002",
+}
+
+
+def _repo(mbids: set[str]) -> TargetLibraryRepository:
+    store = MagicMock()
+    store.target_provider_artist_ids = AsyncMock(return_value=mbids)
+    return TargetLibraryRepository(store)
+
+
+@pytest.mark.asyncio
+async def test_repository_exposes_the_paging_method_the_warmer_calls() -> None:
+    # The warmer calls this by name; absence is the regression itself.
+    assert hasattr(TargetLibraryRepository, "get_artist_mbid_page")
+
+
+@pytest.mark.asyncio
+async def test_page_is_sorted_casefolded_and_starts_after_the_cursor() -> None:
+    repo = _repo(MBIDS)
+
+    first = await repo.get_artist_mbid_page(after_mbid="", limit=2)
+    assert first == [
+        "0a1f7f1e-2a3b-4c5d-8e9f-000000000001",
+        "0b1f7f1e-2a3b-4c5d-8e9f-000000000002",
+    ]
+
+    second = await repo.get_artist_mbid_page(after_mbid=first[-1], limit=2)
+    assert second == ["0c1f7f1e-2a3b-4c5d-8e9f-000000000003"]
+
+    # Exhausted: an empty page is what terminates the warmer's paging loop.
+    assert await repo.get_artist_mbid_page(after_mbid=second[-1], limit=2) == []
+
+
+@pytest.mark.asyncio
+async def test_empty_library_terminates_immediately() -> None:
+    assert await _repo(set()).get_artist_mbid_page(after_mbid="", limit=500) == []
+
+
+@pytest.mark.asyncio
+async def test_blank_mbids_are_skipped_and_limit_is_floored() -> None:
+    repo = _repo({"", "0a1f7f1e-2a3b-4c5d-8e9f-000000000001"})
+    assert await repo.get_artist_mbid_page(after_mbid="", limit=500) == [
+        "0a1f7f1e-2a3b-4c5d-8e9f-000000000001"
+    ]
+    # limit <= 0 must still yield progress rather than an empty page, which the warmer
+    # would misread as "no more artists" and stop.
+    assert len(await repo.get_artist_mbid_page(after_mbid="", limit=0)) == 1


### PR DESCRIPTION
Fixes #236.

## Problem

Under the target lifecycle the artist discovery cache is **never warmed**. The task dies on
its first statement and repeats forever, so the only symptom is a recurring stack trace and
Discover data that never populates.

`start_artist_discovery_cache_warming_task` is called with two different repository types:

| call site | passes | has `get_artist_mbid_page`? |
|---|---|---|
| `backend/main.py:578` (legacy) | `get_library_db()` → `LibraryDB` | yes — `library_db.py:586` |
| `backend/services/native/target_application_lifecycle.py:304` (target) | `library` → `TargetLibraryRepository` | **no** |

`warm_artist_discovery_cache_periodically` is annotated `library_db: "LibraryDB"`, but the
target lifecycle injects a `TargetLibraryRepository`. The annotation is a string and never
enforced, so the mismatch only surfaces at runtime:

```
File "/app/core/tasks.py", line 430, in warm_artist_discovery_cache_periodically
    page = await library_db.get_artist_mbid_page(
AttributeError: 'TargetLibraryRepository' object has no attribute 'get_artist_mbid_page'. Did you mean: 'get_artist_mbids'?
```

Observed on a live instance at exactly 4 h spacing, matching `interval=14400`:
`20:55:29Z`, `00:55:29Z`, `04:55:29Z`.

## Fix

Add `get_artist_mbid_page` to `TargetLibraryRepository`, mirroring `LibraryDB`'s contract.

Chosen over rewriting the caller because:

- both call sites keep working, with no behaviour change for the legacy path;
- the task's keyset paging and `workload_gate` backpressure are preserved exactly as-is;
- `TargetLibraryRepository` is already documented as the *"target catalog adapter for
  services that need the library repository protocol"* — this is a method of that protocol
  which simply never got migrated.

It is built on the existing `get_artist_mbids()` / `target_provider_artist_ids()` query, so
no new SQL is introduced. **Trade-off worth flagging:** that query returns the full set, so
each page re-queries and re-sorts it. For realistic artist counts this is negligible against
the network-bound `precache_artist_discovery` calls it feeds, but if you would prefer a
keyset query pushed down into `NativeLibraryStore`, say so and I will rework it.

## Tests

`backend/tests/services/test_target_library_repository_artist_paging.py` — covers the
missing method, cursor ordering with casefolding, the empty page that terminates the
warmer's loop, blank-MBID skipping, and the `limit` floor (a `limit<=0` returning an empty
page would be misread by the warmer as "no more artists").

Verified it is a genuine regression test — **4 failed before the change (AttributeError),
4 pass after**:

```
$ pytest tests/services/test_target_library_repository_artist_paging.py -q   # without fix
4 failed in 0.50s
$ pytest tests/services/test_target_library_repository_artist_paging.py -q   # with fix
4 passed in 0.45s
```

Adjacent suites pass unchanged — `207 passed` across everything matching
`-k "target_library or library_repo or task"`, including
`test_discover_home_warmer.py`, `test_discovery*.py` and `test_auto_scan_task.py`.
