### PR TITLE
fix(discover): preview stations silently die at the first crossfade under browser autoplay policy

### DIFF
--- a/frontend/src/lib/stores/deckSampler.spec.ts
+++ b/frontend/src/lib/stores/deckSampler.spec.ts
@@ -13,13 +13,19 @@ vi.mock('$lib/stores/audioFocus.svelte', () => ({ audioFocus: focus }));
 // to simulate a clip reaching its end, then let the ticker advance.
 class FakeAudio {
 	static created: FakeAudio[] = [];
+	/** elements that started a real clip (excludes the gesture-unlock blip);
+	 * the sampler reuses a persistent pool, so track starts, not constructions */
+	static started: FakeAudio[] = [];
 	src = '';
 	preload = '';
+	muted = false;
 	volume = 1;
 	currentTime = 0;
 	duration = 30;
 	ended = false;
-	play = vi.fn(async () => {});
+	play = vi.fn(async () => {
+		if (!this.src.startsWith('data:')) FakeAudio.started.push(this);
+	});
 	pause = vi.fn(() => {});
 	constructor() {
 		FakeAudio.created.push(this);
@@ -49,6 +55,7 @@ function albumPreview(n: number, provider = 'deezer') {
 beforeEach(() => {
 	vi.clearAllMocks();
 	FakeAudio.created = [];
+	FakeAudio.started = [];
 	(globalThis as unknown as { Audio: typeof FakeAudio }).Audio = FakeAudio;
 });
 
@@ -73,11 +80,11 @@ describe('deckSampler single album', () => {
 		expect(deckSampler.trackIndex).toBe(0);
 
 		// clip 1 ends -> advance to clip 2
-		FakeAudio.created.at(-1)!.finish();
+		FakeAudio.started.at(-1)!.finish();
 		await vi.waitFor(() => expect(deckSampler.trackIndex).toBe(1));
 
 		// clip 2 ends -> station of one is exhausted -> idle
-		FakeAudio.created.at(-1)!.finish();
+		FakeAudio.started.at(-1)!.finish();
 		await waitForStatus('idle');
 		expect(focus.release).toHaveBeenCalled();
 	});
@@ -102,9 +109,9 @@ describe('deckSampler station', () => {
 		expect(deckSampler.stationPosition).toEqual({ index: 0, total: 2 });
 
 		// exhaust the first album's 2 clips -> should load the second entry
-		FakeAudio.created.at(-1)!.finish();
+		FakeAudio.started.at(-1)!.finish();
 		await vi.waitFor(() => expect(deckSampler.trackIndex).toBe(1));
-		FakeAudio.created.at(-1)!.finish();
+		FakeAudio.started.at(-1)!.finish();
 		await vi.waitFor(() => expect(deckSampler.stationPosition.index).toBe(1));
 		expect(deckSampler.currentEntry?.title).toBe('Album 2');
 	});
@@ -132,8 +139,8 @@ describe('deckSampler station', () => {
 
 		expect(deckSampler.stationPosition.index).toBe(2);
 		expect(deckSampler.currentEntry?.title).toBe('Album 3');
-		// exactly one element was ever started -> no double audio
-		expect(FakeAudio.created.length).toBe(1);
+		// exactly one clip was ever started -> no double audio
+		expect(FakeAudio.started.length).toBe(1);
 	});
 
 	it('next() skips to the following entry immediately', async () => {
@@ -156,7 +163,7 @@ describe('deckSampler transport', () => {
 		apiGet.mockResolvedValue(albumPreview(2));
 		deckSampler.start('rg-1', 'Artist', 'Album');
 		await waitForStatus('playing');
-		const el = FakeAudio.created.at(-1)!;
+		const el = FakeAudio.started.at(-1)!;
 
 		deckSampler.pause();
 		expect(deckSampler.status).toBe('paused');
@@ -172,7 +179,7 @@ describe('deckSampler transport', () => {
 		apiGet.mockResolvedValue(albumPreview(1));
 		deckSampler.start('rg-1', 'Artist', 'Album');
 		await waitForStatus('playing');
-		const el = FakeAudio.created.at(-1)!;
+		const el = FakeAudio.started.at(-1)!;
 
 		deckSampler.setVolume(0.4);
 		expect(deckSampler.volume).toBe(0.4);

--- a/frontend/src/lib/stores/deckSampler.svelte.ts
+++ b/frontend/src/lib/stores/deckSampler.svelte.ts
@@ -21,6 +21,11 @@ import type { AlbumPreviewResponse, PreviewTrackItem, TrackPreviewResponse } fro
 const FOCUS_ID = 'deck-sampler';
 const CROSSFADE_S = 2;
 const TICK_MS = 100;
+// gesture-unlock source: browsers only allow play() from a user gesture, and
+// crossfades start clips from a timer. Playing this once per element during the
+// starting click marks the element gesture-activated so later src swaps play.
+const SILENT_CLIP =
+	'data:audio/wav;base64,UklGRjQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YRAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const VOLUME_KEY = 'droppedneedle_sampler_volume';
 // clips per album when playing a multi-entry station (keeps a lean-back station
 // moving); a single-album sample plays everything the backend returns
@@ -66,6 +71,41 @@ function createDeckSampler() {
 	let audioB: HTMLAudioElement | null = null;
 	let activeEl: HTMLAudioElement | null = null;
 	let useA = true;
+	// persistent pair reused across clips and stations: recreating elements per
+	// clip loses gesture activation and the browser rejects timer-driven play()
+	let poolA: HTMLAudioElement | null = null;
+	let poolB: HTMLAudioElement | null = null;
+
+	function unlockPool() {
+		if (!poolA) {
+			poolA = new Audio();
+			poolA.preload = 'auto';
+		}
+		if (!poolB) {
+			poolB = new Audio();
+			poolB.preload = 'auto';
+		}
+		for (const el of [poolA, poolB]) {
+			try {
+				el.muted = true;
+				el.src = SILENT_CLIP;
+				const p = el.play();
+				if (p)
+					p.then(
+						() => {
+							// a real clip may have replaced the unlock clip already
+							if (el.src.startsWith('data:')) el.pause();
+							el.muted = false;
+						},
+						() => {
+							el.muted = false;
+						}
+					);
+			} catch {
+				el.muted = false;
+			}
+		}
+	}
 	let ticker: ReturnType<typeof setInterval> | null = null;
 	let session = 0;
 
@@ -106,8 +146,10 @@ function createDeckSampler() {
 	}
 
 	function nextEl(): HTMLAudioElement {
-		const el = new Audio();
-		el.preload = 'auto';
+		if (!poolA || !poolB) unlockPool();
+		const el = useA ? poolB! : poolA!;
+		el.pause();
+		el.muted = false;
 		if (useA) {
 			audioB = el;
 		} else {
@@ -163,7 +205,16 @@ function createDeckSampler() {
 		activeEl = el;
 		try {
 			await el.play();
-		} catch {
+		} catch (err) {
+			if ((err as DOMException)?.name === 'NotAllowedError') {
+				// autoplay blocked: hold paused and ask for a tap instead of
+				// silently chain-skipping the rest of the station
+				if (mySession === session) {
+					status = 'paused';
+					playbackToast.show('Tap the preview play button to keep sampling', 'warning');
+				}
+				return;
+			}
 			// unplayable preview (expired URL, codec): skip forward
 			if (mySession === session) void advance(mySession);
 			return;
@@ -284,26 +335,29 @@ function createDeckSampler() {
 		}
 	}
 
-	/** End the run; on a single-item preview, tell the user it was unavailable
-	 * (the widget hides on 'error', so a toast is the only feedback). */
+	/** End the run; the widget hides on stop, so a toast is the only feedback -
+	 * always say why the preview ended rather than vanishing silently. */
 	function failOrEnd(entry: SampleEntry) {
 		const wasSingle = station.length === 1;
 		stopAll();
-		if (wasSingle) {
-			status = 'error';
-			playbackToast.show(
-				entry.kind === 'album'
+		status = 'error';
+		playbackToast.show(
+			wasSingle
+				? entry.kind === 'album'
 					? `No preview available for ${entry.title}`
-					: `No preview available for that track`,
-				'warning'
-			);
-		}
+					: `No preview available for that track`
+				: 'Preview station ended: no more playable clips',
+			'warning'
+		);
 	}
 
 	function beginStation(title: string, entries: SampleEntry[]): void {
 		stopInternal();
 		if (entries.length === 0) return;
 		const mySession = ++session;
+		// still inside the starting click: unlock both pool elements while we
+		// have the user gesture, so timer-driven crossfades are allowed later
+		unlockPool();
 		audioFocus.claim(FOCUS_ID, stopAll);
 		status = 'loading';
 		station = entries;

--- a/frontend/src/lib/stores/deckSampler.svelte.ts
+++ b/frontend/src/lib/stores/deckSampler.svelte.ts
@@ -19,7 +19,7 @@ import { playbackToast } from '$lib/stores/playbackToast.svelte';
 import type { AlbumPreviewResponse, PreviewTrackItem, TrackPreviewResponse } from '$lib/types';
 
 const FOCUS_ID = 'deck-sampler';
-const CROSSFADE_S = 2;
+const CROSSFADE_S = 0.5;
 const TICK_MS = 100;
 // gesture-unlock source: browsers only allow play() from a user gesture, and
 // crossfades start clips from a timer. Playing this once per element during the

--- a/frontend/src/lib/stores/deckSampler.svelte.ts
+++ b/frontend/src/lib/stores/deckSampler.svelte.ts
@@ -76,7 +76,7 @@ function createDeckSampler() {
 	let poolA: HTMLAudioElement | null = null;
 	let poolB: HTMLAudioElement | null = null;
 
-	function unlockPool() {
+	function ensurePool() {
 		if (!poolA) {
 			poolA = new Audio();
 			poolA.preload = 'auto';
@@ -85,7 +85,13 @@ function createDeckSampler() {
 			poolB = new Audio();
 			poolB.preload = 'auto';
 		}
-		for (const el of [poolA, poolB]) {
+	}
+
+	/** Only effective inside a user gesture (beginStation's click); elsewhere the
+	 * silent play() would itself be blocked. */
+	function unlockPool() {
+		ensurePool();
+		for (const el of [poolA!, poolB!]) {
 			try {
 				el.muted = true;
 				el.src = SILENT_CLIP;
@@ -146,7 +152,9 @@ function createDeckSampler() {
 	}
 
 	function nextEl(): HTMLAudioElement {
-		if (!poolA || !poolB) unlockPool();
+		// null-safety only: creating elements is fine outside a gesture, unlocking
+		// isn't - beginStation already unlocked the pool during the starting click
+		ensurePool();
 		const el = useA ? poolB! : poolA!;
 		el.pause();
 		el.muted = false;


### PR DESCRIPTION
## Problem

On any browser profile without high media engagement for the site (every mobile browser, and fresh desktop profiles), sampling an album plays exactly **one** clip. At the first crossfade the station silently dies and the floating preview widget vanishes with no feedback. Likely the same failure class as #192 ("small window which indicates it's loading shows for a quick second").

## Root cause

`deckSampler` creates a fresh `new Audio()` per clip. Only the first element inherits the user's click activation. The crossfade's `play()` runs from the ticker interval, so the browser rejects it with `NotAllowedError`; the catch treats that as an unplayable clip and chain-skips through the entire station into the silent natural-end path.

## Fix (commit 1)

- Reuse a persistent pair of audio elements, unlocked during the starting click by briefly playing a silent WAV data URI (muted). Gesture activation then survives timer-driven `src` swaps, so crossfades are allowed everywhere.
- `NotAllowedError` pauses the station with a toast instead of chain-skipping; resume runs from the widget button's own gesture, so it works.
- `failOrEnd` always toasts; multi-entry stations previously died silently.
- Spec updated to track started clips rather than constructed elements (elements are pooled now).

## Separable commit 2

`CROSSFADE_S` 2s → 0.5s. A 2-second overlap between two *unrelated* 30s previews at near-full volume reads as "two songs playing at once" rather than a blend. Happy to drop this commit if you prefer the longer crossfade.

## Verification

Driven headlessly (Chromium, mobile emulation, default autoplay policy) against a live instance: before, 1 of 4 clips played and the widget vanished at ~29s with no toast; after, all 4 clips play, the widget persists, and overlap windows are ≤0.25s. Full frontend unit suite passes (889 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)