### PR TITLE
fix(identification): stop one contradicted track vetoing an exact release match

### DIFF
--- a/backend/services/native/album_evidence_engine.py
+++ b/backend/services/native/album_evidence_engine.py
@@ -20,6 +20,13 @@ MATCHER_VERSION = "feedback-fixes-v1"
 PAIR_COST_CEILING = 0.40
 ALBUM_DISTANCE_CEILING = 0.35
 CANDIDATE_MARGIN_FLOOR = 0.05
+# A tolerated mismatch is one where the tracklists disagree about a title, not one
+# where the recording itself is provably different. A guest-artist suffix the release
+# does not carry, a romanised title, a bonus track present in one edition and not the
+# other: each of those contradicts exactly one track on an otherwise exact release.
+# Requiring unanimity there rejects the correct release group over a tagging detail,
+# so demand a strong majority instead and let the score carry the rest.
+SUPPORTED_RATIO_FLOOR = 0.80
 ORDINARY_ALBUM_MAX_FILES = 20
 ORDINARY_UNKNOWN_LIMIT = 1
 LARGE_UNKNOWN_LIMIT = 2
@@ -29,6 +36,9 @@ MAX_CANDIDATES = 10
 
 _NON_WORD = re.compile(r"[^\w]+", re.UNICODE)
 _UNSAFE_SECONDARY_TYPES = frozenset({"compilation", "live"})
+# Evidence that the local file and the candidate track are different recordings, as
+# opposed to the same recording described differently. These stay absolute vetoes.
+_HARD_CONFLICT_KINDS = frozenset({"recording_mbid_conflict", "duration_conflict"})
 
 
 def _fold(value: str) -> str:
@@ -227,6 +237,11 @@ class AlbumEvidenceEngine:
         contradictions = sum(
             item.classification == "contradictory" for item in track_evidence
         )
+        hard_contradictions = sum(
+            item.classification == "contradictory"
+            and bool(_HARD_CONFLICT_KINDS.intersection(item.evidence_kinds))
+            for item in track_evidence
+        )
         unknown = len(track_evidence) - comparable
         unknown_limit = (
             ORDINARY_UNKNOWN_LIMIT
@@ -245,11 +260,18 @@ class AlbumEvidenceEngine:
             if album_artist
             else 0.25,
         ]
-        mean_pair_cost = sum(pair_costs) / len(pair_costs) if pair_costs else 1.0
+        # Contradicted tracks count against the mean at full cost. Averaging only the
+        # tracks that matched would score a candidate covering 8 of 9 identically to
+        # one covering all 9, and the tie would be broken arbitrarily.
+        cost_samples = len(pair_costs) + contradictions
+        mean_pair_cost = (
+            (sum(pair_costs) + contradictions) / cost_samples if cost_samples else 1.0
+        )
         distance = 0.65 * mean_pair_cost + 0.20 * album_costs[0] + 0.15 * album_costs[1]
+        supported_ratio = supported / comparable if comparable else 0.0
         reason = "SUPPORTED"
         if (
-            contradictions
+            hard_contradictions
             or title_class == "contradictory"
             or artist_class == "contradictory"
         ):
@@ -260,8 +282,10 @@ class AlbumEvidenceEngine:
             reason = "UNKNOWN_EXTRAS_EXCEED_LIMIT"
         elif unsafe_type:
             reason = "UNSAFE_RELEASE_TYPE"
-        elif comparable == 0 or supported != comparable:
+        elif comparable == 0:
             reason = "INSUFFICIENT_METADATA"
+        elif supported_ratio < SUPPORTED_RATIO_FLOOR:
+            reason = "CONFLICTING_TRACK_EVIDENCE"
         elif distance > ALBUM_DISTANCE_CEILING:
             reason = "INSUFFICIENT_METADATA"
 

--- a/backend/tests/services/native/test_album_evidence_engine.py
+++ b/backend/tests/services/native/test_album_evidence_engine.py
@@ -15,6 +15,7 @@ from services.native.album_evidence_engine import (
     LARGE_UNKNOWN_LIMIT,
     MATCHER_VERSION,
     ORDINARY_UNKNOWN_LIMIT,
+    SUPPORTED_RATIO_FLOOR,
     AlbumEvidenceEngine,
 )
 from services.native.local_album_grouper import (
@@ -312,6 +313,148 @@ def test_studio_protection_and_genuine_compilation_acceptance() -> None:
         secondary=["compilation"],
     )
     assert AlbumEvidenceEngine().decide(compilation, [genuine]).outcome == "identified"
+
+
+def _guest_suffix_album() -> tuple[list[GroupingTrack], AlbumCandidate]:
+    """Nine tracks matching a release exactly, except one local title carries a guest
+    credit the release does not use - the Thriller / "The Girl Is Mine (with Paul
+    McCartney)" shape."""
+    titles = [
+        "Wanna Be Startin' Somethin'",
+        "Baby Be Mine",
+        "The Girl Is Mine",
+        "Thriller",
+        "Beat It",
+        "Billie Jean",
+        "Human Nature",
+        "P.Y.T. (Pretty Young Thing)",
+        "The Lady in My Life",
+    ]
+    local = [
+        _track(
+            f"local-{index}",
+            title if index != 3 else "The Girl Is Mine (with Paul McCartney)",
+            number=index,
+        )
+        for index, title in enumerate(titles, start=1)
+    ]
+    candidate = _candidate(
+        "rg",
+        [
+            _candidate_track(title, index)
+            for index, title in enumerate(titles, start=1)
+        ],
+    )
+    return local, candidate
+
+
+def test_one_contradicted_title_does_not_veto_an_otherwise_exact_release() -> None:
+    local, candidate = _guest_suffix_album()
+    decision = AlbumEvidenceEngine().decide(local, [candidate])
+    evidence = decision.candidates[0]
+    classes = [item.classification for item in evidence.track_evidence]
+
+    assert classes.count("supported") == 8
+    assert classes.count("contradictory") == 1
+    assert evidence.album_title_classification == "supported"
+    assert evidence.album_artist_classification == "supported"
+    assert decision.outcome == "identified"
+    assert decision.reason_code == "SUPPORTED"
+
+
+def test_a_contradicted_track_still_costs_the_candidate_score() -> None:
+    """The tolerated mismatch must not score identically to a clean match, or the
+    wrong edition can win the ordering in decide()."""
+    local, candidate = _guest_suffix_album()
+    engine = AlbumEvidenceEngine()
+    tolerated = engine.evaluate_candidate(local, candidate)
+
+    clean_local = list(local)
+    clean_local[2] = _track("local-3", "The Girl Is Mine", number=3)
+    clean = engine.evaluate_candidate(clean_local, candidate)
+
+    assert clean.reason_code == "SUPPORTED"
+    assert tolerated.reason_code == "SUPPORTED"
+    assert clean.score > tolerated.score
+
+
+@pytest.mark.parametrize(
+    ("track_count", "contradicted", "expected"),
+    [
+        (10, 2, "identified"),  # 0.80, exactly at the floor
+        (10, 3, "contradictory"),  # 0.70, below it
+        (5, 1, "identified"),  # 0.80 on a short EP
+        (2, 1, "contradictory"),  # a single mismatch out of two proves nothing
+    ],
+)
+def test_supported_ratio_floor_bounds_what_a_mismatch_may_cost(
+    track_count: int, contradicted: int, expected: str
+) -> None:
+    local = [
+        _track(
+            f"local-{index}",
+            f"Track {index}" if index > contradicted else f"Unrelated {index}",
+            number=index,
+        )
+        for index in range(1, track_count + 1)
+    ]
+    candidate = _candidate(
+        "rg",
+        [_candidate_track(f"Track {index}", index) for index in range(1, track_count + 1)],
+    )
+    decision = AlbumEvidenceEngine().decide(local, [candidate])
+    supported = sum(
+        item.classification == "supported"
+        for item in decision.candidates[0].track_evidence
+    )
+    assert (supported / track_count >= SUPPORTED_RATIO_FLOOR) is (
+        expected == "identified"
+    )
+    assert decision.outcome == expected
+
+
+def test_a_conflicting_recording_mbid_remains_an_absolute_veto() -> None:
+    """A different recording is a different recording, however well the rest lines
+    up - the ratio floor must not launder that away."""
+    local = [
+        _track(f"local-{index}", f"Track {index}", number=index, recording=f"rec-{index}")
+        for index in range(1, 11)
+    ]
+    candidate = _candidate(
+        "rg",
+        [
+            _candidate_track(
+                f"Track {index}",
+                index,
+                recording=f"rec-{index}" if index != 1 else "rec-elsewhere",
+            )
+            for index in range(1, 11)
+        ],
+    )
+    decision = AlbumEvidenceEngine().decide(local, [candidate])
+    blocked = decision.candidates[0].track_evidence[0]
+
+    assert blocked.classification == "contradictory"
+    assert "recording_mbid_conflict" in blocked.evidence_kinds
+    assert decision.outcome == "contradictory"
+    assert decision.reason_code == "CONFLICTING_TRACK_EVIDENCE"
+
+
+def test_a_wrong_album_title_remains_an_absolute_veto() -> None:
+    local = [
+        _track(f"local-{index}", f"Track {index}", number=index, album="Greatest Hits")
+        for index in range(1, 11)
+    ]
+    candidate = _candidate(
+        "rg",
+        [_candidate_track(f"Track {index}", index) for index in range(1, 11)],
+        title="Something Else Entirely",
+    )
+    decision = AlbumEvidenceEngine().decide(local, [candidate])
+
+    assert decision.candidates[0].album_title_classification == "contradictory"
+    assert decision.outcome == "contradictory"
+    assert decision.reason_code == "CONFLICTING_TRACK_EVIDENCE"
 
 
 def test_unicode_punctuation_and_duration_grace_are_supported() -> None:


### PR DESCRIPTION
Fixes #238.

## What

`AlbumEvidenceEngine.evaluate_candidate` rejected a candidate outright when **any** track came back contradictory. This replaces that with:

- the veto stays absolute for evidence that the recording really is different — `recording_mbid_conflict` and `duration_conflict` — and for a contradicted album title or album artist, which mean the wrong album;
- otherwise a candidate needs a strong majority of supported tracks (`SUPPORTED_RATIO_FLOOR = 0.80`) and the score carries the rest;
- contradicted tracks now count against the mean pair cost at full cost.

That last part is needed for the first to be safe. `pair_costs` only collected the tracks that matched, so a candidate covering 8 of 9 scored identically to one covering all 9 and `decide()` broke the tie arbitrarily. With misses included in the mean, the more complete edition wins on score, which is what the existing `CANDIDATE_MARGIN_FLOOR` machinery expects.

## Why

Michael Jackson's *Thriller* was sitting unidentified in my review queue. The stored evidence for the correct release group:

- `album_title_classification: supported`
- `album_artist_classification: supported`
- `score: 0.9966801268424036`
- 8 of 9 tracks supported, every one on `normalized_title` + `compatible_duration` + `compatible_position`

Rejected with `CONFLICTING_TRACK_EVIDENCE`, because my file is tagged `The Girl Is Mine (with Paul Mccartney)` and the release calls it `The Girl Is Mine`.

Better tagging does not solve this in the general case. Guest-artist suffixes, romanised versus original-script titles, and bonus tracks that differ between editions each contradict exactly one track on an otherwise exact release. On my 2,733-album library, 49 of the 482 albums stuck in `needs_review` are this shape — the largest recoverable group. Because artwork resolution is keyed on the release-group MBID, every one of them is also permanently without cover art, which is how I found it.

Issue #238 has the full evidence row and the breakdown of all 482.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests

**The new tests fail without the fix.** Reverting only the decision logic in `album_evidence_engine.py` while keeping the tests:

```
FAILED test_one_contradicted_title_does_not_veto_an_otherwise_exact_release
FAILED test_a_contradicted_track_still_costs_the_candidate_score
FAILED test_supported_ratio_floor_bounds_what_a_mismatch_may_cost[10-2-identified]
FAILED test_supported_ratio_floor_bounds_what_a_mismatch_may_cost[5-1-identified]
4 failed, 20 passed
```

The four guardrail cases — the recording-MBID veto, the wrong-album-title veto, and the two below-floor ratios — pass both before and after, so they are not vacuous.

**End to end on the real data.** Same inputs (9 local tracks from my `library.db`, MusicBrainz release `0881a2b7-2be3-4dfd-94f0-b186069802bd`), run against each engine:

```
upstream dev-0af05f6            with this change
supported   : 8/9               supported   : 8/9
score       : 0.9967            score       : 0.9248
reason_code : CONFLICTING_...   reason_code : SUPPORTED
OUTCOME     : contradictory     OUTCOME     : identified
selected    : None              selected    : f32fab67-…:0881a2b7-…
```

The score drops from 0.9967 to 0.9248 — the tolerated miss is now paid for, rather than being free.

**Suite.** `5184 passed`. 21 failures in `tests/infrastructure/test_feedback_fixes_maintenance.py`, `tests/infrastructure/test_maintenance_manifest.py` and `tests/services/test_wanted_watcher_service.py` are pre-existing and environmental in my checkout — a pristine `0af05f6` gives an identical `21 failed, 49 passed` on those three files. `tests/e2e` and `tests/benchmarks` were not run.

One thing for you to decide: I left `MATCHER_VERSION` alone to keep the change focused. Nothing in the backend gates re-evaluation on it, so existing installs will not re-attempt previously rejected albums until something retries them. If you would rather stale attempts be re-run automatically, bumping it here is the natural place.

## AI-Assisted Contributions

Claude (Claude Code) did the investigation and wrote the patch and the tests. Specifically: it traced the rejection from my stuck review queue back to the veto in `evaluate_candidate`, proposed the ratio floor plus the mean-cost change, wrote `album_evidence_engine.py` and the six new test cases, and produced the before/after runs above.

I reviewed the change, ran the suites and the real-data comparison myself, and I understand what it does. Extra scrutiny welcome on two judgement calls that are mine to defend rather than the model's: the 0.80 floor is a round number chosen because it clears one miss on a five-track EP and two on a ten-track album while rejecting anything looser, and treating `duration_conflict` as a hard veto alongside `recording_mbid_conflict` follows `_pair`, which already flags both as `hard_conflict`.

## Checklist

- [x] Backend lint passes (`ruff check` clean on both changed files)
- [x] Backend tests pass (see above)
- [ ] Frontend lint passes — no frontend changes in this PR
- [ ] Frontend type check passes — no frontend changes in this PR
- [x] No `any` in TypeScript — n/a
- [x] No hardcoded colors — n/a
- [x] All external API calls have timeouts — n/a, no new calls
- [x] New msgspec structs follow existing patterns — none added
- [x] TanStack Query used for all new data fetching — n/a
- [x] No secrets, tokens, or credentials in source
