### PR TITLE
fix(subsonic): treat byYear fromYear/toYear=0 as unbounded, not invalid

### DIFF
--- a/backend/api/compat/subsonic/router.py
+++ b/backend/api/compat/subsonic/router.py
@@ -478,12 +478,20 @@ async def _album_list(c: Ctx):
     to_year = None
     genre = None
     if typ == "byYear":
-        first = c.pint("fromYear", minimum=1, maximum=9999)
-        last = c.pint("toYear", minimum=1, maximum=9999)
+        first = c.pint("fromYear", minimum=0, maximum=9999)
+        last = c.pint("toYear", minimum=0, maximum=9999)
         if first is None or last is None:
             raise SubsonicError(10, "fromYear and toYear are required for byYear")
-        from_year, to_year = min(first, last), max(first, last)
-        sort = "year_asc" if first <= last else "year_desc"
+        # Subsonic client convention: 0 means "no bound" on that side (real
+        # years are never 0), not a literal year value.
+        first = first or None
+        last = last or None
+        if first is not None and last is not None:
+            from_year, to_year = min(first, last), max(first, last)
+            sort = "year_asc" if first <= last else "year_desc"
+        else:
+            from_year, to_year = first, last
+            sort = "year_desc" if last is not None else "year_asc"
     elif c.p("fromYear") is not None or c.p("toYear") is not None:
         raise SubsonicError(10, "fromYear and toYear require type=byYear")
     if typ == "byGenre":

--- a/backend/tests/compat/test_subsonic_browsing.py
+++ b/backend/tests/compat/test_subsonic_browsing.py
@@ -196,6 +196,44 @@ async def test_album_list_by_year_direction_and_genre(compat_env):
     assert {album["name"] for album in rock} == {"Older Rock"}
 
 
+async def test_album_list_by_year_zero_means_unbounded(compat_env):
+    # Feishin (and other Subsonic clients) send fromYear/toYear=0 as their
+    # convention for "no bound on this side" - a real year is never 0, so a
+    # bare zero must not be rejected the way an out-of-range value would be.
+    await _add_album(
+        compat_env,
+        rg="00000000-0000-0000-0000-000000000012",
+        title="Old Enough",
+        year=1990,
+        genre="Rock",
+    )
+    await _add_album(
+        compat_env,
+        rg="00000000-0000-0000-0000-000000000013",
+        title="Recent Enough",
+        year=2010,
+        genre="Rock",
+    )
+    open_upper = _get(
+        compat_env,
+        "getAlbumList2",
+        type="byYear",
+        fromYear="1980",
+        toYear="0",
+        size="20",
+    )["albumList2"]["album"]
+    assert {album["name"] for album in open_upper} >= {"Old Enough", "Recent Enough"}
+    open_lower = _get(
+        compat_env,
+        "getAlbumList2",
+        type="byYear",
+        fromYear="0",
+        toYear="2020",
+        size="20",
+    )["albumList2"]["album"]
+    assert {album["name"] for album in open_lower} >= {"Old Enough", "Recent Enough"}
+
+
 async def test_album_list_highest_and_unknown_fail_explicitly(compat_env):
     highest = _get(compat_env, "getAlbumList2", type="highest")
     assert highest["status"] == "failed"


### PR DESCRIPTION
## Summary

Fixes #294.

Feishin (and likely other Subsonic clients) send `fromYear`/`toYear=0` as their convention for "no bound on this side" when browsing `getAlbumList2` with `type=byYear` (e.g. `fromYear=2026&toYear=0` meaning "2026 onward"). The `byYear` handler parsed both with `minimum=1`, so a bare `0` was rejected as out of range with `Invalid parameter 'toYear'` on every request using that convention — a real year is never `0`, so it should mean "unbounded" rather than "invalid".

## Fix

- Parse `fromYear`/`toYear` with `minimum=0` instead of `minimum=1`.
- Treat a parsed `0` as `None` (unbounded) before building the sort/range.
- Fall back to an open-ended ascending/descending sort when only one side is bounded.

## Test plan

- Reproduced against a live Feishin 1.13.0 session: repeated `getAlbumList2` polling with `fromYear=2026&toYear=0` every ~30s errored every time before this fix, succeeded every time after.
- Added `test_album_list_by_year_zero_means_unbounded` covering both directions (open upper bound, open lower bound). Verified it fails against the original code (`KeyError: 'albumList2'`, since the request errors instead of returning results) and passes with the fix.
- Full existing test file (`test_subsonic_browsing.py`, 22 tests) passes.
- Ran the full backend suite: 6435 passed, 4 skipped, 15 failed. All 15 failures reproduce identically on a clean `main` checkout with no changes applied, and trace back to a missing local `docker-compose.yml` (the repo only ships `docker-compose.example.yml`) — unrelated to this change.
- `ruff check backend` passes with no findings.

## AI disclosure

Claude helped diagnose the root cause (cross-referencing live Feishin request logs against the parameter validation code) and write this fix and its test, per the AI-Assisted Contributions section of CONTRIBUTING.md.