### PR TITLE
fix(tests): stub download mutation factories; guard batch addJob across account switch

### DIFF
--- a/frontend/src/lib/components/AlbumCard.svelte.spec.ts
+++ b/frontend/src/lib/components/AlbumCard.svelte.spec.ts
@@ -4,6 +4,12 @@ import { render } from 'vitest-browser-svelte';
 import AlbumCard from './AlbumCard.svelte';
 import type { Album, EnrichmentSource } from '$lib/types';
 
+// Stub the album-request mutation factory so the card renders without a QueryClientProvider
+// (same approach as the TopPicksDeck spec).
+vi.mock('$lib/queries/downloads/DownloadMutations.svelte', () => ({
+	requestAlbum: () => ({ mutateAsync: vi.fn(), isPending: false })
+}));
+
 const baseAlbum: Album = {
 	title: 'OK Computer',
 	artist: 'Radiohead',

--- a/frontend/src/lib/components/DiscographyDownloadModal.svelte
+++ b/frontend/src/lib/components/DiscographyDownloadModal.svelte
@@ -6,6 +6,7 @@
 		requestBatch,
 		type BatchAlbumItem
 	} from '$lib/queries/downloads/DownloadMutations.svelte';
+	import { authStore } from '$lib/stores/authStore.svelte';
 	import AlbumImage from '$lib/components/AlbumImage.svelte';
 
 	let dialogEl: HTMLDialogElement | undefined = $state();
@@ -71,6 +72,7 @@
 		if (filteredReleases.length === 0) return;
 		const artistName = discographyDownloadStore.artistName;
 		const artistId = discographyDownloadStore.artistId;
+		const initiatingUserId = authStore.user?.id;
 		submitting = true;
 
 		const items: BatchAlbumItem[] = filteredReleases.map((r) => ({
@@ -88,8 +90,9 @@
 				autoDownloadArtist: autoDownload
 			})
 			.catch(() => null);
-
-		if (result?.success) {
+		// an in-flight batch that resolves after an account switch belongs to the prior
+		// session - the shell already cleared the stores, do not re-add the old job (#155)
+		if (result?.success && authStore.user?.id === initiatingUserId) {
 			batchDownloadStore.addJob(
 				artistName,
 				artistId,

--- a/frontend/src/lib/components/discover/TopPicksDeck.svelte.spec.ts
+++ b/frontend/src/lib/components/discover/TopPicksDeck.svelte.spec.ts
@@ -13,6 +13,11 @@ vi.mock('$lib/stores/integration', async () => {
 		integrationStore: readable({ download_client: true, youtube: true, youtube_api: true })
 	};
 });
+// Stub the album-request mutation factory so AlbumRequestButton renders without a
+// QueryClientProvider (same approach as the album page's rescanAlbum stub).
+vi.mock('$lib/queries/downloads/DownloadMutations.svelte', () => ({
+	requestAlbum: () => ({ mutateAsync: vi.fn(), isPending: false })
+}));
 
 const section: TopPicksSection = {
 	title: 'Top Picks for You',

--- a/frontend/src/routes/layout.svelte.spec.ts
+++ b/frontend/src/routes/layout.svelte.spec.ts
@@ -144,7 +144,7 @@ vi.mock('$lib/utils/requestsApi', () => ({
 }));
 vi.mock('$lib/queries/downloads/DownloadMutations.svelte', async (importOriginal) => ({
 	...(await importOriginal<typeof import('$lib/queries/downloads/DownloadMutations.svelte')>()),
-	requestBatch: batchRequestMock
+	requestBatch: () => ({ mutateAsync: batchRequestMock })
 }));
 vi.mock('$lib/utils/navigationProgress', () => ({
 	createNavigationProgressController: vi.fn(() => ({


### PR DESCRIPTION
Repairs the two failing families in `Frontend CI / Tests` on main (5 TopPicksDeck + 11 AlbumCard tests, plus a layout-spec unhandled rejection).

**Root cause:** `TopPicksDeck` and `AlbumCard` render `AlbumRequestButton`/`requestAlbum()` in their trees; their specs render without a `QueryClientProvider`, so `createMutation` threw in Svelte context. Fixed with the house stub pattern (`requestAlbum: () => ({ mutateAsync: vi.fn(), isPending: false })`), as in the album-page specs.

**Real bug found underneath:** `routes/layout.svelte.spec.ts` mocked `requestBatch` with a bare `vi.fn()` where `DiscographyDownloadModal` expects `requestBatch().mutateAsync` — the deferred-completion-after-account-switch test passed only because the mock threw before `addJob`. The mock now hands back `{ mutateAsync }`, which exposed the race the test was meant to catch: an in-flight batch resolving after a user switch re-added the old user's job after the shell cleared the stores. `DiscographyDownloadModal.handleDownload` now captures the initiating user and skips `addJob`/`handleClose` when the session changed in flight (mirrors `requestAlbum`'s `initiatingUserId` capture).

Verified locally in this PR's tree: client project 855/855, server project 1258/1258, svelte-check 0 errors, eslint clean on touched files.