### PR TITLE
fix(slskd): resolve nested paths with Unicode normalization

### DIFF
--- a/backend/repositories/slskd/slskd_repository.py
+++ b/backend/repositories/slskd/slskd_repository.py
@@ -17,6 +17,7 @@ stay structurally identical to the protocol for the conformance contract test.
 import asyncio
 import logging
 import re
+import unicodedata
 from pathlib import Path
 
 from models.common import ServiceStatus
@@ -36,6 +37,16 @@ logger = logging.getLogger(__name__)
 
 _DISC_DIR = re.compile(r"\b(?:Disc|CD)\s*\d+\b", re.IGNORECASE)
 _LOSSLESS_EXT = {"flac", "alac", "wav", "ape", "wv"}
+
+
+def _normalised_filename(value: str) -> str:
+    """Canonical filename form used only for comparisons.
+
+    Linux filesystems preserve the code points supplied by each container, so the
+    same visible name may be NFC in slskd's API and NFD on the shared mount (or vice
+    versa).  Normalising the comparison keeps the real on-disk ``Path`` intact.
+    """
+    return unicodedata.normalize("NFC", value)
 
 
 class SlskdRepository:
@@ -250,6 +261,7 @@ class SlskdRepository:
             return None
         mount = self._downloads_mount.resolve()
         basename = parts[-1]
+        normalised_basename = _normalised_filename(basename)
 
         def _within_mount(candidate: Path) -> Path | None:
             resolved = candidate.resolve()
@@ -260,29 +272,46 @@ class SlskdRepository:
                 return None
             return resolved
 
+        def _name_matches(entry: Path) -> bool:
+            return _normalised_filename(entry.name) == normalised_basename
+
+        def _find_in_directory(directory: Path) -> Path | None:
+            """Find ``basename`` directly below a directory, including NFC/NFD aliases."""
+            direct = _within_mount(directory / basename)
+            if direct is not None and direct.is_file():
+                return direct
+            try:
+                for entry in directory.iterdir():
+                    if not entry.is_file() or not _name_matches(entry):
+                        continue
+                    return _within_mount(entry)
+            except OSError:
+                return None
+            return None
+
         # 1. slskd's common layout: {mount}/{leaf remote folder}/{filename}.
         if len(parts) >= 2:
-            leaf = _within_mount(mount / parts[-2] / basename)
-            if leaf is not None and leaf.exists():
+            leaf = _find_in_directory(mount / parts[-2])
+            if leaf is not None:
                 return leaf
         # 2. Flat layout: {mount}/{filename}.
-        flat = _within_mount(mount / basename)
-        if flat is not None and flat.exists():
+        flat = _find_in_directory(mount)
+        if flat is not None:
             return flat
         # 3. Peers that file by username: walk {mount}/{username}/ at any depth
         # (covers {username}/{file} and {username}/{album}/{file}). Scoped to the
         # peer so a same-named track from a different user can't be picked up.
         user_root = _within_mount(mount / username) if username else None
         if user_root is not None and user_root.is_dir():
-            hit = self._walk_find(user_root, mount, lambda e: e.name == basename)
+            hit = self._walk_find(user_root, mount, _name_matches)
             if hit is not None:
                 return hit
         # 4. slskd may have sanitised the folder name - scan one level down for it.
         try:
             for child in sorted(mount.iterdir()):
                 if child.is_dir():
-                    cand = _within_mount(child / basename)
-                    if cand is not None and cand.exists():
+                    cand = _find_in_directory(child)
+                    if cand is not None:
                         return cand
         except OSError as exc:
             logger.warning("Could not scan downloads mount %s: %s", mount, exc)
@@ -308,7 +337,7 @@ class SlskdRepository:
         # a different same-named track - an unscoped size-ONLY walk would cross peers
         # (step 5 stays peer-scoped on purpose). Reached only after every step missed.
         def _name_size_match(entry: Path) -> bool:
-            if entry.name != basename:
+            if not _name_matches(entry):
                 return False
             if not size:
                 return True

--- a/backend/services/native/download_orchestrator.py
+++ b/backend/services/native/download_orchestrator.py
@@ -134,6 +134,7 @@ _FILES_NOT_FOUND_MSG = (
     "Files downloaded, but couldn't be found in the slskd downloads folder - check "
     "the slskd downloads path points to where slskd saves completed files"
 )
+_TAG_MISMATCH_MSG = "Files downloaded and found, but their embedded tags did not match the requested music"
 # slskd delivered the files and we found them, but writing them into the library failed
 # (perms, disk full, a cross-mount copy the filesystem rejected). Local fault, not the
 # peer's - blaming Soulseek sends users chasing the wrong problem.
@@ -787,6 +788,7 @@ class DownloadOrchestrator:
         wrong_track = False
         source_missing = False
         import_failed = False
+        tag_mismatch = False
         while True:
             attempt_result = ProcessResult(
                 succeeded=[], failed=[], workspace_disposition="discard"
@@ -921,6 +923,8 @@ class DownloadOrchestrator:
                     source_missing = True
                 if any(f.reason == IMPORT_FAILED for f in result.failed):
                     import_failed = True
+                if any(f.reason == "tag_mismatch" for f in result.failed):
+                    tag_mismatch = True
                 if result.management_hold_reason_code is not None:
                     # The peer delivered a verified acquisition unit and the app now
                     # owns durable held copies. A different peer cannot fix a local
@@ -1021,6 +1025,7 @@ class DownloadOrchestrator:
                     imported_any,
                     source_missing=source_missing,
                     import_failed=import_failed,
+                    tag_mismatch=tag_mismatch,
                     process_result=attempt_result,
                 )
                 return
@@ -1535,21 +1540,24 @@ class DownloadOrchestrator:
         *,
         source_missing: bool = False,
         import_failed: bool = False,
+        tag_mismatch: bool = False,
         process_result=None,
     ) -> None:
         """No candidates/attempts left and the download still isn't whole. A track
         either imported (already finalized 'completed') or it didn't ('failed'); an
         album keeps whatever landed as 'partial', or 'failed' if nothing did.
 
-        ``source_missing``/``import_failed`` flip the failure message off the default
-        'no source on Soulseek': slskd delivered the files but we either couldn't find
-        them on the mount (config) or couldn't write them into the library (perms/disk).
-        Both are local faults - blaming Soulseek sent users chasing the wrong problem
-        (AUD: 'watched it finish in slskd, then it said no source')."""
+        ``source_missing``/``import_failed``/``tag_mismatch`` flip the failure message
+        off the default 'no source on Soulseek': slskd delivered the files but we either
+        couldn't find them on the mount (config), couldn't write them into the library
+        (perms/disk), or found files whose own tags identify different music. Blaming
+        Soulseek for these concrete outcomes sends users chasing the wrong problem."""
         if source_missing:
             fail_msg = _FILES_NOT_FOUND_MSG
         elif import_failed:
             fail_msg = _IMPORT_FAILED_MSG
+        elif tag_mismatch:
+            fail_msg = _TAG_MISMATCH_MSG
         else:
             fail_msg = self._no_source_message()
         if task.download_type == "track":

--- a/backend/tests/repositories/test_slskd_repository.py
+++ b/backend/tests/repositories/test_slskd_repository.py
@@ -4,6 +4,7 @@ and (username, filenames) status/cancel correlation."""
 
 import asyncio
 import threading
+import unicodedata
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -515,6 +516,39 @@ async def test_get_file_path_deep_nested_non_username_folder(tmp_path):
         _h("peer1"), "@@p\\Music\\Abbey Road (1969)\\01 - Come Together.flac", size=10
     )
     assert path == f.resolve()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("remote_form", "disk_form"),
+    [
+        ("NFC", "NFD"),
+        ("NFD", "NFC"),
+    ],
+)
+async def test_get_file_path_recursively_matches_unicode_normalisation(
+    tmp_path, remote_form, disk_form
+):
+    # Docker bind mounts do not normalise names. slskd can therefore report NFC while
+    # the host directory contains NFD (or the reverse), even though both render as the
+    # same accented filename. The real file is nested below a non-username directory
+    # so this exercises the whole-mount recursive fallback from the incident report.
+    visible_name = "05 - Héroes Del Sábado.flac"
+    remote_name = unicodedata.normalize(remote_form, visible_name)
+    disk_name = unicodedata.normalize(disk_form, visible_name)
+    assert remote_name != disk_name
+
+    folder = tmp_path / "completed" / "Artist" / "Album"
+    folder.mkdir(parents=True)
+    file_path = folder / disk_name
+    file_path.write_bytes(b"abcdefghij")
+
+    repo = SlskdRepository(client=None, url="", api_key="", downloads_mount=tmp_path)
+    path = await repo.get_file_path(
+        _h("peer1"), f"@@peer\\Music\\Album\\{remote_name}", size=10
+    )
+
+    assert path == file_path.resolve()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_download_orchestrator.py
+++ b/backend/tests/services/test_download_orchestrator.py
@@ -662,6 +662,36 @@ async def test_missing_on_mount_fails_with_mount_message_not_quarantine(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_tag_mismatch_fails_with_metadata_message_not_mount_message(
+    tmp_path: Path,
+):
+    """A located file rejected by its own tags is a content mismatch, not a path or
+    mount failure. Preserve that distinction after failover candidates are exhausted."""
+    client = _StubClient(
+        _status("completed", files_completed=1, succeeded=["peer/01.flac"])
+    )
+    store, orch, _fp, _lib = _build(
+        tmp_path,
+        client=client,
+        scorer_result=[_candidate(0.9)],
+        fp_result=ProcessResult(
+            succeeded=[],
+            failed=[FileFailure(filename="peer/01.flac", reason="tag_mismatch")],
+        ),
+        imported_rows=[],
+    )
+    task = await _new_task(store)
+
+    await orch.process_task(task.id)
+
+    final = await store.get_task(task.id)
+    assert final.status == "failed"
+    assert "embedded tags" in final.error_message
+    assert "downloads folder" not in final.error_message
+    assert "No working source" not in final.error_message
+
+
+@pytest.mark.asyncio
 async def test_import_failure_fails_with_library_message_not_soulseek(tmp_path: Path):
     """slskd delivered the files and we found them, but writing them into the library
     failed (IMPORT_FAILED - perms/disk/a rejected cross-mount copy). A local fault: the


### PR DESCRIPTION
## What

Fix slskd completed-file resolution for nested paths whose filenames use different Unicode normalization forms (NFC/NFD).

Also distinguish genuine `tag_mismatch` failures from downloads mount/path resolution failures.

## Why

Docker bind mounts preserve filenames exactly as stored. A filename reported by slskd may therefore be canonically equivalent to, but byte-different from, the filename visible to DroppedNeedle. This caused completed downloads with accented characters to be missed during recursive lookup.

## Testing

- Added regression coverage for NFC-to-NFD and NFD-to-NFC nested paths.
- Added coverage for distinguishing metadata mismatches from mount failures.
- Ran the affected backend suites: 155 tests passed.
- Ran backend lint successfully.

- [x] I have tested these changes locally
- [x] I have added or updated tests

## AI-Assisted Contributions

OpenAI Codex assisted with diagnosing the path-resolution issue, implementing Unicode-normalized filename comparison, updating failure messaging, and writing regression tests. The resulting changes were reviewed and validated locally.

## Checklist

- [x] Backend lint passes (`make backend-lint`)
- [ ] Backend tests pass (`make backend-test`) — targeted affected suites pass
- [ ] Frontend lint passes (`make frontend-lint`) — not run; no frontend changes
- [ ] Frontend type check passes (`make frontend-check`) — not run; no frontend changes
- [x] No `any` in TypeScript
- [x] No hardcoded colors (design tokens only)
- [x] All external API calls have timeouts
- [x] New msgspec structs follow existing patterns
- [x] TanStack Query used for all new data fetching
- [x] No secrets, tokens, or credentials in source

closes #288 