### PR TITLE
Fix target-mode background warmers crashing on TargetLibraryRepository

### DIFF
--- a/backend/services/native/target_application_lifecycle.py
+++ b/backend/services/native/target_application_lifecycle.py
@@ -190,6 +190,7 @@ async def start_target_operational_runtime(
         get_target_events_watcher_service,
         get_jellyfin_repository,
         get_jellyfin_library_service,
+        get_library_db,
         get_mbid_store,
         get_target_navidrome_library_service,
         get_now_playing_service,
@@ -303,14 +304,14 @@ async def start_target_operational_runtime(
     )
     start_artist_discovery_cache_warming_task(
         get_target_artist_discovery_service,
-        library,
+        get_library_db(),
         interval=advanced.artist_discovery_warm_interval,
         delay=advanced.artist_discovery_warm_delay,
         workload_gate=get_background_workload_gate(),
     )
     start_audiodb_sweep_task(
         get_audiodb_image_service(),
-        library,
+        get_library_db(),
         preferences,
         precache_service=None,
         workload_gate=get_background_workload_gate(),

--- a/backend/tests/infrastructure/test_native_library_store_dependencies.py
+++ b/backend/tests/infrastructure/test_native_library_store_dependencies.py
@@ -56,3 +56,36 @@ def test_target_provider_is_only_referenced_by_isolated_target_composition() -> 
     assert "target_application_lifecycle" in (root / "target_application.py").read_text(
         encoding="utf-8"
     )
+
+
+def test_target_lifecycle_wires_librarydb_into_background_warmers() -> None:
+    """Regression: the target runtime passed its TargetLibraryRepository to the
+    AudioDB sweep and artist-discovery warmer, which page the LibraryDB cache
+    (get_enrichment_candidates / get_artist_mbid_page) and crashed every cycle.
+    """
+    import ast
+
+    root = Path(__file__).parents[2]
+    source = (root / "services/native/target_application_lifecycle.py").read_text(
+        encoding="utf-8"
+    )
+    warmers = {
+        "start_audiodb_sweep_task": 1,
+        "start_artist_discovery_cache_warming_task": 1,
+    }
+    seen: dict[str, ast.expr] = {}
+    for node in ast.walk(ast.parse(source)):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id in warmers
+        ):
+            seen[node.func.id] = node.args[warmers[node.func.id]]
+
+    assert set(seen) == set(warmers)
+    for name, library_arg in seen.items():
+        assert (
+            isinstance(library_arg, ast.Call)
+            and isinstance(library_arg.func, ast.Name)
+            and library_arg.func.id == "get_library_db"
+        ), f"{name} must receive the LibraryDB, not the target repository"


### PR DESCRIPTION
## Problem

In target (native library) mode, `start_target_operational_runtime` passes its `TargetLibraryRepository` to two background warmers that expect the `LibraryDB` metadata cache:

- `start_audiodb_sweep_task` calls `library_db.get_enrichment_candidates(...)` (`core/tasks.py`)
- `start_artist_discovery_cache_warming_task` calls `library_db.get_artist_mbid_page(...)`

`TargetLibraryRepository` implements neither, so in target mode the AudioDB sweep dies with `AttributeError: 'TargetLibraryRepository' object has no attribute 'get_enrichment_candidates'` every cycle, and artist-discovery warming logs `'TargetLibraryRepository' object has no attribute 'get_artist_mbid_page'` every interval. Neither cache ever warms.

The classic entrypoint (`main.py`) already wires both tasks to `get_library_db()`; only the target lifecycle got the wrong object. Target mode populates the same cache tables through `services/native/library_manager.py`, so the `LibraryDB` is the correct dependency there too.

## Fix

Pass `get_library_db()` at both call sites in `services/native/target_application_lifecycle.py`, matching `main.py`.

## Tests

Added a wiring regression test alongside the existing target-composition source checks (`test_native_library_store_dependencies.py`); it fails on the previous wiring and passes with the fix. Existing sweep and pagination suites pass.

Observed in production on a target-mode instance running the `:dev` image (nightly `AttributeError` from the sweep, 4-hourly from artist discovery, gone after this patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)