### PR TITLE
fix(artist): owning one album makes the rest of the discography unreachable

### DIFF
--- a/frontend/src/routes/artist/[id]/+page.svelte
+++ b/frontend/src/routes/artist/[id]/+page.svelte
@@ -15,7 +15,8 @@
 
 	let { data }: Props = $props();
 	const discographyView = $derived(data.discographyView === true);
-	const localQuery = getLibraryArtistDetailQuery(() => data.artistId);
+	// empty id disables the query: the local lookup is unused in discography view
+	const localQuery = getLibraryArtistDetailQuery(() => (discographyView ? '' : data.artistId));
 	const localArtist = $derived(localQuery.data);
 	const canonicalLocalId = $derived(localArtist?.id ?? null);
 	const shouldRedirect = $derived(

--- a/frontend/src/routes/artist/[id]/+page.svelte
+++ b/frontend/src/routes/artist/[id]/+page.svelte
@@ -10,14 +10,17 @@
 	import ProviderArtistPage from './ProviderArtistPage.svelte';
 
 	interface Props {
-		data: { artistId: string; primarySource: MusicSource };
+		data: { artistId: string; primarySource: MusicSource; discographyView?: boolean };
 	}
 
 	let { data }: Props = $props();
+	const discographyView = $derived(data.discographyView === true);
 	const localQuery = getLibraryArtistDetailQuery(() => data.artistId);
 	const localArtist = $derived(localQuery.data);
 	const canonicalLocalId = $derived(localArtist?.id ?? null);
-	const shouldRedirect = $derived(canonicalLocalId !== null && canonicalLocalId !== data.artistId);
+	const shouldRedirect = $derived(
+		!discographyView && canonicalLocalId !== null && canonicalLocalId !== data.artistId
+	);
 
 	$effect(() => {
 		if (localArtist && shouldRedirect) {
@@ -27,7 +30,9 @@
 	});
 </script>
 
-{#if localQuery.isLoading || shouldRedirect}
+{#if discographyView}
+	<ProviderArtistPage {data} />
+{:else if localQuery.isLoading || shouldRedirect}
 	<div class="w-full max-w-7xl mx-auto px-2 py-4 sm:px-4 sm:py-8 lg:px-8">
 		<div class="flex items-end gap-6">
 			<div class="skeleton h-48 w-48 rounded-full"></div>

--- a/frontend/src/routes/artist/[id]/+page.ts
+++ b/frontend/src/routes/artist/[id]/+page.ts
@@ -1,7 +1,10 @@
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ params }) => {
+export const load: PageLoad = async ({ params, url }) => {
 	return {
-		artistId: params.id
+		artistId: params.id,
+		// ?view=discography forces the provider (MusicBrainz) page even when the
+		// artist exists locally, so owning one album doesn't hide the discography
+		discographyView: url.searchParams.get('view') === 'discography'
 	};
 };

--- a/frontend/src/routes/artist/[id]/LocalArtistPage.svelte
+++ b/frontend/src/routes/artist/[id]/LocalArtistPage.svelte
@@ -86,12 +86,19 @@
 					{artist.track_count === 1 ? 'track' : 'tracks'}
 				</p>
 				{#if artist.musicbrainz_artist_id}
-					<a
-						class="btn btn-ghost btn-sm mt-3 gap-2"
-						href={`https://musicbrainz.org/artist/${artist.musicbrainz_artist_id}`}
-						target="_blank"
-						rel="noreferrer">Open in MusicBrainz <ExternalLink class="h-3.5 w-3.5" /></a
-					>
+					<div class="mt-3 flex flex-wrap gap-2">
+						<a
+							class="btn btn-outline btn-sm gap-2"
+							href={`/artist/${artist.musicbrainz_artist_id}?view=discography`}
+							><Disc3 class="h-4 w-4" /> Full discography</a
+						>
+						<a
+							class="btn btn-ghost btn-sm gap-2"
+							href={`https://musicbrainz.org/artist/${artist.musicbrainz_artist_id}`}
+							target="_blank"
+							rel="noreferrer">Open in MusicBrainz <ExternalLink class="h-3.5 w-3.5" /></a
+						>
+					</div>
 				{/if}
 				{#if authStore.isTrusted && artist.artist_identity_state === 'local_only' && contributionAlbums.length}
 					<a class="btn btn-outline btn-sm mt-3 gap-2" href="#musicbrainz-albums">


### PR DESCRIPTION
## Problem

Once an artist exists in the library, `/artist/[id]` always renders `LocalArtistPage` (library albums only), and provider-mbid links are redirected to the canonical local route. So after downloading a single album by an artist, there is no way left in the UI to browse or request their other releases — the request flow that got the user their first album disappears.

Repro: request one album by a well-known artist, let it import, then open the artist from search or a discover card. You land on the library view with one album and no path to the discography.

## Fix

- `+page.ts` threads `?view=discography` through the load. With the param, the page renders `ProviderArtistPage` even when the artist exists locally, and the canonical-route redirect is suppressed.
- `LocalArtistPage` gains a **Full discography** button (next to "Open in MusicBrainz") linking to `/artist/{musicbrainz_artist_id}?view=discography` whenever the artist credit is linked.

Default routing without the param is unchanged; the existing routing spec passes as-is.

## Verification

Driven headlessly against a live instance with a 1-album artist (Michael Jackson): the library page shows the button, the discography view renders the full release list with in-library state, and direct navigation with the param does not redirect. Full frontend unit suite passes (889 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)