### PR TITLE
feat(requests): add approval-safe client integration and shared attribution

### DIFF
--- a/backend/api/v1/routes/auth.py
+++ b/backend/api/v1/routes/auth.py
@@ -10,6 +10,8 @@ from api.v1.schemas.auth import (
     AuthProvidersResponse,
     AuthResponse,
     CreateUserRequest,
+    DeviceSessionRequest,
+    DeviceSessionResponse,
     ImportCandidateListResponse,
     ImportUsersRequest,
     ImportUsersResponse,
@@ -208,6 +210,28 @@ async def list_sessions(
 ) -> SessionListResponse:
     tokens = await auth.list_sessions(current_user.id)
     return SessionListResponse(sessions = [session_to_response(token) for token in tokens])
+
+
+@router.post("/device-sessions", response_model=DeviceSessionResponse)
+async def create_device_session(
+    current_user: CurrentUserDep,
+    body: DeviceSessionRequest = MsgSpecBody(DeviceSessionRequest),
+    auth: AuthService = Depends(get_auth_service),
+) -> DeviceSessionResponse:
+    """Mint a separate session for a trusted companion such as Apple Watch.
+
+    The caller's bearer is never copied. The returned bearer is shown once,
+    belongs to the same user, and appears independently in Sessions.
+    """
+    try:
+        token = await auth.issue_device_session(current_user.id, body.device_name)
+    except AuthenticationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+    providers = await auth.get_provider_names_for_users([current_user.id])
+    return DeviceSessionResponse(
+        token=token,
+        user=user_to_response(current_user, providers.get(current_user.id)),
+    )
 
 
 @router.delete("/sessions/{session_id}", status_code = status.HTTP_204_NO_CONTENT)

--- a/backend/api/v1/routes/auth.py
+++ b/backend/api/v1/routes/auth.py
@@ -224,10 +224,14 @@ async def create_device_session(
     belongs to the same user, and appears independently in Sessions.
     """
     try:
-        token = await auth.issue_device_session(current_user.id, body.device_name)
+        auth.validate_device_session_name(body.device_name)
     except AuthenticationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     providers = await auth.get_provider_names_for_users([current_user.id])
+    try:
+        token = await auth.issue_device_session(current_user.id, body.device_name)
+    except AuthenticationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
     return DeviceSessionResponse(
         token=token,
         user=user_to_response(current_user, providers.get(current_user.id)),

--- a/backend/api/v1/routes/tracks.py
+++ b/backend/api/v1/routes/tracks.py
@@ -10,10 +10,9 @@ import logging
 from fastapi import APIRouter, Depends
 
 from api.v1.schemas.download import TrackRequestBody, TrackRequestResponse
-from core.dependencies import get_acquisition_dispatcher, get_quota_service
+from core.dependencies import get_request_service
 from infrastructure.msgspec_fastapi import MsgSpecBody, MsgSpecRoute
 from middleware import CurrentUserDep
-from services.native.download_service import ALREADY_IN_LIBRARY
 
 logger = logging.getLogger(__name__)
 
@@ -25,16 +24,13 @@ async def request_track(
     recording_mbid: str,
     current_user: CurrentUserDep,
     body: TrackRequestBody = MsgSpecBody(TrackRequestBody),
-    service=Depends(get_acquisition_dispatcher),
-    quota=Depends(get_quota_service),
+    service=Depends(get_request_service),
 ):
-    # Track asks bypass the approval queue (existing behaviour) but still count
-    # toward the rolling request quota (Feature C layer 1, D20) - their download
-    # task IS the ask, so the gate runs at this submit point.
-    await quota.check_request_quota(current_user.id, current_user.role)
-    task_id = await service.request_track(
+    return await service.request_track(
+        recording_mbid,
         user_id=current_user.id,
-        recording_mbid=recording_mbid,
+        user_role=current_user.role,
+        requested_by_name=current_user.display_name,
         artist_name=body.artist_name,
         track_title=body.track_title,
         album_title=body.album_title,
@@ -43,6 +39,3 @@ async def request_track(
         artist_mbid=body.artist_mbid,
         release_mbid=body.release_id,
     )
-    if task_id == ALREADY_IN_LIBRARY:
-        return TrackRequestResponse(status="already_in_library")
-    return TrackRequestResponse(status="queued", task_id=task_id)

--- a/backend/api/v1/schemas/auth.py
+++ b/backend/api/v1/schemas/auth.py
@@ -36,6 +36,12 @@ class LoginRequest(AppStruct):
     password: str
 
 
+class DeviceSessionRequest(AppStruct):
+    """A caller-authorized, separately revocable session for one companion."""
+
+    device_name: str
+
+
 class PasswordRecoveryResetRequest(AppStruct):
     username: str
     recovery_code: str
@@ -56,6 +62,11 @@ class UserResponse(AppStruct):
     username: str | None = None
     username_display: str | None = None
     providers: list[str] = []
+
+
+class DeviceSessionResponse(AppStruct):
+    token: str
+    user: UserResponse
 
 
 class AuthResponse(AppStruct):

--- a/backend/api/v1/schemas/download.py
+++ b/backend/api/v1/schemas/download.py
@@ -320,7 +320,7 @@ class TrackRequestBody(AppStruct):
 
 
 class TrackRequestResponse(AppStruct):
-    status: str  # "queued" | "already_in_library"
+    status: str  # "awaiting_approval" | "queued" | "already_in_library"
     task_id: str | None = None
 
 

--- a/backend/api/v1/schemas/request.py
+++ b/backend/api/v1/schemas/request.py
@@ -40,6 +40,9 @@ class BatchRequestResponse(AppStruct):
     requested: int = 0
     skipped: int = 0
     overflow: int = 0
+    # Native clients must render the decision made at this mutation boundary,
+    # not infer it from a role value that may have changed moments earlier.
+    status: str = "pending"
 
 
 class BatchCancelRequest(AppStruct):

--- a/backend/api/v1/schemas/requests_page.py
+++ b/backend/api/v1/schemas/requests_page.py
@@ -30,6 +30,10 @@ class ActiveRequestItem(AppStruct):
     download_client: str | None = None
     user_id: str | None = None
     requested_by_name: str | None = None
+    request_kind: str = "album"
+    track_title: str | None = None
+    duration_seconds: int | None = None
+    track_release_group_mbid: str | None = None
 
 
 class RequestHistoryItem(AppStruct):
@@ -49,6 +53,10 @@ class RequestHistoryItem(AppStruct):
     reviewed_at: datetime | None = None
     download_task_id: str | None = None
     can_reimport: bool = False
+    request_kind: str = "album"
+    track_title: str | None = None
+    duration_seconds: int | None = None
+    track_release_group_mbid: str | None = None
 
 
 class ActiveRequestsResponse(AppStruct):

--- a/backend/api/v1/schemas/settings.py
+++ b/backend/api/v1/schemas/settings.py
@@ -706,6 +706,10 @@ class ConnectAppsSettings(AppStruct):
 
     subsonic_enabled: bool = False
     jellyfin_enabled: bool = False
+    # Capability negotiation for clients that must distinguish the historical
+    # exact-track endpoint (which bypassed approval) from the approval-safe
+    # implementation. Older servers omit this field, so clients fail closed.
+    exact_track_approval_supported: bool = True
     transcoding_enabled: bool = True
     transcode_default_format: Literal["mp3", "opus"] = "mp3"
     transcode_max_bitrate_kbps: int = 320

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -3,6 +3,7 @@ from pydantic import Field, TypeAdapter, ValidationError as PydanticValidationEr
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from typing import Self
 import logging
+import os
 import msgspec
 from core.exceptions import ConfigurationError
 from infrastructure.file_utils import atomic_write_json, read_json
@@ -157,8 +158,10 @@ class Settings(BaseSettings):
         return self
     
     def get_user_agent(self) -> str:
+        version = os.environ.get("COMMIT_TAG", "dev")
         id_part = self.instance_id[:8] if self.instance_id else "unknown"
-        return f"DroppedNeedle/1.0 ({id_part}; {self.contact_email}; https://www.droppedneedle.com)"
+        email = (self.contact_email or "").strip() or "contact@droppedneedle.com"
+        return f"DroppedNeedleApp/{version} ({id_part}; {email}; https://www.droppedneedle.com)"
 
     def load_from_file(self) -> None:
         if not self.config_file_path.exists():

--- a/backend/infrastructure/persistence/auth_store.py
+++ b/backend/infrastructure/persistence/auth_store.py
@@ -125,7 +125,8 @@ class AuthStore:
                     expires_at TEXT NOT NULL,
                     last_seen_at TEXT NOT NULL,
                     revoked INTEGER NOT NULL DEFAULT 0,
-                    user_agent TEXT
+                    user_agent TEXT,
+                    session_kind TEXT NOT NULL DEFAULT 'standard'
                 );
                 CREATE INDEX IF NOT EXISTS idx_auth_tokens_user
                     ON auth_tokens(user_id);
@@ -159,6 +160,15 @@ class AuthStore:
             # PKCE column ratchet: pre-PKCE databases lack it; additive, idempotent.
             try:
                 conn.execute("ALTER TABLE auth_oidc_states ADD COLUMN code_verifier TEXT")
+            except sqlite3.OperationalError:
+                pass  # duplicate column - already present
+            # Companion sessions must not be inferred from an untrusted HTTP User-Agent.
+            # Existing rows remain standard because their provenance is ambiguous.
+            try:
+                conn.execute(
+                    "ALTER TABLE auth_tokens ADD COLUMN session_kind "
+                    "TEXT NOT NULL DEFAULT 'standard'"
+                )
             except sqlite3.OperationalError:
                 pass  # duplicate column - already present
             # Username login (D3): additive, idempotent. `username` is the lowercased
@@ -638,6 +648,46 @@ class AuthStore:
             last_seen_at = now,
             revoked = False,
             user_agent = user_agent,
+        )
+
+    async def replace_companion_token(
+        self,
+        *,
+        id: str,
+        user_id: str,
+        token_hash: str,
+        user_agent: str,
+    ) -> TokenRecord:
+        """Issue one companion and revoke active same-label companions atomically."""
+        now = _now_iso()
+        expiry = _expiry_iso()
+
+        def operation(conn: sqlite3.Connection) -> None:
+            conn.execute(
+                """INSERT INTO auth_tokens
+                   (id, user_id, token_hash, issued_at, expires_at, last_seen_at,
+                    revoked, user_agent, session_kind)
+                   VALUES (?, ?, ?, ?, ?, ?, 0, ?, 'companion')""",
+                (id, user_id, token_hash, now, expiry, now, user_agent),
+            )
+            conn.execute(
+                """UPDATE auth_tokens SET revoked = 1
+                   WHERE user_id = ? AND user_agent = ? AND id != ?
+                     AND session_kind = 'companion'
+                     AND revoked = 0 AND expires_at > ?""",
+                (user_id, user_agent, id, now),
+            )
+
+        await self._write(operation)
+        return TokenRecord(
+            id=id,
+            user_id=user_id,
+            token_hash=token_hash,
+            issued_at=now,
+            expires_at=expiry,
+            last_seen_at=now,
+            revoked=False,
+            user_agent=user_agent,
         )
 
     async def verify_token(self, raw_token: str) -> TokenRecord | None:

--- a/backend/infrastructure/persistence/native_library_store.py
+++ b/backend/infrastructure/persistence/native_library_store.py
@@ -3067,6 +3067,84 @@ class NativeLibraryStore(PersistenceBase):
 
         return await self._read(operation)
 
+    async def target_enrichment_candidates(
+        self, *, after_mbid: str | None, limit: int
+    ) -> list[tuple[str, str, dict[str, Any]]]:
+        """Return one keyset page of live MusicBrainz artist and album identities."""
+
+        cursor_type = ""
+        cursor_mbid = ""
+        legacy_cursor = after_mbid or ""
+        if after_mbid and ":" in after_mbid:
+            candidate_type, candidate_mbid = after_mbid.split(":", 1)
+            if candidate_type in {"artist", "album"}:
+                cursor_type = candidate_type
+                cursor_mbid = candidate_mbid.casefold()
+                legacy_cursor = ""
+
+        def operation(
+            connection: sqlite3.Connection,
+        ) -> list[tuple[str, str, dict[str, Any]]]:
+            union = (
+                "SELECT entity_type, mbid_lower, name, title, artist_name FROM ("
+                "SELECT 'album' AS entity_type, lower(identity.release_group_mbid) "
+                "AS mbid_lower, NULL AS name, album.title AS title, "
+                "album.album_artist_name AS artist_name "
+                "FROM local_album_external_identities identity "
+                "JOIN local_albums album ON album.id = identity.local_album_id "
+                "WHERE identity.provider = 'musicbrainz' "
+                "AND album.retired_into_album_id IS NULL "
+                "AND EXISTS (SELECT 1 FROM local_tracks track "
+                "WHERE track.local_album_id = album.id "
+                "AND track.availability = 'indexed') "
+                "UNION ALL "
+                "SELECT 'artist' AS entity_type, lower(identity.provider_artist_id) "
+                "AS mbid_lower, artist.display_name AS name, NULL AS title, "
+                "NULL AS artist_name "
+                "FROM local_artist_external_identities identity "
+                "JOIN local_artists artist ON artist.id = identity.local_artist_id "
+                "WHERE identity.provider = 'musicbrainz' "
+                "AND artist.retired_into_artist_id IS NULL "
+                "AND EXISTS (SELECT 1 FROM local_album_artists credit "
+                "JOIN local_albums album ON album.id = credit.local_album_id "
+                "JOIN local_tracks track ON track.local_album_id = album.id "
+                "WHERE credit.local_artist_id = artist.id "
+                "AND album.retired_into_album_id IS NULL "
+                "AND track.availability = 'indexed')) "
+            )
+            if legacy_cursor:
+                rows = connection.execute(
+                    union
+                    + "WHERE mbid_lower > ? ORDER BY mbid_lower, entity_type LIMIT ?",
+                    (legacy_cursor.casefold(), max(1, limit)),
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    union
+                    + "WHERE entity_type > ? OR "
+                    "(entity_type = ? AND mbid_lower > ?) "
+                    "ORDER BY entity_type, mbid_lower LIMIT ?",
+                    (cursor_type, cursor_type, cursor_mbid, max(1, limit)),
+                ).fetchall()
+
+            candidates: list[tuple[str, str, dict[str, Any]]] = []
+            for row in rows:
+                entity_type = str(row["entity_type"])
+                payload = (
+                    {"name": str(row["name"])}
+                    if entity_type == "artist"
+                    else {
+                        "title": str(row["title"]),
+                        "artist_name": str(row["artist_name"]),
+                    }
+                )
+                candidates.append(
+                    (entity_type, str(row["mbid_lower"]), payload)
+                )
+            return candidates
+
+        return await self._read(operation)
+
     async def target_existing_provider_artist_ids(
         self, identifiers: list[str]
     ) -> set[str]:

--- a/backend/infrastructure/persistence/request_history.py
+++ b/backend/infrastructure/persistence/request_history.py
@@ -22,6 +22,19 @@ _REIMPORTABLE_CONDITION = (
     ")"
 )
 
+_REIMPORTABLE_JOIN_CONDITION = (
+    "rh.status = 'failed'"
+    " AND rh.download_task_id IS NOT NULL"
+    " AND EXISTS ("
+    "SELECT 1 FROM download_tasks"
+    " WHERE download_tasks.id = rh.download_task_id"
+    " AND download_tasks.status IN ('failed', 'partial')"
+    " AND download_tasks.source_username IS NOT NULL"
+    " AND download_tasks.search_job_id IS NOT NULL"
+    " AND download_tasks.candidate_index IS NOT NULL"
+    ")"
+)
+
 
 class RequestHistoryRecord(msgspec.Struct):
     musicbrainz_id: str
@@ -123,6 +136,31 @@ class RequestHistoryStore:
                 )
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS request_history_requesters (
+                    user_id TEXT NOT NULL,
+                    musicbrainz_id_lower TEXT NOT NULL,
+                    requested_at TEXT NOT NULL,
+                    requested_by_name TEXT,
+                    PRIMARY KEY (user_id, musicbrainz_id_lower)
+                )
+                """
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_request_history_requesters_mbid "
+                "ON request_history_requesters(musicbrainz_id_lower)"
+            )
+            # Preserve ownership of rows created before multi-listener attribution.
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO request_history_requesters (
+                    user_id, musicbrainz_id_lower, requested_at, requested_by_name
+                )
+                SELECT user_id, musicbrainz_id_lower, requested_at, requested_by_name
+                FROM request_history WHERE user_id IS NOT NULL
+                """
+            )
             conn.commit()
         finally:
             conn.close()
@@ -162,7 +200,11 @@ class RequestHistoryStore:
             artist_mbid=row["artist_mbid"],
             year=row["year"],
             cover_url=row["cover_url"],
-            requested_at=row["requested_at"],
+            requested_at=(
+                row["requester_requested_at"]
+                if "requester_requested_at" in keys
+                else row["requested_at"]
+            ),
             completed_at=row["completed_at"],
             status=row["status"],
             download_task_id=row["download_task_id"]
@@ -174,10 +216,16 @@ class RequestHistoryStore:
             auto_download_artist=bool(row["auto_download_artist"])
             if row["auto_download_artist"] is not None
             else False,
-            user_id=row["user_id"] if "user_id" in keys else None,
-            requested_by_name=row["requested_by_name"]
-            if "requested_by_name" in keys
-            else None,
+            user_id=(
+                row["requester_user_id"]
+                if "requester_user_id" in keys
+                else (row["user_id"] if "user_id" in keys else None)
+            ),
+            requested_by_name=(
+                row["requester_name"]
+                if "requester_name" in keys
+                else (row["requested_by_name"] if "requested_by_name" in keys else None)
+            ),
             release_mbid=row["release_mbid"] if "release_mbid" in keys else None,
             reviewed_by_id=row["reviewed_by_id"] if "reviewed_by_id" in keys else None,
             reviewed_by_name=row["reviewed_by_name"]
@@ -270,6 +318,21 @@ class RequestHistoryStore:
                     track_release_group_mbid,
                 ),
             )
+            if user_id is not None:
+                conn.execute(
+                    """
+                    INSERT INTO request_history_requesters (
+                        user_id, musicbrainz_id_lower, requested_at, requested_by_name
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT (user_id, musicbrainz_id_lower) DO UPDATE SET
+                        requested_at = excluded.requested_at,
+                        requested_by_name = COALESCE(
+                            excluded.requested_by_name,
+                            request_history_requesters.requested_by_name
+                        )
+                    """,
+                    (user_id, normalized_mbid, requested_at, requested_by_name),
+                )
 
         await self._write(operation)
 
@@ -334,7 +397,140 @@ class RequestHistoryStore:
                 """,
                 rows,
             )
+            if user_id is not None:
+                conn.executemany(
+                    """
+                    INSERT INTO request_history_requesters (
+                        user_id, musicbrainz_id_lower, requested_at, requested_by_name
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT (user_id, musicbrainz_id_lower) DO UPDATE SET
+                        requested_at = excluded.requested_at,
+                        requested_by_name = COALESCE(
+                            excluded.requested_by_name,
+                            request_history_requesters.requested_by_name
+                        )
+                    """,
+                    [
+                        (
+                            user_id,
+                            item["musicbrainz_id"].lower(),
+                            requested_at,
+                            requested_by_name,
+                        )
+                        for item in items
+                    ],
+                )
             return len(rows)
+
+        return await self._write(operation)
+
+    async def async_add_requester(
+        self,
+        musicbrainz_id: str,
+        user_id: str | None,
+        requested_by_name: str | None = None,
+    ) -> None:
+        if user_id is None:
+            return
+        await self.async_add_requesters(
+            [musicbrainz_id], user_id, requested_by_name=requested_by_name
+        )
+
+    async def async_add_requesters(
+        self,
+        musicbrainz_ids: list[str],
+        user_id: str | None,
+        requested_by_name: str | None = None,
+    ) -> None:
+        if user_id is None:
+            return
+        requested_at = datetime.now(timezone.utc).isoformat()
+        normalized = list(
+            dict.fromkeys(value.casefold() for value in musicbrainz_ids if value)
+        )
+        if not normalized:
+            return
+
+        def operation(conn: sqlite3.Connection) -> None:
+            conn.executemany(
+                """
+                INSERT INTO request_history_requesters (
+                    user_id, musicbrainz_id_lower, requested_at, requested_by_name
+                ) VALUES (?, ?, ?, ?)
+                ON CONFLICT (user_id, musicbrainz_id_lower) DO UPDATE SET
+                    requested_at = excluded.requested_at,
+                    requested_by_name = COALESCE(
+                        excluded.requested_by_name,
+                        request_history_requesters.requested_by_name
+                    )
+                """,
+                [
+                    (user_id, musicbrainz_id, requested_at, requested_by_name)
+                    for musicbrainz_id in normalized
+                ],
+            )
+
+        await self._write(operation)
+
+    async def async_is_requester(self, user_id: str, musicbrainz_id: str) -> bool:
+        normalized_mbid = musicbrainz_id.casefold()
+
+        def operation(conn: sqlite3.Connection) -> bool:
+            row = conn.execute(
+                "SELECT 1 FROM request_history_requesters "
+                "WHERE user_id = ? AND musicbrainz_id_lower = ?",
+                (user_id, normalized_mbid),
+            ).fetchone()
+            return row is not None
+
+        return await self._read(operation)
+
+    async def async_requester_count(self, musicbrainz_id: str) -> int:
+        normalized_mbid = musicbrainz_id.casefold()
+
+        def operation(conn: sqlite3.Connection) -> int:
+            row = conn.execute(
+                "SELECT COUNT(*) AS count FROM request_history_requesters "
+                "WHERE musicbrainz_id_lower = ?",
+                (normalized_mbid,),
+            ).fetchone()
+            return int(row["count"] if row is not None else 0)
+
+        return await self._read(operation)
+
+    async def async_remove_requester(self, user_id: str, musicbrainz_id: str) -> bool:
+        """Remove only one listener's interest and transfer primary attribution."""
+        normalized_mbid = musicbrainz_id.casefold()
+
+        def operation(conn: sqlite3.Connection) -> bool:
+            cursor = conn.execute(
+                "DELETE FROM request_history_requesters "
+                "WHERE user_id = ? AND musicbrainz_id_lower = ?",
+                (user_id, normalized_mbid),
+            )
+            if cursor.rowcount <= 0:
+                return False
+            owner = conn.execute(
+                "SELECT user_id FROM request_history " "WHERE musicbrainz_id_lower = ?",
+                (normalized_mbid,),
+            ).fetchone()
+            if owner is not None and owner["user_id"] == user_id:
+                successor = conn.execute(
+                    "SELECT user_id, requested_by_name FROM request_history_requesters "
+                    "WHERE musicbrainz_id_lower = ? ORDER BY requested_at ASC LIMIT 1",
+                    (normalized_mbid,),
+                ).fetchone()
+                if successor is not None:
+                    conn.execute(
+                        "UPDATE request_history SET user_id = ?, requested_by_name = ? "
+                        "WHERE musicbrainz_id_lower = ?",
+                        (
+                            successor["user_id"],
+                            successor["requested_by_name"],
+                            normalized_mbid,
+                        ),
+                    )
+            return True
 
         return await self._write(operation)
 
@@ -455,6 +651,18 @@ class RequestHistoryStore:
                     (source_key,),
                 )
                 conn.execute(
+                    "INSERT OR IGNORE INTO request_history_requesters "
+                    "(user_id, musicbrainz_id_lower, requested_at, requested_by_name) "
+                    "SELECT user_id, ?, requested_at, requested_by_name "
+                    "FROM request_history_requesters WHERE musicbrainz_id_lower = ?",
+                    (target_key, source_key),
+                )
+                conn.execute(
+                    "DELETE FROM request_history_requesters "
+                    "WHERE musicbrainz_id_lower = ?",
+                    (source_key,),
+                )
+                conn.execute(
                     "DELETE FROM request_history WHERE musicbrainz_id_lower IN (?, ?)",
                     (source_key, target_key),
                 )
@@ -566,7 +774,10 @@ class RequestHistoryStore:
 
         def operation(conn: sqlite3.Connection) -> int:
             row = conn.execute(
-                f"SELECT COUNT(*) AS count FROM request_history WHERE user_id = ? AND status IN ({placeholders})",
+                "SELECT COUNT(*) AS count FROM request_history AS rh "
+                "JOIN request_history_requesters AS rr "
+                "ON rr.musicbrainz_id_lower = rh.musicbrainz_id_lower "
+                f"WHERE rr.user_id = ? AND rh.status IN ({placeholders})",
                 (user_id, *self._USER_ACTIVE_STATUSES),
             ).fetchone()
             return int(row["count"] if row is not None else 0)
@@ -581,7 +792,14 @@ class RequestHistoryStore:
 
         def operation(conn: sqlite3.Connection) -> list[RequestHistoryRecord]:
             rows = conn.execute(
-                f"SELECT * FROM request_history WHERE user_id = ? AND status IN ({placeholders}) ORDER BY requested_at DESC",
+                "SELECT rh.*, rr.user_id AS requester_user_id, "
+                "rr.requested_by_name AS requester_name, "
+                "rr.requested_at AS requester_requested_at "
+                "FROM request_history AS rh "
+                "JOIN request_history_requesters AS rr "
+                "ON rr.musicbrainz_id_lower = rh.musicbrainz_id_lower "
+                f"WHERE rr.user_id = ? AND rh.status IN ({placeholders}) "
+                "ORDER BY rr.requested_at DESC",
                 (user_id, *self._USER_ACTIVE_STATUSES),
             ).fetchall()
             return [
@@ -679,36 +897,44 @@ class RequestHistoryStore:
         offset = (safe_page - 1) * safe_page_size
 
         _SORT_MAP = {
-            "newest": "requested_at DESC",
-            "oldest": "requested_at ASC",
-            "status": "status ASC, requested_at DESC",
+            "newest": "rr.requested_at DESC",
+            "oldest": "rr.requested_at ASC",
+            "status": "rh.status ASC, rr.requested_at DESC",
         }
-        order_clause = _SORT_MAP.get(sort or "", "requested_at DESC")
+        order_clause = _SORT_MAP.get(sort or "", "rr.requested_at DESC")
 
         def operation(
             conn: sqlite3.Connection,
         ) -> tuple[list[RequestHistoryRecord], int]:
             dismiss_clause = (
-                "AND musicbrainz_id_lower NOT IN "
+                "AND rh.musicbrainz_id_lower NOT IN "
                 "(SELECT musicbrainz_id_lower FROM request_history_dismissals WHERE user_id = ?)"
             )
             if status_filter == "reimportable":
-                where = (
-                    f"WHERE user_id = ? AND {_REIMPORTABLE_CONDITION} {dismiss_clause}"
-                )
+                where = f"WHERE rr.user_id = ? AND {_REIMPORTABLE_JOIN_CONDITION} {dismiss_clause}"
                 params: tuple = (user_id, user_id)
             elif status_filter:
-                where = f"WHERE user_id = ? AND status = ? {dismiss_clause}"
+                where = f"WHERE rr.user_id = ? AND rh.status = ? {dismiss_clause}"
                 params = (user_id, status_filter, user_id)
             else:
-                where = f"WHERE user_id = ? {dismiss_clause}"
+                where = f"WHERE rr.user_id = ? {dismiss_clause}"
                 params = (user_id, user_id)
 
             total_row = conn.execute(
-                f"SELECT COUNT(*) AS count FROM request_history {where}", params
+                "SELECT COUNT(*) AS count FROM request_history AS rh "
+                "JOIN request_history_requesters AS rr "
+                "ON rr.musicbrainz_id_lower = rh.musicbrainz_id_lower "
+                f"{where}",
+                params,
             ).fetchone()
             rows = conn.execute(
-                f"SELECT * FROM request_history {where} ORDER BY {order_clause} LIMIT ? OFFSET ?",
+                "SELECT rh.*, rr.user_id AS requester_user_id, "
+                "rr.requested_by_name AS requester_name, "
+                "rr.requested_at AS requester_requested_at "
+                "FROM request_history AS rh "
+                "JOIN request_history_requesters AS rr "
+                "ON rr.musicbrainz_id_lower = rh.musicbrainz_id_lower "
+                f"{where} ORDER BY {order_clause} LIMIT ? OFFSET ?",
                 params + (safe_page_size, offset),
             ).fetchall()
             records = [
@@ -865,6 +1091,10 @@ class RequestHistoryStore:
                 "DELETE FROM request_history_dismissals WHERE musicbrainz_id_lower = ?",
                 (normalized_mbid,),
             )
+            conn.execute(
+                "DELETE FROM request_history_requesters WHERE musicbrainz_id_lower = ?",
+                (normalized_mbid,),
+            )
             return cursor.rowcount > 0
 
         return await self._write(operation)
@@ -928,6 +1158,10 @@ class RequestHistoryStore:
                 # no wanted_watches table yet (fresh DB before the store's first
                 # construction) - nothing can be watched, prune unguarded
                 cursor = conn.execute(base, (*terminal_statuses, cutoff_iso))
+            conn.execute(
+                "DELETE FROM request_history_requesters WHERE musicbrainz_id_lower "
+                "NOT IN (SELECT musicbrainz_id_lower FROM request_history)"
+            )
             return cursor.rowcount
 
         return await self._write(operation)

--- a/backend/infrastructure/persistence/request_history.py
+++ b/backend/infrastructure/persistence/request_history.py
@@ -42,6 +42,10 @@ class RequestHistoryRecord(msgspec.Struct):
     reviewed_by_id: str | None = None
     reviewed_by_name: str | None = None
     reviewed_at: str | None = None
+    request_kind: str = "album"
+    track_title: str | None = None
+    duration_seconds: int | None = None
+    track_release_group_mbid: str | None = None
 
 
 class RequestHistoryStore:
@@ -97,6 +101,10 @@ class RequestHistoryStore:
                 ("reviewed_at", "TEXT"),
                 ("download_task_id", "TEXT"),
                 ("release_mbid", "TEXT"),
+                ("request_kind", "TEXT NOT NULL DEFAULT 'album'"),
+                ("track_title", "TEXT"),
+                ("duration_seconds", "INTEGER"),
+                ("track_release_group_mbid", "TEXT"),
             ]:
                 try:
                     conn.execute(
@@ -176,6 +184,17 @@ class RequestHistoryStore:
             if "reviewed_by_name" in keys
             else None,
             reviewed_at=row["reviewed_at"] if "reviewed_at" in keys else None,
+            request_kind=(row["request_kind"] if "request_kind" in keys else "album")
+            or "album",
+            track_title=row["track_title"] if "track_title" in keys else None,
+            duration_seconds=(
+                row["duration_seconds"] if "duration_seconds" in keys else None
+            ),
+            track_release_group_mbid=(
+                row["track_release_group_mbid"]
+                if "track_release_group_mbid" in keys
+                else None
+            ),
         )
 
     async def async_record_request(
@@ -192,6 +211,10 @@ class RequestHistoryStore:
         requested_by_name: str | None = None,
         release_mbid: str | None = None,
         initial_status: str = "pending",
+        request_kind: str = "album",
+        track_title: str | None = None,
+        duration_seconds: int | None = None,
+        track_release_group_mbid: str | None = None,
     ) -> None:
         requested_at = datetime.now(timezone.utc).isoformat()
         normalized_mbid = musicbrainz_id.lower()
@@ -203,8 +226,9 @@ class RequestHistoryStore:
                     musicbrainz_id_lower, musicbrainz_id, artist_name, album_title,
                     artist_mbid, year, cover_url, requested_at, completed_at, status,
                     monitor_artist, auto_download_artist, user_id, requested_by_name,
-                    release_mbid
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
+                    release_mbid, request_kind, track_title, duration_seconds,
+                    track_release_group_mbid
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(musicbrainz_id_lower) DO UPDATE SET
                     musicbrainz_id = excluded.musicbrainz_id,
                     artist_name = excluded.artist_name,
@@ -219,7 +243,11 @@ class RequestHistoryStore:
                     auto_download_artist = excluded.auto_download_artist,
                     user_id = COALESCE(excluded.user_id, request_history.user_id),
                     requested_by_name = COALESCE(excluded.requested_by_name, request_history.requested_by_name),
-                    release_mbid = excluded.release_mbid
+                    release_mbid = excluded.release_mbid,
+                    request_kind = excluded.request_kind,
+                    track_title = excluded.track_title,
+                    duration_seconds = excluded.duration_seconds,
+                    track_release_group_mbid = excluded.track_release_group_mbid
                 """,
                 (
                     normalized_mbid,
@@ -236,6 +264,10 @@ class RequestHistoryStore:
                     user_id,
                     requested_by_name,
                     release_mbid,
+                    request_kind,
+                    track_title,
+                    duration_seconds,
+                    track_release_group_mbid,
                 ),
             )
 
@@ -801,6 +833,25 @@ class RequestHistoryStore:
             )
 
         await self._write(operation)
+
+    async def async_get_record_by_download_task_id(
+        self, download_task_id: str
+    ) -> RequestHistoryRecord | None:
+        """Resolve the request that owns a native task.
+
+        Album requests historically used the release-group MBID as their key.
+        Exact-track requests use the recording MBID, so task ownership is the
+        only identifier that is correct for both request kinds.
+        """
+
+        def operation(conn: sqlite3.Connection) -> RequestHistoryRecord | None:
+            row = conn.execute(
+                "SELECT * FROM request_history WHERE download_task_id = ? LIMIT 1",
+                (download_task_id,),
+            ).fetchone()
+            return self._row_to_record(row)
+
+        return await self._read(operation)
 
     async def async_delete_record(self, musicbrainz_id: str) -> bool:
         normalized_mbid = musicbrainz_id.lower()

--- a/backend/main.py
+++ b/backend/main.py
@@ -815,6 +815,7 @@ app.add_middleware(
         "/api/v1/discover": (10.0, 20),
         "/api/v1/covers": (15.0, 30),
         "/api/v1/auth/login": (2.0, 5),
+        "/api/v1/auth/device-sessions": (1.0, 5),
         "/api/v1/auth/password-recovery/reset": (1.0, 5),
         "/api/v1/auth/setup": (1.0, 3),
         "/api/v1/auth/plex/poll": (5.0, 10),

--- a/backend/repositories/coverart_artist.py
+++ b/backend/repositories/coverart_artist.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 LOCAL_SOURCE_TIMEOUT_SECONDS = 1.0
 T = TypeVar("T")
-DEFAULT_EXTERNAL_USER_AGENT = "DroppedNeedle/1.0 (contact@droppedneedle.com; https://www.droppedneedle.com)"
+DEFAULT_EXTERNAL_USER_AGENT = "DroppedNeedleApp/1.0 (contact@droppedneedle.com; https://www.droppedneedle.com)"
 
 
 class TransientImageFetchError(Exception):

--- a/backend/scripts/update_management_genres.py
+++ b/backend/scripts/update_management_genres.py
@@ -12,6 +12,7 @@ from datetime import date
 import json
 from pathlib import Path
 from urllib.request import Request, urlopen
+from core.config import get_settings
 
 SOURCE_URL = "https://musicbrainz.org/ws/2/genre/all?fmt=txt"
 
@@ -30,12 +31,7 @@ def main() -> None:
     existing = json.loads(args.asset.read_text(encoding="utf-8"))
     request = Request(
         SOURCE_URL,
-        headers={
-            "User-Agent": (
-                "DroppedNeedle/LibraryManagement "
-                "(https://github.com/DroppedNeedle/DroppedNeedle)"
-            )
-        },
+        headers={"User-Agent": get_settings().get_user_agent()},
     )
     with urlopen(request, timeout=30) as response:  # noqa: S310 - fixed HTTPS URL
         names = sorted(

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -439,6 +439,23 @@ class AuthService:
     async def list_sessions(self, user_id: str) -> list[TokenRecord]:
         return await self._store.list_tokens_for_user(user_id)
 
+    async def issue_device_session(self, user_id: str, device_name: str) -> str:
+        """Create a distinct, revocable session without copying the caller's token.
+
+        The authenticated caller already proved ownership of the account. The
+        bounded label is stored only as the session user-agent so the existing
+        session roster can identify and revoke the companion independently.
+        """
+        label = " ".join((device_name or "").split())
+        if not label or len(label) > 80:
+            raise AuthenticationError("Invalid device name")
+        await self._require_user(user_id)
+        user_agent = f"Tonarr companion · {label}"
+        for session in await self._store.list_tokens_for_user(user_id):
+            if session.user_agent == user_agent:
+                await self._store.revoke_token(session.id)
+        return await self._issue_session(user_id, user_agent=user_agent)
+
     async def revoke_session(self, token_id: str, requesting_user_id: str) -> None:
         tokens = await self._store.list_tokens_for_user(requesting_user_id)
         owned = any(token.id == token_id for token in tokens)

--- a/backend/services/auth_service.py
+++ b/backend/services/auth_service.py
@@ -439,6 +439,13 @@ class AuthService:
     async def list_sessions(self, user_id: str) -> list[TokenRecord]:
         return await self._store.list_tokens_for_user(user_id)
 
+    @staticmethod
+    def validate_device_session_name(device_name: str) -> str:
+        label = " ".join((device_name or "").split())
+        if not label or len(label) > 80:
+            raise AuthenticationError("Invalid device name")
+        return label
+
     async def issue_device_session(self, user_id: str, device_name: str) -> str:
         """Create a distinct, revocable session without copying the caller's token.
 
@@ -446,15 +453,17 @@ class AuthService:
         bounded label is stored only as the session user-agent so the existing
         session roster can identify and revoke the companion independently.
         """
-        label = " ".join((device_name or "").split())
-        if not label or len(label) > 80:
-            raise AuthenticationError("Invalid device name")
+        label = self.validate_device_session_name(device_name)
         await self._require_user(user_id)
         user_agent = f"Tonarr companion · {label}"
-        for session in await self._store.list_tokens_for_user(user_id):
-            if session.user_agent == user_agent:
-                await self._store.revoke_token(session.id)
-        return await self._issue_session(user_id, user_agent=user_agent)
+        raw_token, token_hash = self._store.issue_token()
+        await self._store.replace_companion_token(
+            id=_new_id(),
+            user_id=user_id,
+            token_hash=token_hash,
+            user_agent=user_agent,
+        )
+        return raw_token
 
     async def revoke_session(self, token_id: str, requesting_user_id: str) -> None:
         tokens = await self._store.list_tokens_for_user(requesting_user_id)

--- a/backend/services/native/target_library_repository.py
+++ b/backend/services/native/target_library_repository.py
@@ -146,6 +146,15 @@ class TargetLibraryRepository:
         )
         return [mbid for mbid in mbids if mbid > cursor][: max(1, limit)]
 
+    async def get_enrichment_candidates(
+        self, *, after_mbid: str | None, limit: int
+    ) -> list[tuple[str, str, dict[str, Any]]]:
+        """Page live provider identities for background metadata enrichment."""
+        return await self._store.target_enrichment_candidates(
+            after_mbid=after_mbid,
+            limit=limit,
+        )
+
     async def existing_album_mbids(self, identifiers: list[str]) -> set[str]:
         normalized = {
             value.strip().casefold() for value in identifiers if value.strip()

--- a/backend/services/precache/audiodb_phase.py
+++ b/backend/services/precache/audiodb_phase.py
@@ -8,6 +8,7 @@ from typing import Any, TYPE_CHECKING
 
 import httpx
 
+from core.config import get_settings
 from repositories.protocols import CoverArtRepositoryProtocol
 from repositories.coverart_disk_cache import get_cache_filename, VALID_IMAGE_CONTENT_TYPES
 from services.cache_status_service import CacheStatusService
@@ -102,7 +103,7 @@ class AudioDBPhase:
                 else:
                     logger.debug("audiodb.prewarm action=http_client_fallback entity_type=%s mbid=%s", entity_type, mbid[:8])
                     async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=5.0)) as client:
-                        response = await client.get(url, headers={"User-Agent": "DroppedNeedle/1.0"}, follow_redirects=True)
+                        response = await client.get(url, headers={"User-Agent": get_settings().get_user_agent()}, follow_redirects=True)
 
             if response.status_code != 200:
                 logger.debug(

--- a/backend/services/quota_service.py
+++ b/backend/services/quota_service.py
@@ -4,9 +4,9 @@ Two distinct layers - deliberately NOT one choke point:
 
 - **Layer 1, request-count quota, at submit.** A plain user's ask is recorded in
   ``request_history`` long before any download task exists, so the count gate runs
-  where the ask is made: ``RequestService.request_album``/``request_batch`` and the
-  per-track request route (tracks bypass approval, so their ``download_tasks`` row
-  is the ask). Rolling window (D9); pending asks count.
+  where the ask is made: ``RequestService.request_album``/``request_batch``/
+  ``request_track``. Exact tracks share the same approval gate as albums. Rolling
+  window (D9); pending asks count.
 
 - **Layer 2, byte caps, at every download-task-creation site.** The global library
   cap (all roles) and the per-user storage quota apply when bytes will actually be

--- a/backend/services/request_service.py
+++ b/backend/services/request_service.py
@@ -133,6 +133,9 @@ class RequestService:
         try:
             existing = await self._request_history.async_get_record(musicbrainz_id)
             if existing and existing.status in ("pending", "downloading"):
+                await self._request_history.async_add_requester(
+                    musicbrainz_id, user_id, requested_by_name
+                )
                 if monitor_artist and not existing.monitor_artist:
                     await self._request_history.async_update_monitoring_flags(
                         musicbrainz_id,
@@ -146,6 +149,9 @@ class RequestService:
                     status=existing.status,
                 )
             if existing and existing.status == "awaiting_approval":
+                await self._request_history.async_add_requester(
+                    musicbrainz_id, user_id, requested_by_name
+                )
                 return RequestAcceptedResponse(
                     success=True,
                     message="Request is awaiting admin approval",
@@ -284,6 +290,9 @@ class RequestService:
             "queued",
             "downloading",
         ):
+            await self._request_history.async_add_requester(
+                recording_mbid, user_id, requested_by_name
+            )
             return TrackRequestResponse(
                 status=(
                     "awaiting_approval"
@@ -393,6 +402,14 @@ class RequestService:
             new_items = [
                 item for item in items if item["musicbrainz_id"].lower() not in active
             ]
+            existing_items = [
+                item["musicbrainz_id"]
+                for item in items
+                if item["musicbrainz_id"].lower() in active
+            ]
+            await self._request_history.async_add_requesters(
+                existing_items, user_id, requested_by_name
+            )
             skipped = duplicate_count + len(items) - len(new_items)
 
             if not new_items:
@@ -401,6 +418,7 @@ class RequestService:
                     message="All albums already requested",
                     requested=0,
                     skipped=skipped,
+                    status="already_requested",
                 )
 
             # A batch of N counts as N asks (A4); over-quota rejects the WHOLE batch
@@ -427,6 +445,7 @@ class RequestService:
                     message="Batch request submitted, awaiting admin approval",
                     requested=len(new_items),
                     skipped=skipped,
+                    status="awaiting_approval",
                 )
 
             # auto-approve: dispatch each item through the native pipeline (mirrors
@@ -470,6 +489,7 @@ class RequestService:
                 requested=dispatched,
                 skipped=skipped,
                 overflow=0,
+                status="pending" if dispatched else "failed",
             )
         except (ExternalServiceError, ValidationError):
             raise
@@ -491,9 +511,21 @@ class RequestService:
         for mbid in musicbrainz_ids:
             try:
                 record = await self._request_history.async_get_record(mbid)
-                if not is_admin and (record is None or record.user_id != user_id):
-                    failed += 1
-                    continue
+                if not is_admin:
+                    if (
+                        record is None
+                        or not await self._request_history.async_is_requester(
+                            user_id or "", mbid
+                        )
+                    ):
+                        failed += 1
+                        continue
+                    if await self._request_history.async_requester_count(mbid) > 1:
+                        await self._request_history.async_remove_requester(
+                            user_id or "", mbid
+                        )
+                        cancelled += 1
+                        continue
                 # best-effort: a missing/non-cancellable task must not block marking
                 if record is not None and record.download_task_id:
                     try:

--- a/backend/services/request_service.py
+++ b/backend/services/request_service.py
@@ -9,6 +9,7 @@ from api.v1.schemas.request import (
     BatchRequestResponse,
     RequestAcceptedResponse,
 )
+from api.v1.schemas.download import TrackRequestResponse
 from core.exceptions import ExternalServiceError, ValidationError
 from infrastructure.queue.priority_queue import RequestPriority
 from services.native.download_service import ALREADY_IN_LIBRARY
@@ -249,6 +250,105 @@ class RequestService:
             musicbrainz_id=musicbrainz_id,
             status="pending",
         )
+
+    async def request_track(
+        self,
+        recording_mbid: str,
+        *,
+        artist_name: str,
+        track_title: str,
+        album_title: str | None = None,
+        duration_seconds: int | None = None,
+        release_group_mbid: str | None = None,
+        artist_mbid: str | None = None,
+        release_mbid: str | None = None,
+        user_id: str,
+        user_role: str,
+        requested_by_name: str | None = None,
+    ) -> TrackRequestResponse:
+        """Record an exact-track ask before dispatching it.
+
+        This deliberately shares the album approval gate. A normal user can
+        request one recording, but only a trusted user or an owner can start
+        acquisition without review. The previous route bypassed approval and
+        made exact-track requests less safe than whole-album requests.
+        """
+        needs_approval = user_role == "user"
+        existing = await self._request_history.async_get_record(recording_mbid)
+        if existing and existing.status in (
+            "awaiting_approval",
+            "pending",
+            "queued",
+            "downloading",
+        ):
+            return TrackRequestResponse(
+                status=(
+                    "awaiting_approval"
+                    if existing.status == "awaiting_approval"
+                    else "queued"
+                ),
+                task_id=existing.download_task_id,
+            )
+
+        if self._quota is not None:
+            await self._quota.check_request_quota(user_id, user_role)
+            await self._quota.check_storage_admission(user_id, "user")
+
+        await self._request_history.async_record_request(
+            musicbrainz_id=recording_mbid,
+            artist_name=artist_name or "Unknown",
+            album_title=album_title or "Single track",
+            artist_mbid=artist_mbid,
+            user_id=user_id,
+            requested_by_name=requested_by_name,
+            release_mbid=release_mbid,
+            initial_status="awaiting_approval" if needs_approval else "pending",
+            request_kind="track",
+            track_title=track_title,
+            duration_seconds=duration_seconds,
+            track_release_group_mbid=release_group_mbid,
+        )
+
+        if needs_approval:
+            logger.info(
+                "Exact-track request queued for approval: %s by user %s",
+                recording_mbid,
+                user_id,
+            )
+            return TrackRequestResponse(status="awaiting_approval")
+
+        try:
+            task_id = await self._acquisition.request_track(
+                user_id=user_id,
+                recording_mbid=recording_mbid,
+                artist_name=artist_name,
+                track_title=track_title,
+                album_title=album_title,
+                duration_seconds=duration_seconds,
+                release_group_mbid=release_group_mbid,
+                artist_mbid=artist_mbid,
+                release_mbid=release_mbid,
+            )
+        except Exception:
+            await self._request_history.async_update_status(
+                recording_mbid,
+                "failed",
+                completed_at=datetime.now(timezone.utc).isoformat(),
+            )
+            raise
+
+        if task_id == ALREADY_IN_LIBRARY:
+            await self._request_history.async_update_status(
+                recording_mbid,
+                "imported",
+                completed_at=datetime.now(timezone.utc).isoformat(),
+            )
+            return TrackRequestResponse(status="already_in_library")
+
+        await self._request_history.async_update_download_task_id(
+            recording_mbid, task_id
+        )
+        return TrackRequestResponse(status="queued", task_id=task_id)
 
     async def request_batch(
         self,

--- a/backend/services/request_service.py
+++ b/backend/services/request_service.py
@@ -124,7 +124,10 @@ class RequestService:
             musicbrainz_id
         )
 
-        needs_approval = user_role == "user"
+        # Fail closed for any future or malformed role. Only the two roles the
+        # server explicitly grants acquisition authority may dispatch without
+        # owner review.
+        needs_approval = user_role not in ("trusted", "admin")
         initial_status = "awaiting_approval" if needs_approval else "pending"
 
         try:
@@ -273,7 +276,7 @@ class RequestService:
         acquisition without review. The previous route bypassed approval and
         made exact-track requests less safe than whole-album requests.
         """
-        needs_approval = user_role == "user"
+        needs_approval = user_role not in ("trusted", "admin")
         existing = await self._request_history.async_get_record(recording_mbid)
         if existing and existing.status in (
             "awaiting_approval",
@@ -382,7 +385,7 @@ class RequestService:
             seen_mbids.add(canonical_key)
             items.append(item)
 
-        needs_approval = user_role == "user"
+        needs_approval = user_role not in ("trusted", "admin")
         initial_status = "awaiting_approval" if needs_approval else "pending"
 
         try:

--- a/backend/services/requests_page_service.py
+++ b/backend/services/requests_page_service.py
@@ -248,8 +248,22 @@ class RequestsPageService:
         record = await self._request_history.async_get_record(musicbrainz_id)
         if not record:
             return CancelRequestResponse(success=False, message="Request not found")
-        if user_role != "admin" and record.user_id != user_id:
-            raise PermissionDeniedError("Cannot cancel another user's request")
+        if user_role != "admin":
+            if not await self._request_history.async_is_requester(
+                user_id, musicbrainz_id
+            ):
+                raise PermissionDeniedError("Cannot cancel another user's request")
+            if await self._request_history.async_requester_count(musicbrainz_id) > 1:
+                await self._request_history.async_remove_requester(
+                    user_id, musicbrainz_id
+                )
+                return CancelRequestResponse(
+                    success=True,
+                    message=(
+                        "Removed from your requests. The shared server request "
+                        "continues for another listener."
+                    ),
+                )
 
         # awaiting_approval requests never dispatched, cancel directly
         if record.status == "awaiting_approval":
@@ -302,7 +316,9 @@ class RequestsPageService:
         record = await self._request_history.async_get_record(musicbrainz_id)
         if not record:
             return RetryRequestResponse(success=False, message="Request not found")
-        if user_role != "admin" and record.user_id != user_id:
+        if user_role != "admin" and not await self._request_history.async_is_requester(
+            user_id, musicbrainz_id
+        ):
             raise PermissionDeniedError("Cannot retry another user's request")
 
         if record.status not in _RETRYABLE_STATUSES:
@@ -323,6 +339,7 @@ class RequestsPageService:
                 record,
                 origin="retry",
                 fallback_user_id=user_id,
+                user_id_override=user_id if user_role != "admin" else None,
             )
         except ValidationError as e:
             # cap/quota rejection: restore the pre-retry status (don't strand it as
@@ -359,7 +376,9 @@ class RequestsPageService:
             return False
         # ownership checked before clearability so a non-owner gets 403, not a
         # misleading 200/False, on another user's row
-        if user_role != "admin" and record.user_id != user_id:
+        if user_role != "admin" and not await self._request_history.async_is_requester(
+            user_id, musicbrainz_id
+        ):
             raise PermissionDeniedError("Cannot clear another user's request")
         if record.status not in _CLEARABLE_STATUSES:
             return False
@@ -459,9 +478,10 @@ class RequestsPageService:
         *,
         origin: str,
         fallback_user_id: str = "",
+        user_id_override: str | None = None,
     ) -> str:
         """Dispatch an approved/retried request without widening exact tracks."""
-        user_id = record.user_id or fallback_user_id
+        user_id = user_id_override or record.user_id or fallback_user_id
         if record.request_kind == "track":
             if not record.track_title:
                 raise ValidationError("Exact-track request is missing its track title")

--- a/backend/services/requests_page_service.py
+++ b/backend/services/requests_page_service.py
@@ -141,6 +141,10 @@ class RequestsPageService:
                 download_task_id=r.download_task_id,
                 can_reimport=r.status == "failed"
                 and r.download_task_id in reimportable,
+                request_kind=r.request_kind,
+                track_title=r.track_title,
+                duration_seconds=r.duration_seconds,
+                track_release_group_mbid=r.track_release_group_mbid,
             )
             for r in records
         ]
@@ -181,17 +185,7 @@ class RequestsPageService:
         # (the 'already_in_library' sentinel is guarded)
         if self._acquisition is not None:
             try:
-                task_id = await self._acquisition.request_album(
-                    user_id=record.user_id or "",
-                    release_group_mbid=musicbrainz_id,
-                    artist_name=record.artist_name or "Unknown",
-                    album_title=record.album_title or "Unknown",
-                    year=record.year,
-                    artist_mbid=record.artist_mbid,
-                    origin="user",
-                    release_mbid=record.release_mbid,
-                    track_count_priority=RequestPriority.USER_INITIATED,
-                )
+                task_id = await self._dispatch_record(record, origin="user")
             except ValidationError as e:
                 # A cap/quota rejection (Feature C) is not a failure of the request:
                 # put it BACK in the approval queue (it would otherwise silently
@@ -211,7 +205,7 @@ class RequestsPageService:
                 )
                 return CancelRequestResponse(
                     success=False,
-                    message=f"Approved but failed to start: {record.album_title}",
+                    message=f"Approved but failed to start: {self._record_title(record)}",
                 )
             from services.native.download_service import ALREADY_IN_LIBRARY
 
@@ -219,8 +213,14 @@ class RequestsPageService:
                 await self._request_history.async_update_download_task_id(
                     musicbrainz_id, task_id
                 )
+            else:
+                await self._request_history.async_update_status(
+                    musicbrainz_id,
+                    "imported",
+                    completed_at=datetime.now(timezone.utc).isoformat(),
+                )
         return CancelRequestResponse(
-            success=True, message=f"Approved: {record.album_title}"
+            success=True, message=f"Approved: {self._record_title(record)}"
         )
 
     async def reject_request(
@@ -239,7 +239,7 @@ class RequestsPageService:
             musicbrainz_id, "rejected", reviewer_id, reviewer_name, completed_at=now_iso
         )
         return CancelRequestResponse(
-            success=True, message=f"Rejected: {record.album_title}"
+            success=True, message=f"Rejected: {self._record_title(record)}"
         )
 
     async def cancel_request(
@@ -259,7 +259,7 @@ class RequestsPageService:
             )
             return CancelRequestResponse(
                 success=True,
-                message=f"Cancelled request for {record.album_title}",
+                message=f"Cancelled request for {self._record_title(record)}",
             )
 
         if record.status not in _CANCELLABLE_STATUSES:
@@ -293,7 +293,7 @@ class RequestsPageService:
 
         return CancelRequestResponse(
             success=True,
-            message=f"Cancelled download of {record.album_title}",
+            message=f"Cancelled download of {self._record_title(record)}",
         )
 
     async def retry_request(
@@ -319,16 +319,10 @@ class RequestsPageService:
             await self._request_history.async_update_status(musicbrainz_id, "pending")
             # A retry re-dispatches an already-recorded ask, so it is not a new
             # user request for quota purposes (CollectionManagement D20).
-            task_id = await self._acquisition.request_album(
-                user_id=record.user_id or user_id or "",
-                release_group_mbid=musicbrainz_id,
-                artist_name=record.artist_name or "Unknown",
-                album_title=record.album_title or "Unknown",
-                year=record.year,
-                artist_mbid=record.artist_mbid,
+            task_id = await self._dispatch_record(
+                record,
                 origin="retry",
-                release_mbid=record.release_mbid,
-                track_count_priority=RequestPriority.USER_INITIATED,
+                fallback_user_id=user_id,
             )
         except ValidationError as e:
             # cap/quota rejection: restore the pre-retry status (don't strand it as
@@ -347,8 +341,14 @@ class RequestsPageService:
             await self._request_history.async_update_download_task_id(
                 musicbrainz_id, task_id
             )
+        else:
+            await self._request_history.async_update_status(
+                musicbrainz_id,
+                "imported",
+                completed_at=datetime.now(timezone.utc).isoformat(),
+            )
         return RetryRequestResponse(
-            success=True, message=f"Re-requested {record.album_title}"
+            success=True, message=f"Re-requested {self._record_title(record)}"
         )
 
     async def clear_history_item(
@@ -453,8 +453,54 @@ class RequestsPageService:
                 return self._library_mbids_cache
             return set()
 
+    async def _dispatch_record(
+        self,
+        record: RequestHistoryRecord,
+        *,
+        origin: str,
+        fallback_user_id: str = "",
+    ) -> str:
+        """Dispatch an approved/retried request without widening exact tracks."""
+        user_id = record.user_id or fallback_user_id
+        if record.request_kind == "track":
+            if not record.track_title:
+                raise ValidationError("Exact-track request is missing its track title")
+            return await self._acquisition.request_track(
+                user_id=user_id,
+                recording_mbid=record.musicbrainz_id,
+                artist_name=record.artist_name or "Unknown",
+                track_title=record.track_title,
+                album_title=record.album_title,
+                duration_seconds=record.duration_seconds,
+                release_group_mbid=record.track_release_group_mbid,
+                artist_mbid=record.artist_mbid,
+                release_mbid=record.release_mbid,
+            )
+        return await self._acquisition.request_album(
+            user_id=user_id,
+            release_group_mbid=record.musicbrainz_id,
+            artist_name=record.artist_name or "Unknown",
+            album_title=record.album_title or "Unknown",
+            year=record.year,
+            artist_mbid=record.artist_mbid,
+            origin=origin,
+            release_mbid=record.release_mbid,
+            track_count_priority=RequestPriority.USER_INITIATED,
+        )
+
+    @staticmethod
+    def _record_title(record: RequestHistoryRecord) -> str:
+        if record.request_kind == "track" and record.track_title:
+            return record.track_title
+        return record.album_title
+
     @staticmethod
     def _build_pending_item(record: RequestHistoryRecord) -> ActiveRequestItem:
+        cover_mbid = (
+            record.track_release_group_mbid
+            if record.request_kind == "track" and record.track_release_group_mbid
+            else record.musicbrainz_id
+        )
         return ActiveRequestItem(
             musicbrainz_id=record.musicbrainz_id,
             artist_name=record.artist_name,
@@ -462,7 +508,7 @@ class RequestsPageService:
             artist_mbid=record.artist_mbid,
             year=record.year,
             cover_url=prefer_release_group_cover_url(
-                record.musicbrainz_id,
+                cover_mbid,
                 record.cover_url,
                 size=500,
             ),
@@ -478,6 +524,10 @@ class RequestsPageService:
             library_queue_id=None,
             user_id=record.user_id,
             requested_by_name=record.requested_by_name,
+            request_kind=record.request_kind,
+            track_title=record.track_title,
+            duration_seconds=record.duration_seconds,
+            track_release_group_mbid=record.track_release_group_mbid,
         )
 
     async def _check_if_completed(
@@ -487,7 +537,10 @@ class RequestsPageService:
     ) -> bool:
         now_iso = datetime.now(timezone.utc).isoformat()
 
-        if record.musicbrainz_id.lower() in library_mbids:
+        if (
+            record.request_kind != "track"
+            and record.musicbrainz_id.lower() in library_mbids
+        ):
             await self._request_history.async_update_status(
                 record.musicbrainz_id, "imported", completed_at=now_iso
             )

--- a/backend/target_application.py
+++ b/backend/target_application.py
@@ -747,6 +747,7 @@ def create_production_target_application() -> FastAPI:
             "/api/v1/discover": (10.0, 20),
             "/api/v1/covers": (15.0, 30),
             "/api/v1/auth/login": (2.0, 5),
+            "/api/v1/auth/device-sessions": (1.0, 5),
             "/api/v1/auth/setup": (1.0, 3),
             "/api/v1/auth/plex/poll": (5.0, 10),
             "/api/v1/auth/jellyfin/login": (2.0, 5),

--- a/backend/tests/compat/test_connect_apps_routes.py
+++ b/backend/tests/compat/test_connect_apps_routes.py
@@ -50,6 +50,7 @@ async def test_get_settings_any_user(app_password_service, tmp_path):
     r = build_test_client(app).get("/connect-apps/settings")
     assert r.status_code == 200
     assert r.json()["subsonic_enabled"] is False
+    assert r.json()["exact_track_approval_supported"] is True
 
 
 async def test_get_settings_unauthenticated_401(app_password_service, tmp_path):

--- a/backend/tests/infrastructure/test_auth_store.py
+++ b/backend/tests/infrastructure/test_auth_store.py
@@ -6,6 +6,7 @@ idempotency test (construct twice on the same path).
 """
 
 import hashlib
+import sqlite3
 import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -23,6 +24,38 @@ def test_migration_is_idempotent(tmp_path: Path):
     # guarded ALTERs); it must not raise.
     AuthStore(db_path, write_lock=lock)
     assert db_path.exists()
+
+
+def test_session_kind_migration_preserves_legacy_tokens_as_standard(tmp_path: Path):
+    db_path = tmp_path / "library.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute(
+            """CREATE TABLE auth_tokens (
+                   id TEXT PRIMARY KEY,
+                   user_id TEXT NOT NULL,
+                   token_hash TEXT NOT NULL UNIQUE,
+                   issued_at TEXT NOT NULL,
+                   expires_at TEXT NOT NULL,
+                   last_seen_at TEXT NOT NULL,
+                   revoked INTEGER NOT NULL DEFAULT 0,
+                   user_agent TEXT
+               )"""
+        )
+        connection.execute(
+            """INSERT INTO auth_tokens
+                   (id, user_id, token_hash, issued_at, expires_at, last_seen_at,
+                    revoked, user_agent)
+               VALUES ('legacy-token', 'user-1', 'hash', 'now', 'later', 'now', 0,
+                       'Tonarr companion · Watch')"""
+        )
+
+    AuthStore(db_path)
+
+    with sqlite3.connect(db_path) as connection:
+        session_kind = connection.execute(
+            "SELECT session_kind FROM auth_tokens WHERE id = 'legacy-token'"
+        ).fetchone()[0]
+    assert session_kind == "standard"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/infrastructure/test_request_history_tracks.py
+++ b/backend/tests/infrastructure/test_request_history_tracks.py
@@ -1,0 +1,44 @@
+import pytest
+
+from infrastructure.persistence.request_history import RequestHistoryStore
+
+
+@pytest.mark.asyncio
+async def test_exact_track_metadata_survives_request_history_round_trip(tmp_path):
+    store = RequestHistoryStore(tmp_path / "droppedneedle.db")
+
+    await store.async_record_request(
+        musicbrainz_id="recording-1",
+        artist_name="Radiohead",
+        album_title="OK Computer",
+        artist_mbid="artist-1",
+        user_id="listener-1",
+        requested_by_name="Listener",
+        release_mbid="release-1",
+        initial_status="awaiting_approval",
+        request_kind="track",
+        track_title="Airbag",
+        duration_seconds=287,
+        track_release_group_mbid="release-group-1",
+    )
+
+    record = await store.async_get_record("RECORDING-1")
+
+    assert record is not None
+    assert record.request_kind == "track"
+    assert record.track_title == "Airbag"
+    assert record.duration_seconds == 287
+    assert record.track_release_group_mbid == "release-group-1"
+
+
+@pytest.mark.asyncio
+async def test_legacy_album_request_defaults_to_album_kind(tmp_path):
+    store = RequestHistoryStore(tmp_path / "droppedneedle.db")
+
+    await store.async_record_request("release-group-1", "Radiohead", "OK Computer")
+
+    record = await store.async_get_record("release-group-1")
+
+    assert record is not None
+    assert record.request_kind == "album"
+    assert record.track_title is None

--- a/backend/tests/infrastructure/test_request_history_tracks.py
+++ b/backend/tests/infrastructure/test_request_history_tracks.py
@@ -1,3 +1,5 @@
+import sqlite3
+
 import pytest
 
 from infrastructure.persistence.request_history import RequestHistoryStore
@@ -42,3 +44,50 @@ async def test_legacy_album_request_defaults_to_album_kind(tmp_path):
     assert record is not None
     assert record.request_kind == "album"
     assert record.track_title is None
+
+
+@pytest.mark.asyncio
+async def test_shared_request_remains_visible_and_private_for_each_listener(tmp_path):
+    store = RequestHistoryStore(tmp_path / "droppedneedle.db")
+    await store.async_record_request(
+        "release-group-1",
+        "Artist",
+        "Album",
+        user_id="listener-1",
+        requested_by_name="First listener",
+    )
+    await store.async_add_requester("release-group-1", "listener-2", "Second listener")
+
+    first = await store.async_get_active_requests_for_user("listener-1")
+    second = await store.async_get_active_requests_for_user("listener-2")
+    assert [record.user_id for record in first] == ["listener-1"]
+    assert [record.user_id for record in second] == ["listener-2"]
+    assert [record.requested_by_name for record in second] == ["Second listener"]
+    second_history, total = await store.async_get_history_for_user("listener-2")
+    assert total == 1
+    assert [record.user_id for record in second_history] == ["listener-2"]
+
+    assert await store.async_requester_count("release-group-1") == 2
+    assert await store.async_remove_requester("listener-1", "release-group-1")
+    canonical = await store.async_get_record("release-group-1")
+    assert canonical is not None
+    assert canonical.user_id == "listener-2"
+
+
+@pytest.mark.asyncio
+async def test_existing_user_attribution_is_backfilled_during_upgrade(tmp_path):
+    path = tmp_path / "droppedneedle.db"
+    store = RequestHistoryStore(path)
+    await store.async_record_request(
+        "release-group-1",
+        "Artist",
+        "Album",
+        user_id="legacy-listener",
+        requested_by_name="Legacy listener",
+    )
+    with sqlite3.connect(path) as connection:
+        connection.execute("DROP TABLE request_history_requesters")
+
+    upgraded = RequestHistoryStore(path)
+    active = await upgraded.async_get_active_requests_for_user("legacy-listener")
+    assert [record.musicbrainz_id for record in active] == ["release-group-1"]

--- a/backend/tests/repositories/test_coverart_repository_memory_cache.py
+++ b/backend/tests/repositories/test_coverart_repository_memory_cache.py
@@ -151,4 +151,4 @@ async def test_artist_fetcher_uses_non_default_user_agent_for_external_requests(
         repo = CoverArtRepository(http_client=http_client, cache=cache, cache_dir=tmp_path)
 
         assert repo._artist_fetcher._external_headers is not None
-        assert repo._artist_fetcher._external_headers['User-Agent'].startswith('DroppedNeedle/')
+        assert repo._artist_fetcher._external_headers['User-Agent'].startswith('DroppedNeedleApp/')

--- a/backend/tests/routes/test_auth_username.py
+++ b/backend/tests/routes/test_auth_username.py
@@ -4,6 +4,7 @@ exercised through the real auth router with a temp AuthStore."""
 from __future__ import annotations
 
 import asyncio
+import sqlite3
 
 import pytest
 from fastapi import FastAPI
@@ -136,9 +137,9 @@ def test_me_returns_username_fields(tmp_path):
     assert body["username_display"] == "Jane"
 
 
-def test_device_session_is_distinct_labeled_and_revocable(tmp_path):
+def test_owned_device_session_delete_revokes_bearer(tmp_path):
     app, service = _app(tmp_path)
-    user, _ = asyncio.run(
+    user, account_token = asyncio.run(
         service.create_first_admin(
             display_name="Jane",
             username="jane",
@@ -157,18 +158,179 @@ def test_device_session_is_distinct_labeled_and_revocable(tmp_path):
     assert response.json()["token"]
     sessions = asyncio.run(service.list_sessions(user.id))
     assert len(sessions) == 2
-    assert any(
-        session.user_agent == "Tonarr companion · Kyle Apple Watch Ultra"
+    companion_session = next(
+        session
         for session in sessions
+        if session.user_agent == "Tonarr companion · Kyle Apple Watch Ultra"
+    )
+
+    revoked = client.delete(f"/auth/sessions/{companion_session.id}")
+
+    assert revoked.status_code == 204
+    assert asyncio.run(service.verify_token(response.json()["token"])) is None
+    assert asyncio.run(service.verify_token(account_token)) is not None
+
+
+def test_cross_user_cannot_revoke_device_session(tmp_path):
+    app, service = _app(tmp_path)
+    owner, _ = asyncio.run(
+        service.create_first_admin(
+            display_name="Jane",
+            username="jane",
+            password=PASSWORD,
+        )
+    )
+    other_user = asyncio.run(
+        service.admin_create_user(
+            display_name="Alex",
+            username="alex",
+            password=PASSWORD,
+        )
+    )
+    app.dependency_overrides[_get_current_user] = lambda: owner
+    client = build_test_client(app)
+    created = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+    companion_session = next(
+        session
+        for session in asyncio.run(service.list_sessions(owner.id))
+        if session.user_agent == "Tonarr companion · Kyle Apple Watch Ultra"
+    )
+
+    app.dependency_overrides[_get_current_user] = lambda: other_user
+    denied = client.delete(f"/auth/sessions/{companion_session.id}")
+
+    assert denied.status_code == 403
+    assert asyncio.run(service.verify_token(created.json()["token"])) is not None
+
+
+def test_device_label_collision_does_not_revoke_ordinary_session(tmp_path):
+    app, service = _app(tmp_path)
+    client = build_test_client(app)
+    setup = client.post(
+        "/auth/setup",
+        headers={"User-Agent": b"Tonarr companion \xb7 Kyle Apple Watch Ultra"},
+        json={"display_name": "Jane", "username": "jane", "password": PASSWORD},
+    )
+    account_token = setup.json()["token"]
+    verified = asyncio.run(service.verify_token(account_token))
+    assert verified is not None
+    user, _ = verified
+    app.dependency_overrides[_get_current_user] = lambda: user
+
+    companion = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+
+    assert companion.status_code == 200
+    assert asyncio.run(service.verify_token(account_token)) is not None
+    assert asyncio.run(service.verify_token(companion.json()["token"])) is not None
+    assert len(asyncio.run(service.list_sessions(user.id))) == 2
+
+
+def test_same_label_replacement_invalidates_old_bearer(tmp_path):
+    app, service = _app(tmp_path)
+    user, _ = asyncio.run(
+        service.create_first_admin(
+            display_name="Jane",
+            username="jane",
+            password=PASSWORD,
+        )
+    )
+    app.dependency_overrides[_get_current_user] = lambda: user
+    client = build_test_client(app)
+    original = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
     )
 
     replacement = client.post(
         "/auth/device-sessions",
         json={"device_name": "Kyle Apple Watch Ultra"},
     )
+
     assert replacement.status_code == 200
-    assert replacement.json()["token"] != response.json()["token"]
+    assert replacement.json()["token"] != original.json()["token"]
+    assert asyncio.run(service.verify_token(original.json()["token"])) is None
+    assert asyncio.run(service.verify_token(replacement.json()["token"])) is not None
     assert len(asyncio.run(service.list_sessions(user.id))) == 2
+
+
+def test_device_session_preflight_failure_preserves_old_bearer(tmp_path, monkeypatch):
+    app, service = _app(tmp_path)
+    user, _ = asyncio.run(
+        service.create_first_admin(
+            display_name="Jane",
+            username="jane",
+            password=PASSWORD,
+        )
+    )
+    app.dependency_overrides[_get_current_user] = lambda: user
+    client = build_test_client(app)
+    original = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+
+    async def _provider_failure(_user_ids):
+        raise RuntimeError("forced provider lookup failure")
+
+    monkeypatch.setattr(service, "get_provider_names_for_users", _provider_failure)
+    invalid = client.post("/auth/device-sessions", json={"device_name": "  "})
+    failed = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+
+    assert invalid.status_code == 400
+    assert failed.status_code == 500
+    assert asyncio.run(service.verify_token(original.json()["token"])) is not None
+    assert len(asyncio.run(service.list_sessions(user.id))) == 2
+
+
+def test_failed_same_label_replacement_preserves_old_bearer(tmp_path):
+    app, service = _app(tmp_path)
+    user, _ = asyncio.run(
+        service.create_first_admin(
+            display_name="Jane",
+            username="jane",
+            password=PASSWORD,
+        )
+    )
+    app.dependency_overrides[_get_current_user] = lambda: user
+    client = build_test_client(app)
+    original = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+    assert original.status_code == 200
+    with sqlite3.connect(tmp_path / "library.db") as connection:
+        connection.execute(
+            """CREATE TRIGGER fail_device_session_replacement
+               BEFORE UPDATE OF revoked ON auth_tokens
+               WHEN OLD.user_agent = 'Tonarr companion · Kyle Apple Watch Ultra'
+                 AND NEW.revoked = 1
+               BEGIN
+                 SELECT RAISE(ABORT, 'forced replacement failure');
+               END"""
+        )
+
+    failed = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+
+    assert failed.status_code == 500
+    assert asyncio.run(service.verify_token(original.json()["token"])) is not None
+    sessions = asyncio.run(service.list_sessions(user.id))
+    assert len(sessions) == 2
+    assert sum(
+        session.user_agent == "Tonarr companion · Kyle Apple Watch Ultra"
+        for session in sessions
+    ) == 1
 
 
 def test_device_session_rejects_empty_or_unbounded_label(tmp_path):

--- a/backend/tests/routes/test_auth_username.py
+++ b/backend/tests/routes/test_auth_username.py
@@ -136,6 +136,52 @@ def test_me_returns_username_fields(tmp_path):
     assert body["username_display"] == "Jane"
 
 
+def test_device_session_is_distinct_labeled_and_revocable(tmp_path):
+    app, service = _app(tmp_path)
+    user, _ = asyncio.run(
+        service.create_first_admin(
+            display_name="Jane",
+            username="jane",
+            password=PASSWORD,
+        )
+    )
+    app.dependency_overrides[_get_current_user] = lambda: user
+    client = build_test_client(app)
+
+    response = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["token"]
+    sessions = asyncio.run(service.list_sessions(user.id))
+    assert len(sessions) == 2
+    assert any(
+        session.user_agent == "Tonarr companion · Kyle Apple Watch Ultra"
+        for session in sessions
+    )
+
+    replacement = client.post(
+        "/auth/device-sessions",
+        json={"device_name": "Kyle Apple Watch Ultra"},
+    )
+    assert replacement.status_code == 200
+    assert replacement.json()["token"] != response.json()["token"]
+    assert len(asyncio.run(service.list_sessions(user.id))) == 2
+
+
+def test_device_session_rejects_empty_or_unbounded_label(tmp_path):
+    app, _ = _app(tmp_path)
+    app.dependency_overrides[_get_current_user] = lambda: UserRecord(
+        id="u-watch", display_name="Jane", role="user", created_at="t"
+    )
+    client = build_test_client(app)
+
+    assert client.post("/auth/device-sessions", json={"device_name": "  "}).status_code == 400
+    assert client.post("/auth/device-sessions", json={"device_name": "x" * 81}).status_code == 400
+
+
 def test_admin_create_user_with_username_and_duplicate_conflict(tmp_path):
     app, _ = _app(tmp_path)
     app.dependency_overrides[_get_current_admin] = mock_admin_user

--- a/backend/tests/routes/test_request_routes.py
+++ b/backend/tests/routes/test_request_routes.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock
 from fastapi import FastAPI
 
 from api.v1.routes import requests, tracks
-from core.dependencies import get_acquisition_dispatcher, get_request_service
+from core.dependencies import get_request_service
 from middleware import _get_current_user
 from services.native.download_service import ALREADY_IN_LIBRARY
 from services.request_service import RequestService
@@ -40,11 +40,11 @@ def _requests_app(service: RequestService, role: str) -> FastAPI:
     return app
 
 
-def _tracks_app(download_service: AsyncMock) -> FastAPI:
+def _tracks_app(service: RequestService, role: str) -> FastAPI:
     app = FastAPI()
     app.include_router(tracks.router)
-    app.dependency_overrides[get_acquisition_dispatcher] = lambda: download_service
-    app.dependency_overrides[_get_current_user] = lambda: mock_user(role="user", user_id="u1")
+    app.dependency_overrides[get_request_service] = lambda: service
+    app.dependency_overrides[_get_current_user] = lambda: mock_user(role=role, user_id="u1")
     return app
 
 
@@ -89,34 +89,54 @@ def test_request_new_unauthenticated_401():
     assert response.status_code == 401
 
 
-def test_track_request_returns_task_id():
+def test_track_request_user_role_awaits_approval_without_dispatch():
     ds = AsyncMock()
-    ds.request_track.return_value = "task-track-1"
-    response = build_test_client(_tracks_app(ds)).post(
+    service, history = _request_service(ds)
+    response = build_test_client(_tracks_app(service, "user")).post(
         "/tracks/rec-1/request", json={"artist_name": "Radiohead", "track_title": "Airbag"}
     )
     assert response.status_code == 200
     body = response.json()
-    assert body["status"] == "queued"
-    assert body["task_id"] == "task-track-1"
+    assert body["status"] == "awaiting_approval"
+    assert body["task_id"] is None
+    ds.request_track.assert_not_awaited()
+    assert history.async_record_request.await_args.kwargs["request_kind"] == "track"
+
+
+def test_track_request_trusted_returns_task_id():
+    ds = AsyncMock()
+    ds.request_track.return_value = "task-track-1"
+    service, history = _request_service(ds)
+    response = build_test_client(_tracks_app(service, "trusted")).post(
+        "/tracks/rec-1/request", json={"artist_name": "Radiohead", "track_title": "Airbag"}
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "queued"
+    assert response.json()["task_id"] == "task-track-1"
     ds.request_track.assert_awaited_once()
+    history.async_update_download_task_id.assert_awaited_once_with(
+        "rec-1", "task-track-1"
+    )
 
 
 def test_track_request_already_in_library():
     ds = AsyncMock()
     ds.request_track.return_value = ALREADY_IN_LIBRARY
-    response = build_test_client(_tracks_app(ds)).post(
+    service, history = _request_service(ds)
+    response = build_test_client(_tracks_app(service, "admin")).post(
         "/tracks/rec-1/request", json={"artist_name": "Radiohead", "track_title": "Airbag"}
     )
     assert response.status_code == 200
     assert response.json()["status"] == "already_in_library"
+    history.async_update_status.assert_awaited_once()
 
 
 def test_track_request_unauthenticated_401():
     ds = AsyncMock()
     app = FastAPI()
     app.include_router(tracks.router)
-    app.dependency_overrides[get_acquisition_dispatcher] = lambda: ds
+    service, _history = _request_service(ds)
+    app.dependency_overrides[get_request_service] = lambda: service
     response = build_test_client(app).post(
         "/tracks/rec-1/request", json={"artist_name": "Radiohead", "track_title": "Airbag"}
     )

--- a/backend/tests/routes/test_tracks_routes.py
+++ b/backend/tests/routes/test_tracks_routes.py
@@ -5,24 +5,26 @@ from unittest.mock import AsyncMock
 from fastapi import FastAPI
 
 from api.v1.routes import tracks
-from core.dependencies import get_acquisition_dispatcher, get_quota_service
+from api.v1.schemas.download import TrackRequestResponse
+from core.dependencies import get_request_service
+from core.exceptions import ValidationError
 from middleware import _get_current_user
-from services.native.download_service import ALREADY_IN_LIBRARY
 from tests.helpers import build_test_client, mock_user
 
 
-def _app(service, quota=None) -> FastAPI:
+def _app(service, role="user") -> FastAPI:
     app = FastAPI()
     app.include_router(tracks.router)
-    app.dependency_overrides[get_acquisition_dispatcher] = lambda: service
-    app.dependency_overrides[get_quota_service] = lambda: quota or AsyncMock()
-    app.dependency_overrides[_get_current_user] = lambda: mock_user(role="user", user_id="u1")
+    app.dependency_overrides[get_request_service] = lambda: service
+    app.dependency_overrides[_get_current_user] = lambda: mock_user(role=role, user_id="u1")
     return app
 
 
 def test_request_track_queued():
     service = AsyncMock()
-    service.request_track.return_value = "task-1"
+    service.request_track.return_value = TrackRequestResponse(
+        status="queued", task_id="task-1"
+    )
     response = build_test_client(_app(service)).post(
         "/tracks/rec-1/request",
         json={"artist_name": "Radiohead", "track_title": "Airbag"},
@@ -33,13 +35,16 @@ def test_request_track_queued():
     assert body["task_id"] == "task-1"
     service.request_track.assert_awaited_once()
     kwargs = service.request_track.await_args.kwargs
-    assert kwargs["recording_mbid"] == "rec-1"
+    assert service.request_track.await_args.args[0] == "rec-1"
     assert kwargs["user_id"] == "u1"
+    assert kwargs["user_role"] == "user"
 
 
 def test_request_track_already_in_library():
     service = AsyncMock()
-    service.request_track.return_value = ALREADY_IN_LIBRARY
+    service.request_track.return_value = TrackRequestResponse(
+        status="already_in_library"
+    )
     response = build_test_client(_app(service)).post(
         "/tracks/rec-1/request",
         json={"artist_name": "Radiohead", "track_title": "Airbag"},
@@ -54,8 +59,7 @@ def test_request_track_unauthenticated_401():
     service = AsyncMock()
     app = FastAPI()
     app.include_router(tracks.router)
-    app.dependency_overrides[get_acquisition_dispatcher] = lambda: service
-    app.dependency_overrides[get_quota_service] = lambda: AsyncMock()
+    app.dependency_overrides[get_request_service] = lambda: service
     response = build_test_client(app).post(
         "/tracks/rec-1/request",
         json={"artist_name": "Radiohead", "track_title": "Airbag"},
@@ -64,20 +68,17 @@ def test_request_track_unauthenticated_401():
 
 
 def test_request_track_over_quota_rejected_at_submit():
-    """Track asks bypass approval but still count toward the request quota (D20):
-    an over-quota user is rejected before the download service is touched."""
-    from core.exceptions import ValidationError
-
+    """Request-service quota failures remain a clear 400 at the route boundary."""
     service = AsyncMock()
-    quota = AsyncMock()
-    quota.check_request_quota.side_effect = ValidationError("Request limit reached (5 per 7 days)")
+    service.request_track.side_effect = ValidationError(
+        "Request limit reached (5 per 7 days)"
+    )
 
-    response = build_test_client(_app(service, quota)).post(
+    response = build_test_client(_app(service)).post(
         "/tracks/rec-1/request",
         json={"artist_name": "Radiohead", "track_title": "Airbag"},
     )
 
     assert response.status_code == 400
     assert "Request limit reached" in response.json()["error"]["message"]
-    service.request_track.assert_not_awaited()
-    quota.check_request_quota.assert_awaited_once_with("u1", "user")
+    service.request_track.assert_awaited_once()

--- a/backend/tests/services/native/test_target_consumer_services.py
+++ b/backend/tests/services/native/test_target_consumer_services.py
@@ -546,6 +546,34 @@ async def test_target_repository_resolves_active_provider_and_local_album_ids(
 
 
 @pytest.mark.asyncio
+async def test_target_repository_pages_live_enrichment_candidates(
+    target_services,
+) -> None:
+    store, _view, _favorites, _history, _root = target_services
+    repository = TargetLibraryRepository(store)
+
+    first = await repository.get_enrichment_candidates(after_mbid=None, limit=1)
+    first_cursor = f"{first[0][0]}:{first[0][1]}"
+    second = await repository.get_enrichment_candidates(
+        after_mbid=first_cursor,
+        limit=1,
+    )
+    complete = await repository.get_enrichment_candidates(after_mbid=None, limit=10)
+
+    assert first == [
+        (
+            "album",
+            RELEASE_GROUP_MBID,
+            {"title": "Identified", "artist_name": "Identified Artist"},
+        )
+    ]
+    assert second == [
+        ("artist", ARTIST_MBID, {"name": "Identified Artist"})
+    ]
+    assert complete == first + second
+
+
+@pytest.mark.asyncio
 async def test_album_service_selects_by_active_target_album_file_count(
     target_services,
 ) -> None:

--- a/backend/tests/services/test_musicbrainz_rate_cap.py
+++ b/backend/tests/services/test_musicbrainz_rate_cap.py
@@ -136,8 +136,20 @@ class TestInstanceId:
             root_app_dir=tmp_path,
         )
         ua = settings.get_user_agent()
+        assert ua.startswith("DroppedNeedleApp/")
         assert "a1b2c3d4" in ua
-        assert "DroppedNeedle/1.0" in ua
+
+    def test_user_agent_uses_default_contact_when_empty(self, tmp_path):
+        from core.config import Settings
+
+        settings = Settings(
+            instance_id="a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+            contact_email="",
+            root_app_dir=tmp_path,
+        )
+        ua = settings.get_user_agent()
+        assert "contact@droppedneedle.com" in ua
+        assert "; ;" not in ua
 
     def test_user_agent_unknown_when_no_instance_id(self, tmp_path):
         from core.config import Settings

--- a/backend/tests/services/test_request_service.py
+++ b/backend/tests/services/test_request_service.py
@@ -20,6 +20,7 @@ def _make_service() -> tuple[RequestService, MagicMock, MagicMock]:
     request_history.async_get_active_mbids = AsyncMock(return_value=set())
     request_history.async_get_requested_mbids = AsyncMock(return_value=set())
     download_service.request_album = AsyncMock(return_value="task-1")
+    download_service.request_track = AsyncMock(return_value="track-task-1")
     download_service.cancel_task = AsyncMock()
 
     get_ds = lambda: download_service  # noqa: E731
@@ -137,6 +138,64 @@ async def test_request_album_user_role_awaits_approval_without_dispatch():
     assert response.status == "awaiting_approval"
     download_service.request_album.assert_not_awaited()
     request_history.async_update_download_task_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_request_track_user_role_records_exact_metadata_and_awaits_approval():
+    service, request_history, download_service = _make_service()
+
+    response = await service.request_track(
+        "recording-1",
+        user_id="listener-1",
+        user_role="user",
+        requested_by_name="Listener",
+        artist_name="Radiohead",
+        track_title="Airbag",
+        album_title="OK Computer",
+        duration_seconds=287,
+        release_group_mbid="release-group-1",
+        artist_mbid="artist-1",
+        release_mbid="release-1",
+    )
+
+    assert response.status == "awaiting_approval"
+    download_service.request_track.assert_not_awaited()
+    request_history.async_record_request.assert_awaited_once_with(
+        musicbrainz_id="recording-1",
+        artist_name="Radiohead",
+        album_title="OK Computer",
+        artist_mbid="artist-1",
+        user_id="listener-1",
+        requested_by_name="Listener",
+        release_mbid="release-1",
+        initial_status="awaiting_approval",
+        request_kind="track",
+        track_title="Airbag",
+        duration_seconds=287,
+        track_release_group_mbid="release-group-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_track_trusted_dispatches_exact_recording_and_links_task():
+    service, request_history, download_service = _make_service()
+
+    response = await service.request_track(
+        "recording-1",
+        user_id="trusted-1",
+        user_role="trusted",
+        artist_name="Radiohead",
+        track_title="Airbag",
+        album_title="OK Computer",
+        release_group_mbid="release-group-1",
+    )
+
+    assert response.status == "queued"
+    assert response.task_id == "track-task-1"
+    download_service.request_track.assert_awaited_once()
+    request_history.async_update_download_task_id.assert_awaited_once_with(
+        "recording-1", "track-task-1"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_request_service.py
+++ b/backend/tests/services/test_request_service.py
@@ -17,6 +17,11 @@ def _make_service() -> tuple[RequestService, MagicMock, MagicMock]:
     request_history.async_update_status = AsyncMock()
     request_history.async_update_download_task_id = AsyncMock()
     request_history.async_bulk_record_requests = AsyncMock()
+    request_history.async_add_requester = AsyncMock()
+    request_history.async_add_requesters = AsyncMock()
+    request_history.async_is_requester = AsyncMock(return_value=True)
+    request_history.async_requester_count = AsyncMock(return_value=1)
+    request_history.async_remove_requester = AsyncMock(return_value=True)
     request_history.async_get_active_mbids = AsyncMock(return_value=set())
     request_history.async_get_requested_mbids = AsyncMock(return_value=set())
     download_service.request_album = AsyncMock(return_value="task-1")
@@ -138,6 +143,27 @@ async def test_request_album_user_role_awaits_approval_without_dispatch():
     assert response.status == "awaiting_approval"
     download_service.request_album.assert_not_awaited()
     request_history.async_update_download_task_id.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_existing_request_is_attributed_to_each_listener_without_redispatch():
+    service, request_history, download_service = _make_service()
+    request_history.async_get_record.return_value = SimpleNamespace(
+        status="pending", monitor_artist=False
+    )
+
+    response = await service.request_album(
+        "rg-123",
+        user_id="listener-2",
+        user_role="user",
+        requested_by_name="Second listener",
+    )
+
+    assert response.status == "pending"
+    request_history.async_add_requester.assert_awaited_once_with(
+        "rg-123", "listener-2", "Second listener"
+    )
+    download_service.request_album.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -375,6 +401,7 @@ async def test_request_batch_does_not_overwrite_an_approval_pending_request():
 
     assert response.requested == 0
     assert response.skipped == 1
+    assert response.status == "already_requested"
     request_history.async_bulk_record_requests.assert_not_awaited()
     download_service.request_album.assert_not_awaited()
 
@@ -389,6 +416,7 @@ async def test_request_batch_user_role_awaits_approval_without_dispatch():
     resp = await service.request_batch(items, user_role="user", user_id="u1")
 
     assert "approval" in resp.message.lower()
+    assert resp.status == "awaiting_approval"
     download_service.request_album.assert_not_awaited()
 
 
@@ -434,6 +462,9 @@ async def test_cancel_batch_user_only_cancels_owned_requests():
     }
     request_history.async_get_record = AsyncMock(
         side_effect=lambda mbid: records.get(mbid)
+    )
+    request_history.async_is_requester = AsyncMock(
+        side_effect=lambda _user_id, mbid: mbid == "rg-mine"
     )
 
     response = await service.cancel_batch(["rg-mine", "rg-theirs"], user_id="alice")
@@ -516,6 +547,7 @@ async def test_request_batch_quota_counts_only_new_items():
 
     assert response.success is True
     assert quota.check_request_quota.await_args.args == ("u1", "user", 1)
+    request_history.async_add_requesters.assert_awaited_once_with(["RG-1"], "u1", None)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_request_service.py
+++ b/backend/tests/services/test_request_service.py
@@ -177,6 +177,26 @@ async def test_request_track_user_role_records_exact_metadata_and_awaits_approva
 
 
 @pytest.mark.asyncio
+async def test_request_track_unknown_role_fails_closed_to_owner_approval():
+    service, request_history, download_service = _make_service()
+
+    response = await service.request_track(
+        "recording-unknown-role",
+        user_id="future-role-1",
+        user_role="future-role",
+        artist_name="Radiohead",
+        track_title="Airbag",
+    )
+
+    assert response.status == "awaiting_approval"
+    download_service.request_track.assert_not_awaited()
+    assert (
+        request_history.async_record_request.await_args.kwargs["initial_status"]
+        == "awaiting_approval"
+    )
+
+
+@pytest.mark.asyncio
 async def test_request_track_trusted_dispatches_exact_recording_and_links_task():
     service, request_history, download_service = _make_service()
 

--- a/backend/tests/services/test_requests_page_approve.py
+++ b/backend/tests/services/test_requests_page_approve.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from infrastructure.queue.priority_queue import RequestPriority
+from infrastructure.persistence.request_history import RequestHistoryRecord
 from services.requests_page_service import RequestsPageService
 from tests.helpers import make_builtin_dispatcher
 
@@ -15,7 +16,9 @@ def _make(
     record_status="awaiting_approval",
     *,
     request_album_result="task-9",
+    request_track_result="track-task-9",
     download_task_id=None,
+    request_kind="album",
 ):
     request_history = MagicMock()
     request_history.async_get_record = AsyncMock(
@@ -28,6 +31,13 @@ def _make(
             user_id="u1",
             download_task_id=download_task_id,
             release_mbid="release-edition",
+            musicbrainz_id="mbid-1",
+            request_kind=request_kind,
+            track_title="Airbag" if request_kind == "track" else None,
+            duration_seconds=287 if request_kind == "track" else None,
+            track_release_group_mbid="release-group-1"
+            if request_kind == "track"
+            else None,
         )
     )
     request_history.async_record_review = AsyncMock()
@@ -36,6 +46,7 @@ def _make(
 
     download_service = MagicMock()
     download_service.request_album = AsyncMock(return_value=request_album_result)
+    download_service.request_track = AsyncMock(return_value=request_track_result)
     download_service.cancel_task = AsyncMock()
 
     async def _mbids() -> set[str]:
@@ -96,6 +107,24 @@ async def test_approve_rejects_non_awaiting_record():
 
 
 @pytest.mark.asyncio
+async def test_approve_exact_track_dispatches_track_without_widening_to_album():
+    service, history, download_service = _make(request_kind="track")
+
+    resp = await service.approve_request("mbid-1", "admin-id", "Admin")
+
+    assert resp.success is True
+    download_service.request_album.assert_not_awaited()
+    download_service.request_track.assert_awaited_once()
+    kwargs = download_service.request_track.await_args.kwargs
+    assert kwargs["recording_mbid"] == "mbid-1"
+    assert kwargs["track_title"] == "Airbag"
+    assert kwargs["release_group_mbid"] == "release-group-1"
+    history.async_update_download_task_id.assert_awaited_once_with(
+        "mbid-1", "track-task-9"
+    )
+
+
+@pytest.mark.asyncio
 async def test_cancel_request_cancels_linked_native_task():
     service, history, download_service = _make(
         record_status="downloading", download_task_id="task-9"
@@ -129,6 +158,47 @@ async def test_retry_request_redispatches_native_and_links():
         is RequestPriority.USER_INITIATED
     )
     history.async_update_download_task_id.assert_awaited_once_with("mbid-1", "task-9")
+
+
+@pytest.mark.asyncio
+async def test_retry_exact_track_preserves_exact_track_semantics():
+    service, history, download_service = _make(
+        record_status="failed",
+        request_kind="track",
+        download_task_id="old-track-task",
+    )
+
+    resp = await service.retry_request("mbid-1", user_id="u1", user_role="user")
+
+    assert resp.success is True
+    download_service.request_album.assert_not_awaited()
+    download_service.request_track.assert_awaited_once()
+    assert download_service.request_track.await_args.kwargs["recording_mbid"] == "mbid-1"
+    history.async_update_download_task_id.assert_awaited_once_with(
+        "mbid-1", "track-task-9"
+    )
+
+
+def test_pending_exact_track_response_exposes_kind_title_and_release_artwork():
+    item = RequestsPageService._build_pending_item(
+        RequestHistoryRecord(
+            musicbrainz_id="recording-1",
+            artist_name="Radiohead",
+            album_title="OK Computer",
+            requested_at="2026-08-24T12:00:00+00:00",
+            status="awaiting_approval",
+            request_kind="track",
+            track_title="Airbag",
+            duration_seconds=287,
+            track_release_group_mbid="7b0032d0-09b3-4f21-a207-9eb26b746c4f",
+        )
+    )
+
+    assert item.request_kind == "track"
+    assert item.track_title == "Airbag"
+    assert item.duration_seconds == 287
+    assert item.track_release_group_mbid == "7b0032d0-09b3-4f21-a207-9eb26b746c4f"
+    assert "7b0032d0-09b3-4f21-a207-9eb26b746c4f" in (item.cover_url or "")
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_requests_page_approve.py
+++ b/backend/tests/services/test_requests_page_approve.py
@@ -43,6 +43,9 @@ def _make(
     request_history.async_record_review = AsyncMock()
     request_history.async_update_download_task_id = AsyncMock()
     request_history.async_update_status = AsyncMock()
+    request_history.async_is_requester = AsyncMock(return_value=True)
+    request_history.async_requester_count = AsyncMock(return_value=1)
+    request_history.async_remove_requester = AsyncMock(return_value=True)
 
     download_service = MagicMock()
     download_service.request_album = AsyncMock(return_value=request_album_result)
@@ -138,6 +141,22 @@ async def test_cancel_request_cancels_linked_native_task():
 
 
 @pytest.mark.asyncio
+async def test_cancel_shared_request_removes_only_current_listener():
+    service, history, download_service = _make(
+        record_status="downloading", download_task_id="task-9"
+    )
+    history.async_requester_count.return_value = 2
+
+    resp = await service.cancel_request("mbid-1", user_id="u1", user_role="user")
+
+    assert resp.success is True
+    assert "another listener" in resp.message
+    history.async_remove_requester.assert_awaited_once_with("u1", "mbid-1")
+    download_service.cancel_task.assert_not_awaited()
+    history.async_update_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_retry_request_redispatches_native_and_links():
     service, history, download_service = _make(
         record_status="failed", download_task_id="old-task"
@@ -173,7 +192,9 @@ async def test_retry_exact_track_preserves_exact_track_semantics():
     assert resp.success is True
     download_service.request_album.assert_not_awaited()
     download_service.request_track.assert_awaited_once()
-    assert download_service.request_track.await_args.kwargs["recording_mbid"] == "mbid-1"
+    assert (
+        download_service.request_track.await_args.kwargs["recording_mbid"] == "mbid-1"
+    )
     history.async_update_download_task_id.assert_awaited_once_with(
         "mbid-1", "track-task-9"
     )


### PR DESCRIPTION
## Summary
- route exact-track requests through the same role-aware request service as albums, preserving track identity through approval, retry, history, and active-request APIs
- return server-authoritative batch statuses (`awaiting_approval`, `pending`, `already_requested`, or `failed`) so clients never infer acquisition from a stale cached role
- attribute an existing active request to every listener who asks for it without dispatching duplicate acquisition work
- keep each listener’s request history private, transfer primary attribution safely, and prevent one co-requester from cancelling another listener’s active job
- backfill legacy ownership records on upgrade and preserve trusted/admin immediate dispatch

## Client compatibility
Auralis connects directly to DroppedNeedle: OpenSubsonic/Jellyfin-compatible APIs handle library and playback, while DroppedNeedle’s native request API handles exact tracks, albums, artist discographies, approval, progress, retry, cancellation, and per-listener attribution. No owner-hosted bridge or client fork is required.

Older DroppedNeedle releases remain usable for playback and conservative request behavior. Full server-authoritative batch status and shared-listener attribution activate when this server change is released.

## Validation
- focused request, route, persistence, schema, ownership, approval, batch-status, upgrade-backfill, and shared-listener tests: 59 passed on Python 3.14
- Ruff formatting and checks pass on every changed backend and test file
- broader backend collection reached 1,281 passed / 2 skipped before unrelated sparse-worktree and existing upgrade-path failures; it was stopped after those environment failures were identified