### PR TITLE
perf(library): index album-artist lookups used by discovery warming

### DIFF
--- a/backend/infrastructure/persistence/native_library_schema.py
+++ b/backend/infrastructure/persistence/native_library_schema.py
@@ -1647,6 +1647,7 @@ CREATE INDEX IF NOT EXISTS idx_local_tracks_availability ON local_tracks(availab
 CREATE INDEX IF NOT EXISTS idx_local_tracks_policy ON local_tracks(root_id, applied_policy, desired_policy_revision, relative_path);
 CREATE INDEX IF NOT EXISTS idx_local_tracks_search ON local_tracks(title_folded, artist_name_folded, album_title_folded);
 CREATE INDEX IF NOT EXISTS idx_local_tracks_path_hash ON local_tracks(path_hash);
+CREATE INDEX IF NOT EXISTS idx_local_album_artists_artist_album ON local_album_artists(local_artist_id, local_album_id);
 CREATE INDEX IF NOT EXISTS idx_local_album_identity_rg ON local_album_external_identities(release_group_mbid);
 CREATE INDEX IF NOT EXISTS idx_local_album_identity_rg_lower ON local_album_external_identities(lower(release_group_mbid));
 CREATE INDEX IF NOT EXISTS idx_local_album_identity_release_lower ON local_album_external_identities(lower(release_mbid));

--- a/backend/tests/infrastructure/test_native_library_store.py
+++ b/backend/tests/infrastructure/test_native_library_store.py
@@ -2542,6 +2542,19 @@ async def test_migration_provenance_repeats_and_refuses_changed_sources(
             "idx_local_album_identity_rg",
         ),
         (
+            "SELECT identity.provider_artist_id "
+            "FROM local_artist_external_identities identity "
+            "WHERE EXISTS (SELECT 1 FROM local_album_artists credit "
+            "JOIN local_albums album ON album.id = credit.local_album_id "
+            "JOIN local_tracks track ON track.local_album_id = credit.local_album_id "
+            "WHERE credit.local_artist_id = identity.local_artist_id "
+            "AND album.retired_into_album_id IS NULL "
+            "AND track.availability = 'indexed') "
+            "ORDER BY identity.provider_artist_id",
+            "SEARCH credit USING COVERING INDEX "
+            "idx_local_album_artists_artist_album (local_artist_id=?)",
+        ),
+        (
             "SELECT * FROM local_tracks WHERE genre_folded = ? AND availability = ?",
             "idx_local_tracks_genre_artwork",
         ),


### PR DESCRIPTION
Title: perf(library): index album-artist lookups used by discovery warming

## What

- Add a covering index on `local_album_artists(local_artist_id, local_album_id)`.
- Add a query-plan regression case for the correlated artist lookup used by
  `target_provider_artist_ids()`.

## Why

Artist discovery warming repeatedly loads the target library's complete artist
ID set. The query correlates `local_artist_external_identities` with
`local_album_artists` on `local_artist_id`, but the existing primary key begins
with `local_album_id`. SQLite therefore cannot use it for this lookup and the
cost grows quadratically with library size.

On a consistent copy of a real library database (1,245 artist identities,
2,015 album-artist credits, 8,919 indexed tracks), the unchanged query returned
the same 1,204 rows and result digest:

- before: 6.04-6.16 seconds;
- after: 2.35-3.17 milliseconds.

The composite form is covering for the production query. It is intentionally
not unique because one artist can have credits on multiple albums.

Refs #280. This addresses one native-library SQL CPU hotspot observed during
artist-discovery warming; it does not close the multi-symptom issue.

## Testing

- [x] I have tested these changes locally
- [x] I have added or updated tests
- Focused regression test: 1 passed, 13 deselected.
- Query plan contains:
  `SEARCH credit USING COVERING INDEX idx_local_album_artists_artist_album (local_artist_id=?)`
- Result set and digest were identical before and after the index on the real
  library copy.
- Changed files pass Ruff and `git diff --check`.
- Full backend run: 6,437 passed, 4 skipped, 13 failed; the same 13 failures
  reproduce on clean `origin/main` in this environment (12 expect a missing
  root `docker-compose.yml`; one has an existing stale mock expectation).

## AI-Assisted Contributions

Codex assisted with root-cause tracing, benchmarks, implementation, and test
design. An independent Codex review rechecked the lifecycle-to-query path,
SQLite plan, scaling behavior, idempotent startup creation, public branches,
open pull requests, and issue scope.

## Checklist

- [x] Backend lint passes (`backend/.venv/bin/ruff check backend`)
- [ ] Backend tests pass (`make backend-test`)
- [x] Frontend lint: not applicable (backend-only change)
- [x] Frontend type check: not applicable (backend-only change)
- [x] No `any` in TypeScript (not applicable)
- [x] No hardcoded colors (not applicable)
- [x] All external API calls have timeouts (no external API changes)
- [x] New msgspec structs follow existing patterns (not applicable)
- [x] TanStack Query used for all new data fetching (not applicable)
- [x] No secrets, tokens, or credentials in source
